### PR TITLE
Add ErbLint for view linting

### DIFF
--- a/.github/workflows/erblint.yml
+++ b/.github/workflows/erblint.yml
@@ -1,0 +1,17 @@
+name: Erblint style checks
+
+on:
+  pull_request:
+    paths: ['app/**/*.erb']
+
+jobs:
+  erblint:
+    name: Erblint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby & Javascript
+        uses: ./.github/actions/setup-languages
+      - name: Run Erblint
+        working-directory: app
+        run: bundle exec erblint --lint-all

--- a/app/.erb-lint.yml
+++ b/app/.erb-lint.yml
@@ -1,0 +1,17 @@
+---
+EnableDefaultLinters: true
+linters:
+  # ErbSafety:
+  #   enabled: true
+  #   better_html_config: .better-html.yml
+  SpaceInHtmlTag:
+    # Allow for closing tags to be on the following line
+    enabled: false
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Layout/TrailingEmptyLines:
+        # Prevent Rubocop from adding newlines at the end of <% %> blocks
+        Enabled: false

--- a/app/.rubocop.yml
+++ b/app/.rubocop.yml
@@ -14,3 +14,10 @@ inherit_gem:
   rubocop-rails-omakase: rubocop.yml
 AllCops:
   NewCops: enable
+
+# Overrides
+Layout/IndentationWidth:
+  Enabled: true
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: normal

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem "capybara"
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails", "~> 2.7"
+  gem "erb_lint", require: false
   gem "i18n-tasks", "~> 1.0"
   gem "rspec-rails", "~> 6.1"
   gem "rubocop"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -121,6 +121,13 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)
@@ -162,6 +169,13 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     drb (2.2.1)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.12.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
@@ -365,6 +379,7 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -440,6 +455,7 @@ DEPENDENCIES
   debase-ruby_core_source
   debug
   dotenv-rails (~> 2.7)
+  erb_lint
   faraday (~> 2.9.0)
   i18n-tasks (~> 1.0)
   jbuilder

--- a/app/app/controllers/cbv/agreements_controller.rb
+++ b/app/app/controllers/cbv/agreements_controller.rb
@@ -1,4 +1,4 @@
 class Cbv::AgreementsController < Cbv::BaseController
-    def show
-    end
+  def show
+  end
 end

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -1,5 +1,5 @@
 class Cbv::SuccessesController < Cbv::BaseController
-    def show
-        @agency_url = "https://www.cms.gov"
-    end
+  def show
+    @agency_url = "https://www.cms.gov"
+  end
 end

--- a/app/app/helpers/uswds_form_builder.rb
+++ b/app/app/helpers/uswds_form_builder.rb
@@ -195,80 +195,80 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   private
-    def append_to_option(options, key, value)
-      current_value = options[key] || ""
+  def append_to_option(options, key, value)
+    current_value = options[key] || ""
 
-      if current_value.is_a?(Proc)
-        options[key] = -> { current_value.call + value }
+    if current_value.is_a?(Proc)
+      options[key] = -> { current_value.call + value }
+    else
+      options[key] = current_value + value
+    end
+  end
+
+  def us_class_for_field_type(field_type, width = nil)
+    case field_type
+    when :check_box
+      "usa-checkbox__input usa-checkbox__input--tile"
+    when :file_field
+      "usa-file-input"
+    when :radio_button
+      "usa-radio__input usa-radio__input--tile"
+    when :text_area
+      "usa-textarea"
+    else
+      classes = "usa-input"
+      classes += " usa-input--#{width}" if width
+      classes
+    end
+  end
+
+
+  # Render the label, hint text, and error message for a form field
+  def us_text_field_label(attribute, text = nil, options = {})
+    hint_option = options.delete(:hint)
+    classes = "usa-label"
+    for_attr = options[:for] || field_id(attribute)
+
+    if options[:class]
+      classes += " #{options[:class]}"
+    end
+
+    unless text
+      text = human_name(attribute)
+    end
+
+    if options[:optional]
+      text += @template.content_tag(:span, " (#{I18n.t('us_form_with.optional').downcase})", class: "usa-hint")
+    end
+
+    if hint_option
+      if hint_option.is_a?(Proc)
+        hint_content = @template.capture(&hint_option)
       else
