### PR TITLE
Fix /cbv/reset controller method name

### DIFF
--- a/app/app/controllers/cbv/resets_controller.rb
+++ b/app/app/controllers/cbv/resets_controller.rb
@@ -1,7 +1,7 @@
 class Cbv::ResetsController < Cbv::BaseController
   skip_before_action :set_cbv_flow
 
-  def reset
+  def show
     session[:cbv_flow_id] = nil
     redirect_to root_url
   end


### PR DESCRIPTION
I had accidentally broken this in 8b1a5c9 by converting it to a RESTful
route but not changing the controller method name to match. Thankfully
[a code review comment][1] drew my attention to this.

[1]: https://github.com/DSACMS/iv-cbv-payroll/pull/69#discussion_r1651356780
