### PR TITLE
Revert "Wait longer for bin/run-command log group to appear"

### DIFF
--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -103,7 +103,6 @@ TASK_START_TIME_MILLIS=$((TASK_START_TIME * 1000))
 
 AWS_ARGS=(
   ecs run-task
-  --debug
   --region="$CURRENT_REGION"
   --cluster="$CLUSTER_NAME"
   --task-definition="$TASK_DEFINITION_FAMILY"
@@ -141,13 +140,12 @@ echo "  LOG_STREAM=$LOG_STREAM"
 NUM_RETRIES_WAITIN_FOR_LOGS=0
 while true; do
   NUM_RETRIES_WAITIN_FOR_LOGS=$((NUM_RETRIES_WAITIN_FOR_LOGS+1))
-  if [ $NUM_RETRIES_WAITIN_FOR_LOGS -eq 120 ]; then
+  if [ $NUM_RETRIES_WAITIN_FOR_LOGS -eq 20 ]; then
     echo "Timing out task $ECS_TASK_ID waiting for logs"
     exit 1
   fi
   IS_LOG_STREAM_CREATED=$(aws logs describe-log-streams --no-cli-pager --log-group-name "$LOG_GROUP" --query "length(logStreams[?logStreamName==\`$LOG_STREAM\`])")
   if [ "$IS_LOG_STREAM_CREATED" == "1" ]; then
-    echo "Found log stream after $((NUM_RETRIES_WAITIN_FOR_LOGS * 5)) seconds"
     break
   fi
   sleep 5


### PR DESCRIPTION
This reverts commit 211485b4451b12805255446aa6564e308b951fdd. No need
for it since the problem was that the IAM Role didn't have permission to
read an SSM secret.