-        options[key] = current_value + value
+        hint_content = @template.raw(hint_option)
       end
+
+      hint = @template.content_tag(:div, hint_content, id: hint_id(attribute), class: "usa-hint")
     end
 
-    def us_class_for_field_type(field_type, width = nil)
-      case field_type
-      when :check_box
-        "usa-checkbox__input usa-checkbox__input--tile"
-      when :file_field
-        "usa-file-input"
-      when :radio_button
-        "usa-radio__input usa-radio__input--tile"
-      when :text_area
-        "usa-textarea"
-      else
-        classes = "usa-input"
-        classes += " usa-input--#{width}" if width
-        classes
-      end
+    label(attribute, @template.raw(text), { class: classes, for: for_attr }) + field_error(attribute) + hint
+  end
+
+  # Label for a checkbox or radio
+  def us_toggle_label(type, attribute, text = nil, options = {})
+    hint_text = options.delete(:hint)
+    label_text = text || object.class.human_attribute_name(attribute)
+    options = options.merge({ class: "usa-#{type}__label" })
+
+    if hint_text
+      hint = @template.content_tag(:span, hint_text, class: "usa-#{type}__label-description")
+      label_text = "#{label_text} #{hint}".html_safe
     end
 
+    label(attribute, label_text, options)
+  end
 
-    # Render the label, hint text, and error message for a form field
-    def us_text_field_label(attribute, text = nil, options = {})
-      hint_option = options.delete(:hint)
-      classes = "usa-label"
-      for_attr = options[:for] || field_id(attribute)
-
-      if options[:class]
-        classes += " #{options[:class]}"
-      end
-
-      unless text
-        text = human_name(attribute)
-      end
-
-      if options[:optional]
-        text += @template.content_tag(:span, " (#{I18n.t('us_form_with.optional').downcase})", class: "usa-hint")
-      end
-
-      if hint_option
-        if hint_option.is_a?(Proc)
-          hint_content = @template.capture(&hint_option)
-        else
-          hint_content = @template.raw(hint_option)
-        end
-
-        hint = @template.content_tag(:div, hint_content, id: hint_id(attribute), class: "usa-hint")
-      end
-
-      label(attribute, @template.raw(text), { class: classes, for: for_attr }) + field_error(attribute) + hint
-    end
-
-    # Label for a checkbox or radio
-    def us_toggle_label(type, attribute, text = nil, options = {})
-      hint_text = options.delete(:hint)
-      label_text = text || object.class.human_attribute_name(attribute)
-      options = options.merge({ class: "usa-#{type}__label" })
-
-      if hint_text
-        hint = @template.content_tag(:span, hint_text, class: "usa-#{type}__label-description")
-        label_text = "#{label_text} #{hint}".html_safe
-      end
-
-      label(attribute, label_text, options)
-    end
-
-    def hint_id(attribute)
-      "#{attribute}_hint"
-    end
+  def hint_id(attribute)
+    "#{attribute}_hint"
+  end
 end

--- a/app/app/views/applicant_mailer/caseworker_summary_email.html.erb
+++ b/app/app/views/applicant_mailer/caseworker_summary_email.html.erb
@@ -1,5 +1,5 @@
-<%= t('.greeting') %>
+<%= t(".greeting") %>
 
-<%= t('.body') %>
+<%= t(".body") %>
 
-<%= t('.thank_you') %>
+<%= t(".thank_you") %>

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -1,9 +1,9 @@
 <p>
-  <%= t('.greeting') %>
+  <%= t(".greeting") %>
 </p>
 
 <p>
-  <%= t('.body') %>
+  <%= t(".body") %>
 </p>
 
 <p>
