### PR TITLE
Fix /cbv/share "Email to Caseworker" button

### DIFF
--- a/app/app/controllers/cbv/shares_controller.rb
+++ b/app/app/controllers/cbv/shares_controller.rb
@@ -11,5 +11,7 @@ class Cbv::SharesController < Cbv::BaseController
       cbv_flow: @cbv_flow,
       payments: @payments
     ).caseworker_summary_email.deliver_now
+
+    redirect_to({ action: :show }, flash: { notice: t(".successfully_shared_to_caseworker") })
   end
 end

--- a/app/app/views/cbv/shares/show.html.erb
+++ b/app/app/views/cbv/shares/show.html.erb
@@ -6,7 +6,7 @@
   <%= t('.body') %>
 </p>
 
-<%= form_with url: cbv_flow_share_path(@cbv_flow), method: :post, local: true do |form| %>
+<%= form_with url: cbv_flow_share_path, method: :patch do |form| %>
   <%= form.button t('.share_with_caseworker'), type: 'submit', class: 'usa-button' %>
 <% end %>
 

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
         download_pdf: Download PDF
         header: Share your income with your caseworker
         share_with_caseworker: Share with Case Worker
+      update:
+        successfully_shared_to_caseworker: We successfully emailed your income to your caseworker!
     summaries:
       show:
         additional_information_title: Is there anything else you'd like your caseworker to know about your income?


### PR DESCRIPTION
This button was accidentally going to the wrong URL, broken in the
refactor of 8b1a5c9.

This commit fixes it and adds a success message as a placeholder until
we build the confirmation/success page.

Fixes FFS-973.
