### PR TITLE
Use PG for Action Cable

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -59,7 +59,7 @@ gem "faraday", "~> 2.9.0"
 
 gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
-
+gem "actioncable-enhanced-postgresql-adapter"
 group :development, :test do
   gem "brakeman", "~> 5.2"
   gem "bundler-audit", "~> 0.9"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -7,6 +7,10 @@ GEM
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
+    actioncable-enhanced-postgresql-adapter (1.0.1)
+      actioncable (>= 6.0)
+      connection_pool (>= 2.2.5)
+      pg (~> 1.5)
     actionmailbox (7.1.3.3)
       actionpack (= 7.1.3.3)
       activejob (= 7.1.3.3)
@@ -381,6 +385,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actioncable-enhanced-postgresql-adapter
   bootsnap
   brakeman (~> 5.2)
   bundler-audit (~> 0.9)

--- a/app/config/cable.yml
+++ b/app/config/cable.yml
@@ -1,11 +1,8 @@
 development:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  adapter: enhanced_postgresql
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: iv_cbv_payroll_production
+  adapter: enhanced_postgresql


### PR DESCRIPTION
Installs an adapter for using Postgres for Action Cable instead of Redis.