### PR TITLE
Don't delete all webhooks when ENV["USER"] is empty

### DIFF
--- a/app/app/services/pinwheel_webhook_manager.rb
+++ b/app/app/services/pinwheel_webhook_manager.rb
@@ -12,7 +12,7 @@ class PinwheelWebhookManager
 
   def existing_subscriptions(name)
     subscriptions = @pinwheel.fetch_webhook_subscriptions["data"]
-    subscriptions.find_all { |subscription| subscription["url"].match(format_identifier_hash(name)) }
+    subscriptions.find_all { |subscription| subscription["url"].end_with?(format_identifier_hash(name)) }
   end
 
   def remove_subscriptions(subscriptions)

--- a/app/config/initializers/ngrok_development.rb
+++ b/app/config/initializers/ngrok_development.rb
@@ -8,10 +8,12 @@ Rails.application.config.to_prepare do
       puts "Found ngrok tunnel at #{tunnel_url}!"
 
       subscription_name = ENV["USER"]
+      raise "USER environment variable not specified" unless subscription_name.present?
+
       pinwheel_webhooks = PinwheelWebhookManager.new
       pinwheel_webhooks.create_subscription_if_necessary(tunnel_url, subscription_name)
     rescue => ex
-      puts "Unable to configure Ngrok for development: #{ex}"
+      puts "🟥 Unable to configure Ngrok for development: #{ex}"
       puts ex.inspect
     end
   end


### PR DESCRIPTION
Not sure how this happened (Docker?) but if there's no USER env var,
then it will delete all other existing webhook subscriptions, since they
will all match the hash.

This both seeks to prevent creating a new empty-named webhook as well as
matching the exact name at the end of the webhook URL.