@@ -11,5 +11,5 @@
 </p>
 
 <p>
-  <%= t('.thank_you') %>
+  <%= t(".thank_you") %>
 </p>

--- a/app/app/views/application/_banner_lock_icon.html.erb
+++ b/app/app/views/application/_banner_lock_icon.html.erb
@@ -8,8 +8,8 @@
     role="img"
     aria-labelledby="banner-lock-title banner-lock-description"
   >
-    <title id="banner-lock-title"><%= t('shared.banner.lock') %></title>
-    <desc id="banner-lock-description"><%= t('shared.banner.locked_padlock') %></desc>
+    <title id="banner-lock-title"><%= t("shared.banner.lock") %></title>
+    <desc id="banner-lock-description"><%= t("shared.banner.locked_padlock") %></desc>
     <path
       fill="#000000"
       fill-rule="evenodd"

--- a/app/app/views/application/_demo_site_banner.html.erb
+++ b/app/app/views/application/_demo_site_banner.html.erb
@@ -1,3 +1,3 @@
 <div class="font-sans-lg padding-y-4 bg-secondary-darker text-white line-height-heading-1 text-center">
-  <%= t('shared.header.demo_banner') %>
+  <%= t("shared.header.demo_banner") %>
 </div>

--- a/app/app/views/application/_header.html.erb
+++ b/app/app/views/application/_header.html.erb
@@ -4,14 +4,14 @@
     <div class="usa-navbar">
       <div class="usa-logo">
         <em class="usa-logo__text">
-          <%= link_to t('shared.header.title'), root_path %>
+          <%= link_to t("shared.header.title"), root_path %>
         </em>
       </div>
-      <button class="usa-menu-btn"><%= t('shared.header.menu') %></button>
+      <button class="usa-menu-btn"><%= t("shared.header.menu") %></button>
     </div>
-    <nav aria-label="<%= t('shared.header.primary') %>" class="usa-nav">
+    <nav aria-label="<%= t("shared.header.primary") %>" class="usa-nav">
       <button class="usa-nav__close">
-        <%= image_tag "@uswds/uswds/dist/img/usa-icons/close.svg", role: "img", alt: t('shared.header.close') %>
+        <%= image_tag "@uswds/uswds/dist/img/usa-icons/close.svg", role: "img", alt: t("shared.header.close") %>
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <% I18n.available_locales.each do |l| %>

--- a/app/app/views/application/_usa_banner.html.erb
+++ b/app/app/views/application/_usa_banner.html.erb
@@ -1,18 +1,18 @@
-<a class="usa-skipnav" href="#main-content"><%= t('shared.skip_link') %></a>
+<a class="usa-skipnav" href="#main-content"><%= t("shared.skip_link") %></a>
 
-<section class="usa-banner site-banner" aria-label="<%= t('shared.banner.official_site') %>">
+<section class="usa-banner site-banner" aria-label="<%= t("shared.banner.official_site") %>">
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <%= image_tag "@uswds/uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
+          <%= image_tag "@uswds/uswds/dist/img/us_flag_small.png", alt: t("shared.banner.us_flag"), class: "usa-banner__header-flag" %>
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">
-            <%= t('shared.banner.official_site') %>
+            <%= t("shared.banner.official_site") %>
           </p>
           <p class="usa-banner__header-action" aria-hidden="true">
-            <%= t('shared.banner.how') %>
+            <%= t("shared.banner.how") %>
           </p>
         </div>
         <button
@@ -20,28 +20,32 @@
           aria-expanded="false"
           aria-controls="gov-banner"
         >
-          <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
+          <span class="usa-banner__button-text"><%= t("shared.banner.how") %></span>
         </button>
       </div>
     </header>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-      <%= javascript_tag nonce: true do %>
+      <script nonce="true">
+//<![CDATA[
+
         document.getElementById('gov-banner').setAttribute('hidden', '');
