### PR TITLE
Handle delivery error in CBV Flow Invitations Controller

### DIFF
--- a/app/app/controllers/cbv_flow_invitations_controller.rb
+++ b/app/app/controllers/cbv_flow_invitations_controller.rb
@@ -6,10 +6,19 @@ class CbvFlowInvitationsController < ApplicationController
   end
 
   def create
-    CbvInvitationService.new.invite(
-      cbv_flow_invitation_params[:email_address],
-      cbv_flow_invitation_params[:case_number]
-    )
+    begin
+      CbvInvitationService.new.invite(
+        cbv_flow_invitation_params[:email_address],
+        cbv_flow_invitation_params[:case_number]
+      )
+    rescue => ex
+      flash[:alert] = t(".invite_failed",
+                        email_address: cbv_flow_invitation_params[:email_address],
+                        error_message: ex.message
+                       )
+      Rails.logger.error("Error sending CBV invitation: #{ex.class} - #{ex.message}")
+      return redirect_to new_cbv_flow_invitation_path(secret: params[:secret])
+    end
 
     flash[:notice] = t(".invite_success", email_address: cbv_flow_invitation_params[:email_address])
     redirect_to root_url

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
       thank_you: Thank you!
   cbv_flow_invitations:
     create:
+      invite_failed: 'Error sending invitation to %{email_address}: %{error_message}.'
       invite_success: Successfully delivered invitation to %{email_address}.
     incorrect_invite_secret: Unable to send invitation due to missing invitation secret parameter.
     new:


### PR DESCRIPTION
When there is a delivery error, let's catch it and give the user a
better error message.

In order to test this in development, you'll need to set
`config.action_mailer.raise_delivery_errors` to true. (It's true by
default in production.)

Finishes FFS-839.

<img width="1149" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/129120/e5db60e4-8777-40ae-86a9-4622eda6f70c">

<img width="1513" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/129120/9987d637-d241-4cd5-a762-7d310413143b">

