### PR TITLE
Fix PinwheelService to hide unsupported employers from search

### DIFF
--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -19,7 +19,10 @@ class PinwheelService
     client_options = {
       request: {
         open_timeout: 5,
-        timeout: 5
+        timeout: 5,
+        # Pinwheel requires repeated params (i.e. `{ foo: [1, 2, 3] }`) to
+        # be serialized as `?foo=1&foo=2&foo=3`:
+        params_encoder: Faraday::FlatParamsEncoder
       },
       url: BASE_URL,
       headers: {


### PR DESCRIPTION
When searching, we attempt to restrict search results to only those with
"paystubs" listed as a "job" that Pinwheel can perform for us. If
Pinwheel doesn't support the "paystubs" job, we can't get the data we
need for the product to actually work.

Some employers were breaking when clicking the "Select" button: these
employers didn't support the Pinwheel "paystubs" job, and we weren't
filtering them out of the results correctly due to a bug.

The issue here is that we were encoding the API request parameters
incorrectly, as:

  POST /v1/search?q=foo&required_jobs[]=paystubs

The correct way to encode the `required_jobs` URL param, per API docs,
is:

  POST /v1/search?q=foo&required_jobs=paystubs

(any additional values in the required_jobs array would be passed as
repeated parameters)

I ran some metrics: 6% of Pinwheel's 2620 employers will be filtered out
as a result. The biggest ones that I saw were USPS, Walgreens, Duane
Reade, and Harris Teeter.

Finishes FFS-952.