-      <% end %>
+
+//]]>
+</script>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <%= image_tag "@uswds/uswds/dist/img/icon-dot-gov.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
           <div class="usa-media-block__body">
-            <strong><%= t('shared.banner.gov_heading') %></strong>
-            <br> <%= t('shared.banner.gov_description_html') %>
+            <strong><%= t("shared.banner.gov_heading") %></strong>
+            <br> <%= t("shared.banner.gov_description_html") %>
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <%= image_tag "@uswds/uswds/dist/img/icon-https.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
           <div class="usa-media-block__body">
             <p>
-              <strong><%= t('shared.banner.secure_heading') %></strong>
-              <br> <%= t('shared.banner.secure_description_html', lock_icon: render('application/banner_lock_icon')) %>
+              <strong><%= t("shared.banner.secure_heading") %></strong>
+              <br> <%= t("shared.banner.secure_description_html", lock_icon: render("application/banner_lock_icon")) %>
             </p>
           </div>
         </div>

--- a/app/app/views/cbv/agreements/show.html.erb
+++ b/app/app/views/cbv/agreements/show.html.erb
@@ -1,23 +1,23 @@
-<h1><%= t('.header') %></h1>
-<p><%= t('.subheader') %></p>
+<h1><%= t(".header") %></h1>
+<p><%= t(".subheader") %></p>
 <ul>
-    <li><%= t('.step1') %></li>
-    <li><%= t('.step2') %></li>
-    <li><%= t('.step3') %></li>
-    <li><%= t('.step4') %></li>
-    <li><%= t('.step5') %></li>
+    <li><%= t(".step1") %></li>
+    <li><%= t(".step2") %></li>
+    <li><%= t(".step3") %></li>
+    <li><%= t(".step4") %></li>
+    <li><%= t(".step5") %></li>
 </ul>
 
 <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-3">
   <div class="usa-alert__body">
     <p class="usa-alert__text">
-      <%= t('.information_is_secure') %>
+      <%= t(".information_is_secure") %>
     </p>
   </div>
-</div><p class="text-bold"><%= t('.by_continuing') %></p>
+</div><p class="text-bold"><%= t(".by_continuing") %></p>
 
 <%= link_to next_path do %>
     <button class="usa-button usa-button--outline" type="button">
-      <%= t('.continue') %>
+      <%= t(".continue") %>
     </button>
   <% end %>

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -1,7 +1,7 @@
-<%= turbo_frame_tag 'employers' do %>
+<%= turbo_frame_tag "employers" do %>
   <% if @employers.present? %>
     <h3 class="site-preview-heading margin-bottom-2">
-      <%= t('cbv.employer_searches.show.results') %>
+      <%= t("cbv.employer_searches.show.results") %>
     </h3>
   <% end %>
   <div class="usa-card-group">
@@ -9,27 +9,27 @@
       <div class="usa-card usa-card--flag usa-card--media-right flex-1">
         <div class="usa-card__container">
           <div class="usa-card__header">
-            <h2 class="usa-card__heading"><%= employer['name'] %></h2>
+            <h2 class="usa-card__heading"><%= employer["name"] %></h2>
           </div>
           <div class="display-none usa-card__media usa-card__media--inset">
             <% if employer['logo_url'] %>
               <div class="usa-card__img">
                 <img
-                  src="<%= employer['logo_url'] %>"
+                  src="<%= employer["logo_url"] %>"
                   alt="A placeholder image"
-                />
+                >
               </div>
             <% end %>
           </div>
           <div class="usa-card__footer">
             <button
               data-action="click->cbv-employer-search#select"
-              data-id="<%= employer['id'] %>"
-              data-response-type="<%= employer['response_type'] %>"
+              data-id="<%= employer["id"] %>"
+              data-response-type="<%= employer["response_type"] %>"
               class="usa-button usa-button--outline"
               type="button"
             >
-              <%= t('cbv.employer_searches.show.select') %>
+              <%= t("cbv.employer_searches.show.select") %>
             </button>
           </div>
         </div>
