### PR TITLE
Enable HTTPS via AWS ACM and Route53

### DIFF
--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -5,8 +5,8 @@ module "dev_config" {
   default_region                  = module.project_config.default_region
   environment                     = "dev"
   network_name                    = "dev"
-  domain_name                     = null
-  enable_https                    = false
+  domain_name                     = "verify-demo.navapbc.cloud"
+  enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -15,6 +15,9 @@ locals {
   # List of configurations for defining environment variables that pull from SSM parameter
   # store. Configurations are of the format
   # { name = "ENV_VAR_NAME", ssm_param_name = "/ssm/param/name" }
+  #
+  # Manage the secret values of them using AWS Systems Manager:
+  # https://us-east-1.console.aws.amazon.com/systems-manager/parameters/
   secrets = [
     {
       name           = "SECRET_KEY_BASE"

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -5,12 +5,12 @@ locals {
 
       domain_config = {
         manage_dns = true
-        # Placeholder value for the hosted zone
-        # A hosted zone represents a domain and all of its subdomains. For example, a
-        # hosted zone of foo.domain.com includes foo.domain.com, bar.foo.domain.com, etc.
-        hosted_zone = "hosted.zone.for.dev.network.com"
+        hosted_zone = "navapbc.cloud"
 
         certificate_configs = {
+          "verify-demo.navapbc.cloud" = {
+            source = "issued"
+          }
           # Example certificate configuration for a certificate that is managed by the project
           # "sub.domain.com" = {
           #   source = "issued"


### PR DESCRIPTION
The infra template makes this quite easy, fingers crossed.

After merging, I will run the commands listed in [https-support.md][1]
and [set-up-custom-domains.md][2].

Finishes FFS-878.

[1]: https://github.com/DSACMS/iv-cbv-payroll/blob/main/docs/infra/https-support.md
[2]: https://github.com/DSACMS/iv-cbv-payroll/blob/main/docs/infra/set-up-custom-domains.md
