### PR TITLE
Fix bin/run-database-migrations.sh script syntax

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -45,9 +45,9 @@ MIGRATOR_ROLE_ARN=$(terraform -chdir="infra/$APP_NAME/service" output -raw migra
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG " \
-  "-target=module.service.aws_ecs_task_definition.app " \
-  "-target=module.service.aws_iam_role_policy.task_executor" \
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG \
+  -target=module.service.aws_ecs_task_definition.app \
+  -target=module.service.aws_iam_role_policy.task_executor" \
   make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
 
 echo "::endgroup::"


### PR DESCRIPTION
I didn't test this before, and sure enough, it doesn't work.
See: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/9765708170/job/26957251457

This seems to be the proper syntax:
<img width="335" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/129120/7a0ac389-898c-4f78-a8fe-7481fbd85a20">