@@ -38,7 +38,7 @@
   </div>
 
   <% if @query.present? %>
-    <h3><%= t('cbv.employer_searches.show.employer_not_listed') %></h3>
+    <h3><%= t("cbv.employer_searches.show.employer_not_listed") %></h3>
     <button
       data-action="click->cbv-employer-search#select"
       data-id=""
@@ -46,7 +46,7 @@
       class="usa-button usa-button--outline"
       type="button"
       >
-        <%= t('cbv.employer_searches.show.search_by_payroll_provider') %>
+        <%= t("cbv.employer_searches.show.search_by_payroll_provider") %>
     </button>
   <% end %>
 <% end %>

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -1,30 +1,30 @@
 <h2>
-  <%= t('.header') %>
+  <%= t(".header") %>
 </h2>
 
 <div data-controller="cbv-employer-search">
-  <p><%= t('.subheader') %></p>
-  <p><%= t('.search_for_employer') %></p>
-  <p><%= t('.directed_to_login_portal') %></p>
+  <p><%= t(".subheader") %></p>
+  <p><%= t(".search_for_employer") %></p>
+  <p><%= t(".directed_to_login_portal") %></p>
 
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: 'usa-search usa-search--big margin-top-4', html: { role: 'search' }, data: { turbo_frame: 'employers', turbo_action: 'advance' } do |f| %>
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-top-4", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
     <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
-    <%= f.text_field :query, value: @query, class: "usa-input", type: 'search', data: { "cbv-employer-search-target": "searchTerms" } %>
+    <%= f.text_field :query, value: @query, class: "usa-input", type: "search", data: { "cbv-employer-search-target": "searchTerms" } %>
     <button
       class="usa-button"
       type="submit"
     >
       <span class="usa-search__submit-text">
-        <%= t('.search') %>
+        <%= t(".search") %>
       </span>
       <%= image_tag "@uswds/uswds/dist/img/usa-icons-bg/search--white.svg", class: "usa-search__submit-icon", alt: "Search" %>
     </button>
   <% end %>
 
-  <%= render partial: 'employer', locals: { employer: @employers } %>
+  <%= render partial: "employer", locals: { employer: @employers } %>
 
-  <%= form_with url: next_path, method: :get, class: 'display-none', data: { 'cbv-employer-search-target': "form" } do |f| %>
-    <input type="hidden" name="user[account_id]" data-cbv-employer-search-target="userAccountId" />
+  <%= form_with url: next_path, method: :get, class: "display-none", data: { 'cbv-employer-search-target': "form" } do |f| %>
+    <input type="hidden" name="user[account_id]" data-cbv-employer-search-target="userAccountId" >
   <% end %>
 
   <a
@@ -45,11 +45,11 @@
       <div class="usa-modal__content">
         <div class="usa-modal__main">
           <h2 class="usa-modal__heading" id="modal-3-heading">
-            <%= t('.fetching_payroll') %>
+            <%= t(".fetching_payroll") %>
           </h2>
           <div class="usa-prose">
             <p id="modal-3-description">
-              <%= t('.fetching_payroll_description') %>
+              <%= t(".fetching_payroll_description") %>
             </p>
           </div>
           <div class="lds-ripple" style="left: 30%;"><div></div><div></div></div>

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -1,27 +1,27 @@
-<h1><%= t('.header') %></h1>
+<h1><%= t(".header") %></h1>
 
-<p><%= t('.subheader') %></p>
+<p><%= t(".subheader") %></p>
 
-<p><%= t('.list_header') %></p>
+<p><%= t(".list_header") %></p>
 <ul>
-  <li><%= t('.employer_name') %></li>
-  <li><%= t('.credentials') %></li>
+  <li><%= t(".employer_name") %></li>
+  <li><%= t(".credentials") %></li>
 </ul>
 
 <% if @cbv_flow.case_number %>
