### PR TITLE
Allow specifying `single_nat_gateway` in network_config

### DIFF
--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -32,7 +32,7 @@ module "aws_vpc" {
 
   # If application needs external services, then create one NAT gateway per availability zone
   enable_nat_gateway     = var.has_external_non_aws_service
-  single_nat_gateway     = false
+  single_nat_gateway     = var.single_nat_gateway
   one_nat_gateway_per_az = var.has_external_non_aws_service
 
   enable_dns_hostnames = true

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -25,6 +25,12 @@ variable "has_external_non_aws_service" {
   default     = false
 }
 
+variable "single_nat_gateway" {
+  type        = bool
+  description = "Whether to provision only a single NAT gateway, rather than one per AZ. Good for saving costs in non-production environments."
+  default     = false
+}
+
 variable "enable_command_execution" {
   type        = bool
   description = "Whether the application(s) in this network need ECS Exec access. Determines whether to create VPC endpoints needed by ECS Exec."

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -75,6 +75,7 @@ module "network" {
   database_subnet_group_name              = local.network_config.database_subnet_group_name
   has_database                            = local.has_database
   has_external_non_aws_service            = local.has_external_non_aws_service
+  single_nat_gateway                      = local.network_config.single_nat_gateway
   enable_command_execution                = local.enable_command_execution
 }
 

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -25,6 +25,8 @@ locals {
           # }
         }
       }
+
+      single_nat_gateway = true
     }
 
     staging = {


### PR DESCRIPTION
NAT Gateways are pricey, at $32/month, and also entail provisioning
an Elastic IP ($4/month). This isn't going to break the bank, but also,
it isn't necessary at all for our non-production environments since they
can tolerate an unlikely AWS AZ outage.

This commit adds the ability to pass through a `single_nat_gateway`
variable all the way to the `vpc` module, which supports sending all our
external traffic via a single NAT gateway.
