### PR TITLE
Use CBV invite as higher priority than whatever's in session

### DIFF
--- a/app/app/controllers/cbv_flows_controller.rb
+++ b/app/app/controllers/cbv_flows_controller.rb
@@ -47,17 +47,19 @@ class CbvFlowsController < ApplicationController
   private
 
   def set_cbv_flow
-    if session[:cbv_flow_id]
+    if params[:token].present?
+      invitation = CbvFlowInvitation.find_by(auth_token: params[:token])
+      if invitation.blank?
+        return redirect_to(root_url, flash: { alert: t("cbv_flows.entry.error_invalid_token") })
+      end
+
+      @cbv_flow = invitation.cbv_flow || CbvFlow.create_from_invitation(invitation)
+    elsif session[:cbv_flow_id]
       begin
         @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
       rescue ActiveRecord::RecordNotFound
         return redirect_to root_url
       end
-    elsif params[:token].present?
-      invitation = CbvFlowInvitation.find_by(auth_token: params[:token])
-      return redirect_to root_url if invitation.blank?
-
-      @cbv_flow = invitation.cbv_flow || CbvFlow.create_from_invitation(invitation)
     else
       # TODO: Restrict ability to enter the flow without a valid token
       @cbv_flow = CbvFlow.create

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
       subheader: Search for an employer
     entry:
       case_number: Case Number
+      error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
       get_started: Get Started
       header: Let's verify your payment information
       security_message: Your information is secure. We will not share or keep your log in information. You will be able to preview and approve everything that is shared with your caseworker.

--- a/app/spec/controllers/cbv_flows_controller_spec.rb
+++ b/app/spec/controllers/cbv_flows_controller_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe CbvFlowsController do
         end
       end
 
+      context "when there is already a CbvFlow in the session" do
+        let(:other_cbv_flow) { CbvFlow.create(case_number: "ZZZ0000", argyle_user_id: "abc-def-ghi") }
+
+        before do
+          session[:cbv_flow_id] = other_cbv_flow.id
+        end
+
+        it "replaces the session's CbvFlow id with the one from the link token" do
+          expect { get :entry, params: { token: invitation.auth_token } }
+            .to change { session[:cbv_flow_id] }
+            .from(other_cbv_flow.id)
+            .to(be_an(Integer))
+        end
+      end
+
       context "when the token is invalid" do
         it "redirects to the homepage" do
           expect { get :entry, params: { token: "some-invalid-token" } }


### PR DESCRIPTION
This is probably only an issue for development, while we have a CBV flow
in our session for development and then want to later test following a
CBV invite via tokenized link. The current behavior is that if there is
a CBV flow in the session, it will be prioritized over the tokenized
link.

But this seems a bit mistaken. If two people are applying for SNAP
one-after-the-other on the same device, we will want the second link to
work despite the presence of the first flow_id in the session.
