### PR TITLE
FFS-986: Update copy on search page

### DIFF
--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -3,10 +3,11 @@
 </h2>
 
 <div data-controller="cbv-employer-search">
-  <h3 class="site-preview-heading">
-    <%= t('.subheader') %>
-  </h3>
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: 'usa-search usa-search--big', html: { role: 'search' }, data: { turbo_frame: 'employers', turbo_action: 'advance' } do |f| %>
+  <p><%= t('.subheader') %></p>
+  <p><%= t('.search_for_employer') %></p>
+  <p><%= t('.directed_to_login_portal') %></p>
+
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: 'usa-search usa-search--big margin-top-4', html: { role: 'search' }, data: { turbo_frame: 'employers', turbo_action: 'advance' } do |f| %>
     <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
     <%= f.text_field :query, value: @query, class: "usa-input", type: 'search', data: { "cbv-employer-search-target": "searchTerms" } %>
     <button

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -12,15 +12,17 @@ en:
   cbv:
     employer_searches:
       show:
+        directed_to_login_portal: You’ll be directed to their login portal, where you can enter your sign-in information to view your payment history.
         employer_not_listed: Employer not listed?
         fetching_payroll: We are fetching your employer's payment information.
         fetching_payroll_description: This may take a few minutes. Please do not close this window.
-        header: Get payment info from your employer.
+        header: Find your employer or payroll provider
         results: Results
         search: Search
         search_by_payroll_provider: Search for payroll provider
+        search_for_employer: Please search for your employer or their payroll provider to access the payments you have received during this period.
         select: Select
-        subheader: Search for an employer
+        subheader: Your caseworker needs your payment information from the last 30 days.
     entries:
       show:
         case_number: Case Number


### PR DESCRIPTION
## Ticket

Resolves [FFS-986](https://jiraent.cms.gov/browse/FFS-986)

## Changes

Updated copy on the `employer_search` screen

## Context for reviewers

I did not add the missing results button. That seems to be more part of [FFS-984](https://jiraent.cms.gov/browse/FFS-984).

## Testing

### Screenshots
![Screen Shot 2024-06-28 at 13 57 24-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/a3bccced-da13-4aeb-8027-62b4aa9970a8)
![Screen Shot 2024-06-28 at 13 57 30-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/0e4aeab7-143e-45bb-ad45-095ab76276c6)

