### PR TITLE
FFS-984: Missing Results Page

### DIFF
--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -1,0 +1,5 @@
+class Cbv::MissingResultsController < Cbv::BaseController
+  def show
+    @agency_url = 'https://www.cms.gov'
+  end
+end

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -39,14 +39,15 @@
 
   <% if @query.present? %>
     <h3><%= t('cbv.employer_searches.show.employer_not_listed') %></h3>
-    <button
-      data-action="click->cbv-employer-search#select"
-      data-id=""
-      data-response-type=""
-      class="usa-button usa-button--outline"
-      type="button"
-      >
-        <%= t('cbv.employer_searches.show.search_by_payroll_provider') %>
-    </button>
+    <%= link_to 'missing_results', data: { turbo_frame: "_top" } do %>
+      <button
+        data-id=""
+        data-response-type=""
+        class="usa-button usa-button--outline"
+        type="button"
+        >
+          <%= t('cbv.employer_searches.show.can_not_find_employer') %>
+      </button>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -3,10 +3,11 @@
 </h2>
 
 <div data-controller="cbv-employer-search">
-  <h3 class="site-preview-heading">
-    <%= t('.subheader') %>
-  </h3>
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: 'usa-search usa-search--big', html: { role: 'search' }, data: { turbo_frame: 'employers', turbo_action: 'advance' } do |f| %>
+  <p><%= t('.subheader') %></p>
+  <p><%= t('.search_for_employer') %></p>
+  <p><%= t('.directed_to_login_portal') %></p>
+
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: 'usa-search usa-search--big margin-top-4', html: { role: 'search' }, data: { turbo_frame: 'employers', turbo_action: 'advance' } do |f| %>
     <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
     <%= f.text_field :query, value: @query, class: "usa-input", type: 'search', data: { "cbv-employer-search-target": "searchTerms" } %>
     <button

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -1,0 +1,7 @@
+<h2><%= t('.header') %></h2>
+
+<%= link_to @agency_url, target: :_blank do %>
+    <button class="usa-button usa-button--outline" type="button">
+      <%= t('.button') %>
+    </button>
+<% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -12,15 +12,17 @@ en:
   cbv:
     employer_searches:
       show:
+        directed_to_login_portal: You’ll be directed to their login portal, where you can enter your sign-in information to view your payment history.
         employer_not_listed: Employer not listed?
         fetching_payroll: We are fetching your employer's payment information.
         fetching_payroll_description: This may take a few minutes. Please do not close this window.
-        header: Get payment info from your employer.
+        header: Find your employer or payroll provider
         results: Results
         search: Search
         search_by_payroll_provider: Search for payroll provider
+        search_for_employer: Please search for your employer or their payroll provider to access the payments you have received during this period.
         select: Select
-        subheader: Search for an employer
+        subheader: Your caseworker needs your payment information from the last 30 days.
     entries:
       show:
         case_number: Case Number

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
   cbv:
     employer_searches:
       show:
+        can_not_find_employer: I can’t find my company or payroll provider
         directed_to_login_portal: You’ll be directed to their login portal, where you can enter your sign-in information to view your payment history.
         employer_not_listed: Employer not listed?
         fetching_payroll: We are fetching your employer's payment information.
@@ -35,6 +36,10 @@ en:
         subheader: We’ll help you connect payment records from your employer to your caseworker so you can prove your income and receive benefits faster.
     error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
     manual_flow_start: Start Flow Manually
+    missing_results:
+      show:
+        button: Go to agency website
+        header: If you can’t find your employer or payroll provider, you’ll need to provide income information separately.
     shares:
       show:
         body: Thank you for completing income verification. Click the button below to preview your results and share it with your caseworker.

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       resource :employer_search, only: %i[show]
       resource :summary, only: %i[show update]
       resource :share, only: %i[show update]
+      resource :missing_results, only: %i[show]
 
       # Utility route to clear your session; useful during development
       resource :reset, only: %i[show]


### PR DESCRIPTION
## Ticket

Resolves [FFS-984](https://jiraent.cms.gov/browse/FFS-984)

## Changes

1. Adds a screen to say what to do when the user can not find their employer on the search page
2. Links to the screen from the search results page

## Context for reviewers

NOTE: This should be reviewed after #78.

There is a link to the "agency site". I used https://www.cms.gov but open to suggestions.

## Testing

### Screenshots
![Screen Shot 2024-06-28 at 14 34 59-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/ff00a53b-4dca-439e-b204-1e92cea882a2)
![Screen Shot 2024-06-28 at 14 35 04-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/057b8dca-cdda-479a-a9c9-2a11b7d1636a)
![Screen Shot 2024-06-28 at 14 35 10-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/66a4a80a-caa3-4477-9f90-8a4c5a95510a)
![Screen Shot 2024-06-28 at 14 35 14-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/696c7cb3-4f5e-49d1-8252-d4899f80355a)