-<p><%= t('.case_number') %>: <strong><%= @cbv_flow.case_number %></strong></p>
+<p><%= t(".case_number") %>: <strong><%= @cbv_flow.case_number %></strong></p>
 <% end %>
 
 <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-3">
   <div class="usa-alert__body">
     <p class="usa-alert__text">
-      <%= t('.security_message') %>
+      <%= t(".security_message") %>
     </p>
   </div>
 </div>
 
 <%= link_to next_path do %>
   <button class="usa-button usa-button--outline" type="button">
-    <%= t('.get_started') %>
+    <%= t(".get_started") %>
   </button>
 <% end %>

--- a/app/app/views/cbv/shares/show.html.erb
+++ b/app/app/views/cbv/shares/show.html.erb
@@ -1,15 +1,15 @@
 <h2>
-  <%= t('.header') %>
+  <%= t(".header") %>
 </h2>
 
 <p>
-  <%= t('.body') %>
+  <%= t(".body") %>
 </p>
 
 <%= form_with url: cbv_flow_share_path, method: :patch do |form| %>
-  <%= form.button t('.share_with_caseworker'), type: 'submit', class: 'usa-button' %>
+  <%= form.button t(".share_with_caseworker"), type: "submit", class: "usa-button" %>
 <% end %>
 
-<%= link_to cbv_flow_summary_path(format: 'pdf'), target: '_blank', class: 'usa-button margin-top-3 usa-button--outline' do %>
-  <%= t('.download_pdf') %>
+<%= link_to cbv_flow_summary_path(format: "pdf"), target: "_blank", class: "usa-button margin-top-3 usa-button--outline" do %>
+  <%= t(".download_pdf") %>
 <% end %>

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -1,18 +1,18 @@
-<h1><%= t('.header') %></h1>
+<h1><%= t(".header") %></h1>
 
 <ul>
-    <li><%= t('.caseworker_received') %></li>
-    <li><%= t('.check_status') %></li>
+    <li><%= t(".caseworker_received") %></li>
+    <li><%= t(".check_status") %></li>
 </ul>
 
 <p>
-    <%= t('.confirmation_number', confirmation_number: 'XXXXXXX') %>
+    <%= t(".confirmation_number", confirmation_number: "XXXXXXX") %>
 </p>
 
-<%= link_to cbv_flow_summary_path(format: 'pdf'), target: '_blank', class: 'usa-button margin-top-3 usa-button--outline' do %>
-    <%= t('.download') %>
+<%= link_to cbv_flow_summary_path(format: "pdf"), target: "_blank", class: "usa-button margin-top-3 usa-button--outline" do %>
+    <%= t(".download") %>
 <% end %>
 
-<%= link_to @agency_url, target: '_blank', class: 'usa-button margin-top-3 usa-button' do %>
-    <%= t('.back_to_agency') %>
+<%= link_to @agency_url, target: "_blank", class: "usa-button margin-top-3 usa-button" do %>
+    <%= t(".back_to_agency") %>
 <% end %>

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -1,12 +1,12 @@
 <h2>
-  <%= t('.header') %>
+  <%= t(".header") %>
 </h2>
 
 <% if @payments.any? %>
   <p>
-    <%= t('.description') %>
+    <%= t(".description") %>
   </p>
-  <h3 class="site-preview-heading"><%= t('.total_payments') %> <%= number_to_currency(@payments.reduce(0) { |sum, payment| sum + payment[:amount] }) %></h3>
+  <h3 class="site-preview-heading"><%= t(".total_payments") %> <%= number_to_currency(@payments.reduce(0) { |sum, payment| sum + payment[:amount] }) %></h3>
 
   <div class="usa-accordion usa-accordion--bordered usa-accordion--multiselectable margin-bottom-4" data-allow-multiple>
     <% @payments.each_with_index do |payment, index| %>
@@ -17,26 +17,26 @@
           aria-expanded="false"
           aria-controls="<%= index %>"
         >
