### PR TITLE
Update task_executor IAM policy before running migrations

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -45,7 +45,10 @@ MIGRATOR_ROLE_ARN=$(terraform -chdir="infra/$APP_NAME/service" output -raw migra
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_task_definition.app -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG " \
+  "-target=module.service.aws_ecs_task_definition.app " \
+  "-target=module.service.aws_iam_role_policy.task_executor" \
+  make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
 
 echo "::endgroup::"
 echo


### PR DESCRIPTION
When adding an environment variable to AWS SSM, the task executor will
need access to read the environment variable in order to start up a
container. This is normally handled later in the deploy, when the
`bin/deploy-release.sh` script runs `make infra-update-app-service`. But
by then, the migrations container will already have failed.

This commit updates the targets for the pre-migration `terraform` run to
also update the `aws_iam_role_policy.task_executor` resource so that it
will have the permissions it needs to start up the migrations.
