### PR TITLE
Use `wkhtmltopdf-binary` gem in dev/test only

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -58,7 +58,6 @@ gem "sidekiq", "~> 6.4"
 gem "faraday", "~> 2.9.0"
 
 gem "wicked_pdf"
-gem "wkhtmltopdf-binary"
 gem "actioncable-enhanced-postgresql-adapter"
 gem "aws-sdk-sesv2"
 
@@ -74,6 +73,7 @@ group :development, :test do
   gem "rubocop-rspec"
   gem "rubocop-rails-omakase"
   gem "standard", "~> 1.7"
+  gem "wkhtmltopdf-binary"
 end
 
 group :development do


### PR DESCRIPTION
This gem doesn't work in production due to our readonly filesystem.
There, we install wkhtmltopdf via apt instead. So let's force it to be
used.
