### PR TITLE
Update PinwheelWebhookManager to not recreate the same webhook

### DIFF
--- a/app/app/services/pinwheel_webhook_manager.rb
+++ b/app/app/services/pinwheel_webhook_manager.rb
@@ -1,28 +1,45 @@
 # This class manages pinwheel webhook subscriptions, and is intended for development environment setup only
 class PinwheelWebhookManager
+  WEBHOOK_EVENTS = %w[
+    account.added
+    paystubs.added
+    paystubs.ninety_days_synced
+  ]
+
   def initialize
     @pinwheel = PinwheelService.new
   end
 
-  def remove_ngrok_subscriptions_by_subscription_name(name)
+  def existing_subscriptions(name)
     subscriptions = @pinwheel.fetch_webhook_subscriptions["data"]
-    ngrok_subscriptions = subscriptions.find_all { |subscription| subscription["url"].match(format_identifier_hash(name)) }
+    subscriptions.find_all { |subscription| subscription["url"].match(format_identifier_hash(name)) }
+  end
 
-    ngrok_subscriptions.each do |subscription|
+  def remove_subscriptions(subscriptions)
+    subscriptions.each do |subscription|
       puts "  Removing existing Pinwheel webhook subscription (url = #{subscription["url"]})"
       @pinwheel.delete_webhook_subscription(subscription["id"])
     end
   end
 
-  def create_subscription(tunnel_url, name)
-    puts "  Registering Pinwheel webhooks for Ngrok tunnel..."
-    response = @pinwheel.create_webhook_subscription([
-      "account.added",
-      "paystubs.added",
-      "paystubs.ninety_days_synced"
-    ], URI.join(tunnel_url, "/webhooks/pinwheel/events", format_identifier_hash(name)))
-    new_webhook_subscription_id = response["data"]["id"]
-    puts "  ✅ Set up Pinwheel webhook: #{new_webhook_subscription_id}"
+  def create_subscription_if_necessary(tunnel_url, name)
+    receiver_url = URI.join(tunnel_url, "/webhooks/pinwheel/events", format_identifier_hash(name)).to_s
+    subscriptions = existing_subscriptions(name)
+    existing_subscription = subscriptions.find do |subscription|
+      subscription["url"] == receiver_url && subscription["enabled_events"] == WEBHOOK_EVENTS
+    end
+
+    if existing_subscription
+      puts "  Existing Pinwheel webhook subscription found: #{existing_subscription["url"]}"
+      remove_subscriptions(subscriptions.excluding(existing_subscription))
+    else
+      remove_subscriptions(subscriptions)
+
+      puts "  Registering Pinwheel webhooks for Ngrok tunnel..."
+      response = @pinwheel.create_webhook_subscription(WEBHOOK_EVENTS, receiver_url)
+      new_webhook_subscription_id = response["data"]["id"]
+      puts "  ✅ Set up Pinwheel webhook: #{new_webhook_subscription_id}"
+    end
   end
 
   def format_identifier_hash(identifier)

--- a/app/config/initializers/ngrok_development.rb
+++ b/app/config/initializers/ngrok_development.rb
@@ -9,8 +9,7 @@ Rails.application.config.to_prepare do
 
       subscription_name = ENV["USER"]
       pinwheel_webhooks = PinwheelWebhookManager.new
-      pinwheel_webhooks.remove_ngrok_subscriptions_by_subscription_name(subscription_name)
-      pinwheel_webhooks.create_subscription(tunnel_url, subscription_name)
+      pinwheel_webhooks.create_subscription_if_necessary(tunnel_url, subscription_name)
     rescue => ex
       puts "Unable to configure Ngrok for development: #{ex}"
       puts ex.inspect


### PR DESCRIPTION
When the Rails server is reloading, the Pinwheel webhook will be the
same URL since Ngrok hasn't restarted. It's inefficient to recreate the
webhook every time.

This commit updates the PinwheelWebhookManager to look for an existing
webhook with the same URL and events and don't do anything if that
already exists.
