### PR TITLE
Fix table permission migration so it runs in development

### DIFF
--- a/app/db/migrate/00000000000000_update_table_permissions.rb
+++ b/app/db/migrate/00000000000000_update_table_permissions.rb
@@ -1,5 +1,0 @@
-class UpdateTablePermissions < ActiveRecord::Migration[7.0]
-  def change
-    execute "ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app"
-  end
-end

--- a/app/db/migrate/20240423000000_set_db_table_permissions.rb
+++ b/app/db/migrate/20240423000000_set_db_table_permissions.rb
@@ -1,6 +1,10 @@
 # see https://github.com/navapbc/template-infra/blob/main/docs/infra/set-up-database.md#important-note-on-postgres-table-permissions
 class SetDbTablePermissions < ActiveRecord::Migration[7.0]
   def change
+    # This is only useful to fix permissions in deploy environments.
+    # In development: do nothing.
+    return if Rails.env.development?
+
     execute <<-SQL
       ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app
     SQL


### PR DESCRIPTION
In development, we may not have an "app" user and a "migrate" user.
Also, this removes a duplicate migration.
