### PR TITLE
Bugfix/ffs 861

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -33,6 +33,19 @@ RUN apt-get update -qq && \
 # Copy application code
 COPY . .
 
+# chromium is not available for arm64, this could be problematic when developing locally on an arm64 machine
+# and running tests that require puppeteer.
+# Set default value for PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+# Detect architecture and skip the installation of chromium if the architecture is arm64
+# see https://github.com/puppeteer/puppeteer/issues/7740#issuecomment-1016083451
+RUN if [ "$(uname -m)" = "arm64" ]; then \
+      export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false; \
+    fi
+
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=$PUPPETEER_SKIP_CHROMIUM_DOWNLOAD npm install
+
 # Install npm packages
 RUN npm install
 
@@ -51,6 +64,7 @@ RUN apt-get update -qq && \
 
 # Install application gems for development
 COPY Gemfile Gemfile.lock ./
+
 RUN bundle config set --local without production && \
     bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
@@ -83,7 +97,7 @@ FROM base as release
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3  curl libvips postgresql-client && \
+    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3 curl libvips postgresql-client libjpeg-dev wkhtmltopdf && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
@@ -96,6 +110,7 @@ COPY bin/db-migrate /usr/bin/
 # Copy built artifacts: gems, application
 COPY --from=release-build /usr/local/bundle /usr/local/bundle
 COPY --from=release-build /rails /rails
+COPY /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -110,7 +110,7 @@ COPY bin/db-migrate /usr/bin/
 # Copy built artifacts: gems, application
 COPY --from=release-build /usr/local/bundle /usr/local/bundle
 COPY --from=release-build /rails /rails
-COPY /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
+RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -28,10 +28,13 @@ FROM base as build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config npm
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config npm libjpeg-dev wkhtmltopdf
 
 # Copy application code
 COPY . .
+
+# Copy wkhtmltopdf binary to /rails/bin, keeping all executables in a common directory
+RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # chromium is not available for arm64, this could be problematic when developing locally on an arm64 machine
 # and running tests that require puppeteer.
@@ -97,7 +100,7 @@ FROM base as release
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3 curl libvips postgresql-client libjpeg-dev wkhtmltopdf && \
+    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3 curl libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
@@ -110,7 +113,6 @@ COPY bin/db-migrate /usr/bin/
 # Copy built artifacts: gems, application
 COPY --from=release-build /usr/local/bundle /usr/local/bundle
 COPY --from=release-build /rails /rails
-RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -28,13 +28,10 @@ FROM base as build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config npm libjpeg-dev wkhtmltopdf
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config npm
 
 # Copy application code
 COPY . .
-
-# Copy wkhtmltopdf binary to /rails/bin, keeping all executables in a common directory
-RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # chromium is not available for arm64, this could be problematic when developing locally on an arm64 machine
 # and running tests that require puppeteer.
@@ -60,13 +57,19 @@ FROM build as dev
 
 ENV RAILS_ENV="development"
 
+# Set the tmp dir to the writeable tmp volume
+ENV TMPDIR="/rails/tmp"
+
 # Install packages needed for development
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y postgresql-client graphviz && \
+    apt-get install --no-install-recommends -y postgresql-client graphviz wkhtmltopdf && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems for development
 COPY Gemfile Gemfile.lock ./
+
+# Copy wkhtmltopdf binary to /rails/bin, keeping all executables in a common directory
+RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 RUN bundle config set --local without production && \
     bundle install && \
@@ -98,9 +101,12 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 ##########################################################################################
 FROM base as release
 
+# Set the tmp dir to the writeable tmp volume
+ENV TMPDIR="/rails/tmp"
+
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3 curl libvips postgresql-client && \
+    apt-get install -y --no-install-recommends unzip python3-venv python-is-python3 curl libvips postgresql-client wkhtmltopdf && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
@@ -110,9 +116,10 @@ RUN apt-get update -qq && \
 # Install custom db migrate script
 COPY bin/db-migrate /usr/bin/
 
-# Copy built artifacts: gems, application
+# Copy built artifacts: gems, application, binary dependencies
 COPY --from=release-build /usr/local/bundle /usr/local/bundle
 COPY --from=release-build /rails /rails
+RUN cp /usr/bin/wkhtmltopdf /rails/bin/wkhtmltopdf
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -79,7 +79,6 @@ end
 group :development do
   gem "debase-ruby_core_source"
   gem "debase", "~> 0.2.5.beta2", require: false
-  gem "ruby-debug-ide"
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
       net-protocol
     newrelic_rpm (8.16.0)
     nio4r (2.7.3)
