### PR TITLE
Enabling new relic agent, adding newrelic_key env var to terraform co…

### DIFF
--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -26,14 +26,14 @@ common: &default_settings
 
   browser_monitoring:
     # include js code via partial to comply with CSP settings
-    auto_instrument: false
+    auto_instrument: true
 
   # This line disables agent regardless of other settings.
   # To enable the New Relic agent:
   # 1) add the New Relic license keys to the appropriate encrypted credentials file(s)
   # 2) Optionally, update app_name entries in this file with the application name you want to show in New Relic
   # 3) Comment out the line below
-  agent_enabled: false
+  agent_enabled: true
 
   # Logging level for log/newrelic_agent.log
   log_level: info

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -40,6 +40,10 @@ locals {
     {
       name           = "SLACK_TEST_EMAIL"
       ssm_param_name = "/service/${var.app_name}-${var.environment}/slack-test-email"
+    },
+    {
+      name           = "NEWRELIC_KEY"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/newrelic-key"
     }
   ]
 }


### PR DESCRIPTION
Enabling the New Relic agent and adding the required environment variable to AWS System Manger in order to view metrics from the CBV demo environment.

- Enables browser monitoring (geographical region, browser agent, AJAX requests, page navigations, time to paint, etc.

## Ticket

Initial step to resolve [FFS-940](https://jiraent.cms.gov/browse/FFS-940)

## Context for reviewers

> This PR doesn't contain the full feature to close out FFS-940, but rather enables data to flow into New Relic so that we can customize the dashboard and setup alerts in accordance to the data being observed.

## Testing
<img width="875" alt="Screenshot 2024-06-28 at 3 19 15 PM" src="https://github.com/DSACMS/iv-cbv-payroll/assets/7874385/a486ed16-2f2a-4ae3-92fd-e1d0b6a86c18">

