### PR TITLE
Add "Search for Payroll Provider" button to employer search page

### DIFF
--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -56,13 +56,25 @@ class PinwheelService
   end
 
   def create_link_token(end_user_id:, response_type:, id:)
-    @http.post(build_url(USER_TOKENS_ENDPOINT), {
+    params = {
       org_name: "Verify.gov",
       required_jobs: [ "paystubs" ],
       end_user_id: end_user_id,
-      skip_intro_screen: true,
-      "#{response_type}_id": id
-    }.to_json).body
+      skip_intro_screen: true
+    }
+
+    case response_type.presence
+    when "employer"
+      params["employer_id"] = id
+    when "platform"
+      params["platform_id"] = id
+    when nil
+      # do nothing
+    else
+      raise "Invalid `response_type`: #{response_type}"
+    end
+
+    @http.post(build_url(USER_TOKENS_ENDPOINT), params.to_json).body
   end
 
   def fetch_webhook_subscriptions

--- a/app/app/views/cbv_flows/_employer.html.erb
+++ b/app/app/views/cbv_flows/_employer.html.erb
@@ -36,4 +36,15 @@
       </div>
     <% end %>
   </div>
+
+  <h3>Employer not listed?</h3>
+  <button
+    data-action="click->cbv-flows#select"
+    data-id=""
+    data-response-type=""
+    class="usa-button usa-button--outline"
+    type="button"
+    >
+      <%= t('cbv_flows.employer_search.search_by_payroll_provider') %>
+  </button>
 <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
       header: Get payment info from your employer.
       results: Results
       search: Search
+      search_by_payroll_provider: Search for payroll provider
       select: Select
       subheader: Search for an employer
     entry:

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Api::PinwheelController do
+  include PinwheelApiHelper
+
+  context "#create_token" do
+    let(:cbv_flow) { CbvFlow.create(case_number: "TEST123") }
+    let(:valid_params) do
+      {
+        pinwheel: { response_type: "employer", id: "123" }
+      }
+    end
+
+    before do
+      session[:cbv_flow_id] = cbv_flow.id
+      stub_create_token_response
+    end
+
+    it "creates a link token with Pinwheel" do
+      post :create_token, params: valid_params
+
+      expect(JSON.parse(response.body))
+        .to include("token" => be_a(String))
+    end
+
+    describe "when the button is pressed without an employer or ID" do
+      let(:valid_params) do
+        {
+          pinwheel: { response_type: "", id: "" }
+        }
+      end
+
+      it "still creates a link token with Pinwheel" do
+        post :create_token, params: valid_params
+
+        expect(JSON.parse(response.body))
+          .to include("token" => be_a(String))
+      end
+    end
+  end
+end

--- a/app/spec/services/pinwheel_service_spec.rb
+++ b/app/spec/services/pinwheel_service_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe PinwheelService, type: :service do
       response = service.create_link_token(end_user_id: end_user_id, response_type: 'employer', id: 'fake_id')
       expect(response['data']['id']).to eq(end_user_id)
     end
+
+    context "with an empty response_type and id" do
+      it 'returns a user token' do
+        response = service.create_link_token(end_user_id: end_user_id, response_type: '', id: '')
+        expect(response['data']['id']).to eq(end_user_id)
+      end
+    end
   end
 
   describe "#verify_webhook_signature" do


### PR DESCRIPTION
For situations when Pinwheel doesn't return the employer matches, this
commit adds a button to the bottom of the employer search page (only
visible after a search is performed) that opens the default Pinwheel
modal.


https://github.com/DSACMS/iv-cbv-payroll/assets/129120/b2883c09-f2d2-4a7c-8454-583fe21601b7