+    nokogiri (1.16.5-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
@@ -332,8 +334,6 @@ GEM
       rubocop-rspec_rails (~> 2.28)
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
-    ruby-debug-ide (0.7.3)
-      rake (>= 0.8.1)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
@@ -398,6 +398,7 @@ GEM
     zeitwerk (2.6.14)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-22
@@ -431,7 +432,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails-omakase
   rubocop-rspec
-  ruby-debug-ide
   secure_headers (~> 6.3)
   sidekiq (~> 6.4)
   sprockets-rails

--- a/app/bin/dev
+++ b/app/bin/dev
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+rm /rails/tmp/pids/server.pid
+
 if gem list --no-installed --exact --silent foreman; then
   echo "Installing foreman..."
   gem install foreman

--- a/app/bin/dev
+++ b/app/bin/dev
@@ -5,10 +5,12 @@ if gem list --no-installed --exact --silent foreman; then
   gem install foreman
 fi
 
-if ! which ngrok >/dev/null; then
-  echo "Install ngrok to continue!"
-  echo "  brew install ngrok"
-  exit 1
+if [ "$DOCKERIZED" != "true" ]; then
+  if ! which ngrok >/dev/null; then
+    echo "Install ngrok to continue!"
+    echo "  brew install ngrok"
+    exit 1
+  fi
 
   if ! ngrok config check; then
     echo "Set up ngrok to continue!"

--- a/app/config/initializers/wicked_pdf.rb
+++ b/app/config/initializers/wicked_pdf.rb
@@ -11,6 +11,12 @@
 WickedPdf.configure do |config|
   # Path to the wkhtmltopdf executable: This usually isn't needed if using
   # one of the wkhtmltopdf-binary family of gems.
+
+  # set the wkhtmltopdf path for docker
+  if ENV['DOCKERIZED'] == 'true'
+    config.exe_path = '/rails/bin/wkhtmltopdf'
+  end
+
   # config.exe_path = '/usr/local/bin/wkhtmltopdf',
   #   or
   # config.exe_path = Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')

--- a/app/config/initializers/wicked_pdf.rb
+++ b/app/config/initializers/wicked_pdf.rb
@@ -13,8 +13,8 @@ WickedPdf.configure do |config|
   # one of the wkhtmltopdf-binary family of gems.
 
   # set the wkhtmltopdf path for docker
-  if ENV['DOCKERIZED'] == 'true'
-    config.exe_path = '/rails/bin/wkhtmltopdf'
+  if ENV["DOCKERIZED"] == "true"
+    config.exe_path = "/rails/bin/wkhtmltopdf"
   end
 
   # config.exe_path = '/usr/local/bin/wkhtmltopdf',

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     environment:
       POSTGRES_PASSWORD: secret123
-      POSTGRES_USER: app_rails
+      POSTGRES_USER: app
     healthcheck:
-      test: "pg_isready --username=app_rails"
+      test: "pg_isready --username=app"
       timeout: 10s
       retries: 20
     ports:
@@ -31,7 +31,9 @@ services:
     environment:
       - DOCKERIZED=true
       - DB_HOST=postgres
-      - DB_NAME=app_rails
+      - DB_NAME=app
+      - DB_USERNAME=app
+      - DB_PASSWORD=secret123
       - REDIS_URL=redis://redis:6379/1
       - RAILS_BINDING=0.0.0.0
       - RAILS_ENV=development

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -7,6 +7,9 @@ locals {
     RAILS_LOG_TO_STDOUT      = "true"
     RAILS_SERVE_STATIC_FILES = "true"
     ARGYLE_SANDBOX           = "true"
+
+    # Set to true to inform the app that it is running in a container
+    DOCKERIZED               = "true"
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
   }


### PR DESCRIPTION
## Ticket

Resolves [FFS-861](https://jiraent.cms.gov/browse/FFS-861)

## Changes

- Fixes inconsistencies with local Docker development and application instances running in ECS by updating the docker compose configuration. This ensures that the postgres database used for local development matches the postgres database used in ECS.
- Removes the `ruby-debug-ide` gem. (A follow-up PR may be needed to include this gem for local debugging, but removes it during the Docker build phase)
- A widely adopted and supported chromium binary is not available for arm64 based machines. A conditional to check system architecture has been added to skip chromium installation when installing puppeteer
- Adds a `DOCKERIZED` environment variable for Docker containers so that the application can have varying runtime configuration (`wkhtmltopdf` binary location) based on the host architecture.

## Context for reviewers

This PR addresses an issue where `wkhtmltopdf` does not have access to all system-level dependencies and configures `wickedpdf` to use the proper temporary directory. This is resolved by setting the `TMPDIR` environment variable. 

## Testing
<img width="805" alt="Screenshot 2024-06-07 at 4 57 18 PM" src="https://github.com/DSACMS/iv-cbv-payroll/assets/7874385/fa83ca04-f8e8-4ce2-8187-dc24b316b75f">

