### PR TITLE
Add IMAGE_TAG to healthcheck

### DIFF
--- a/app/app/controllers/health_check_controller.rb
+++ b/app/app/controllers/health_check_controller.rb
@@ -1,5 +1,5 @@
 class HealthCheckController < ActionController::Base
   def ok
-    head :ok
+    render json: { status: "ok", version: ENV["IMAGE_TAG"] }
   end
 end

--- a/app/spec/controllers/health_check_controller_spec.rb
+++ b/app/spec/controllers/health_check_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe HealthCheckController do
+  around do |ex|
+    stub_environment_variable("IMAGE_TAG", "foobar", &ex)
+  end
+
+  describe "#ok" do
+    it "renders successfully" do
+      get :ok
+      expect(response.body).to eq(JSON.generate(status: :ok, version: "foobar"))
+    end
+  end
+end


### PR DESCRIPTION
This changes the response to /health from a 200 OK with no body to being
a 200 OK with a JSON body similar to:

```
{ "status": "ok", "version": "abcdef0123..." }
```

This will help us verify which version of code has been deployed.