-          <%= payment[:employer] %>: <%= t('.payment_of', amount: number_to_currency(payment[:amount])) %>
+          <%= payment[:employer] %>: <%= t(".payment_of", amount: number_to_currency(payment[:amount])) %>
         </button>
       </div>
       <div id="<%= index %>" class="usa-accordion__content usa-prose">
         <p>
-          <%= t('.time_range', hours: payment[:hours], start: format_date(payment[:start]), end: format_date(payment[:end])) %>
+          <%= t(".time_range", hours: payment[:hours], start: format_date(payment[:start]), end: format_date(payment[:end])) %>
         </p>
       </div>
     <% end %>
   </div>
 <% else %>
   <h3 class="site-preview-heading">
-    <%= t('.none_found') %>
+    <%= t(".none_found") %>
   </h3>
 <% end %>
 
 <h2>
-  <%= t('.form.subheader') %>
+  <%= t(".form.subheader") %>
 </h2>
 <%= form_for(@cbv_flow, url: cbv_flow_summary_path, builder: UswdsFormBuilder) do |f| %>
-  <%= f.text_area :additional_information, label: t('.form.additional_info.label') %>
-  <%= f.submit t('.form.submit') %>
+  <%= f.text_area :additional_information, label: t(".form.additional_info.label") %>
+  <%= f.submit t(".form.submit") %>
 <% end %>

--- a/app/app/views/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/cbv_flow_invitations/new.html.erb
@@ -1,11 +1,11 @@
-<h2><%= t('.header') %></h2>
-<p><%= t('.description') %></p>
+<h2><%= t(".header") %></h2>
+<p><%= t(".description") %></p>
 
 <%= form_with(model: @cbv_flow_invitation, url: invitations_path, builder: UswdsFormBuilder) do |f| %>
   <%= hidden_field_tag :secret, params[:secret] %>
 
-  <%= f.email_field :email_address, label: t('.form.email_address') %>
-  <%= f.text_field :case_number, label: t('.form.case_number') %>
+  <%= f.email_field :email_address, label: t(".form.email_address") %>
+  <%= f.text_field :case_number, label: t(".form.case_number") %>
 
-  <%= f.submit t('.form.submit') %>
+  <%= f.submit t(".form.submit") %>
 <% end %>

--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 
     <% if Rails.env.production? %>
       <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-      <%= javascript_include_tag "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA", async: true, id:"_fed_an_ua_tag" %>
+      <%= javascript_include_tag "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA", async: true, id: "_fed_an_ua_tag" %>
     <% end %>
   </head>
 

--- a/app/app/views/layouts/mailer.html.erb
+++ b/app/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/app/views/pages/home.html.erb
+++ b/app/app/views/pages/home.html.erb
@@ -1,8 +1,8 @@
-<h1><%= t('shared.verify.welcome') %></h1>
-<h2><%= t('shared.verify.description') %></h2>
+<h1><%= t("shared.verify.welcome") %></h1>
+<h2><%= t("shared.verify.description") %></h2>
 
-<p><%= t('shared.verify.subheader') %></p>
+<p><%= t("shared.verify.subheader") %></p>
 
 <%= link_to cbv_flow_entry_path do %>
-  <button class="usa-button usa-button--outline" type="button"><%= t('cbv.manual_flow_start') %></button>
+  <button class="usa-button usa-button--outline" type="button"><%= t("cbv.manual_flow_start") %></button>
 <% end %>


### PR DESCRIPTION
## Ticket

N/A - I realized we should do these when giving Joe some CR feedback.

## Changes
- **Add erb-linter to lint ERB files**
- **Add rubocop config to enforce 2-space indents**

## Context for reviewers

Erblint is the standard way to lint Erb views. I've disabled the SpaceInHtmlTag linter because it forbids putting the close angle bracket on the subsquent line, e.g.:

```
<div
  attribute="value"
>
  <p>...</p>
</div>
```

Personally, I find that more readable than if the `>` were on the same line as `attribute="value"`.

## Testing

It should run as part of this PR.
