### PR TITLE
Enable "ECS Exec" for debugging in AWS ECS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -30,7 +30,11 @@ brew "jq"
 brew "redis"
 
 # ngrok local tunnel to receive argyle webhooks
-brew "ngrok"
+cask "ngrok"
 
 # Terraform version manager for infrastructure
 brew "tfenv"
+
+# AWS command-line utilities necessary for deploying and operations
+brew "awscli"
+cask "session-manager-plugin"

--- a/bin/ecs-console
+++ b/bin/ecs-console
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Usage: bin/ecs-console app dev
+set -euo pipefail
+
+bold() {
+  text=$1
+  echo "$(tput bold)${text}$(tput sgr0)"
+}
+
+APP_NAME=${1:-"app"}
+ENVIRONMENT=${2:-"dev"}
+
+cluster="${APP_NAME}-${ENVIRONMENT}"
+task_arn=$(aws ecs list-tasks --cluster "$cluster" --query 'taskArns[0]' --output text)
+
+echo "Opening Rails console in task $(bold "$task_arn")..."
+exec aws ecs execute-command \
+    --cluster "$cluster" \
+    --task "$task_arn" \
+    --container "${APP_NAME}-${ENVIRONMENT}" \
+    --interactive \
+    --command "bin/rails console"

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -13,5 +13,5 @@ module "dev_config" {
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
   # Defaults to `false`. Uncomment the next line to enable.
-  # enable_command_execution = true
+  enable_command_execution = true
 }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -81,7 +81,7 @@ resource "aws_ecs_task_definition" "app" {
       cpu                    = var.cpu,
       networkMode            = "awsvpc",
       essential              = true,
-      readonlyRootFilesystem = true,
+      readonlyRootFilesystem = !var.enable_command_execution,
 
       # Need to define all parameters in the healthCheck block even if we want
       # to use AWS's defaults, otherwise the terraform plan will show a diff


### PR DESCRIPTION
I want to look at our database in RDS to debug some strange behavior.
Thankfully, we already have [the configuration in place][1] to be able
to use ECS Exec to get me a shell in there. This commit enables the
configuration, and adds a helper script, so we can get a Rails console
in the demo environment running via:

```bash
bin/ecs-console
```

Also fixed/changed:
* Install `ngrok` correctly via Brew
* Install `awscli` and the necessary `session-manager-plugin`
* Revert `readonlyRootFilesystem` configuration to be dependent on
  whether command execution is enabled

<img width="890" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/129120/9c9168b1-c04b-4023-902b-7236a1865c91">

[1]: https://github.com/DSACMS/iv-cbv-payroll/blob/main/docs/infra/service-command-execution.md