### PR TITLE
Track ApplicantDownloadedIncomePDF

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -5,6 +5,11 @@ class Cbv::SummariesController < Cbv::BaseController
     respond_to do |format|
       format.html
       format.pdf do
+        NewRelicEventTracker.track("ApplicantDownloadedIncomePDF", {
+          timestamp: Time.now.to_i,
+          cbv_flow_id: @cbv_flow.id
+        })
+
         render pdf: "#{@cbv_flow.id}"
       end
     end


### PR DESCRIPTION
## Ticket

Resolves [705](https://jiraent.cms.gov/browse/FFS-705)

## Changes

Adds a new event for when the PDF download page is visited.

## Context for reviewers

This satisfies one of the events to track: https://confluenceent.cms.gov/display/SFIV/Dashboards+and+Metrics+for+CBV+MVP

Specifically, "% that export the PDF for their own records". 

The denominator is the applicants that complete the flow. This can be inferred by nature of the download being the last step of the flow.

I'm not sure this is the best way to do this. I'd like to see if NewRelic is properly tracking visits to routes...

## Testing

<img width="903" alt="image" src="https://github.com/DSACMS/iv-cbv-payroll/assets/5004319/4a609c78-5c37-4907-a8e1-6362b3503b7a">

(A test suite asserting events are sent would help...)
