### PR TITLE
Fix AWS ECS healthcheck by using `curl` instead of `wget`

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -91,7 +91,7 @@ resource "aws_ecs_task_definition" "app" {
         retries  = 3,
         timeout  = 5,
         command = ["CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:${var.container_port}/health || exit 1"
+          "curl --fail http://localhost:${var.container_port}/health"
         ]
       },
       environment = local.environment_variables,


### PR DESCRIPTION
We don't actually install wget inside the containers, so this
healthcheck was always failing and has been provisioning new containers
all the time. This may have been the source of some of our deployment
downtime.

It works:
<img width="1188" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/129120/228365dd-cebe-4bcb-be19-c71457e2ffe1">

