### PR TITLE
FFS-880: Build succes page

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -47,7 +47,7 @@ class Cbv::BaseController < ApplicationController
     when "cbv/summaries"
       cbv_flow_share_path
     when "cbv/shares"
-      root_url
+      cbv_flow_success_path
     end
   end
   helper_method :next_path

--- a/app/app/controllers/cbv/shares_controller.rb
+++ b/app/app/controllers/cbv/shares_controller.rb
@@ -12,6 +12,6 @@ class Cbv::SharesController < Cbv::BaseController
       payments: @payments
     ).caseworker_summary_email.deliver_now
 
-    redirect_to({ action: :show }, flash: { notice: t(".successfully_shared_to_caseworker") })
+    redirect_to({ controller: :successes, action: :show }, flash: { notice: t(".successfully_shared_to_caseworker") })
   end
 end

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -1,0 +1,5 @@
+class Cbv::SuccessesController < Cbv::BaseController
+    def show
+        @agency_url = "https://www.cms.gov"
+    end
+end

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -1,0 +1,18 @@
+<h1><%= t('.header') %></h1>
+
+<ul>
+    <li><%= t('.caseworker_received') %></li>
+    <li><%= t('.check_status') %></li>
+</ul>
+
+<p>
+    <%= t('.confirmation_number', confirmation_number: 'XXXXXXX') %>
+</p>
+
+<%= link_to cbv_flow_summary_path(format: 'pdf'), target: '_blank', class: 'usa-button margin-top-3 usa-button--outline' do %>
+    <%= t('.download') %>
+<% end %>
+
+<%= link_to @agency_url, target: '_blank', class: 'usa-button margin-top-3 usa-button' do %>
+    <%= t('.back_to_agency') %>
+<% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -41,6 +41,14 @@ en:
         share_with_caseworker: Share with Case Worker
       update:
         successfully_shared_to_caseworker: We successfully emailed your income to your caseworker!
+    successes:
+      show:
+        back_to_agency: Back to agency website
+        caseworker_received: A caseworker has received your payment information and will review it. They will contact you if any additional information is needed.
+        check_status: To check the status of your SNAP application/recertifaction ....
+        confirmation_number: 'Confirmation number: %{confirmation_number}'
+        download: Download a copy of the report
+        header: Your income report has been successfully shared with a caseworker
     summaries:
       show:
         additional_information_title: Is there anything else you'd like your caseworker to know about your income?

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       resource :employer_search, only: %i[show]
       resource :summary, only: %i[show update]
       resource :share, only: %i[show update]
+      resource :success, only: %i[show]
 
       # Utility route to clear your session; useful during development
       resource :reset, only: %i[show]

--- a/app/spec/controllers/cbv/shares_controller_spec.rb
+++ b/app/spec/controllers/cbv/shares_controller_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Cbv::SharesController do
         expect(email.to).to eq([ email_address ])
         expect(email.subject).to eq("Applicant Income Verification: ABC1234")
       end
+
+      it "redirects to success screen" do
+        post :update
+        expect(response).to redirect_to({ controller: :successes, action: :show })
+      end
+
+      it "displays a notice" do
+        post :update
+        expect(flash[:notice]).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves [FFS-880](FFS-880)

## Changes

1. Builds the /cbv/success screen
2. Links to the success screen from the share screen

## Context for reviewers

1. I was unsure of where the link to the agency should go. Welcome to suggestions
2. I don't think we have a confirmation number to display to the user.
3. The copy second bullet point is not complete but I used what was in [the Figma](https://www.figma.com/board/yQQNaeCEYI1A6hGPyJkEE3/CBV-FigJam?node-id=5-751&t=hTWi2huGKW6AH1FM-0)

## Testing

### Screenshots
![Screen Shot 2024-06-28 at 15 08 06-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/e38ca7e1-f925-4374-b83b-f7995acbe0d6)
![Screen Shot 2024-06-28 at 15 08 01-fullpage](https://github.com/DSACMS/iv-cbv-payroll/assets/169079684/3cbdf92d-7b23-4f13-bf81-64a89d03551a)

