### PR TITLE
Support for multiple applicant comments. One comment per income source.

### DIFF
--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -1,5 +1,4 @@
 class Cbv::PaymentDetailsController < Cbv::BaseController
-  before_action :set_cbv_flow
   helper_method :employer_name,
     :start_date,
     :end_date,
@@ -28,7 +27,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
       updated_at: Time.current
     }
     @cbv_flow.update(additional_information: additional_information.to_json)
-    redirect_to cbv_flow_add_job_path
+    redirect_to next_path
   end
 
   def account_comment
@@ -78,13 +77,6 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     @payments
       .map { |payment| payment[:gross_pay_amount] }
       .reduce(:+)
-  end
-
-  def parse_additional_information(json_string)
-    return {} if json_string.nil?
-    JSON.parse(json_string)
-  rescue JSON::ParserError
-    {}
   end
 
   def sanitize_comment(comment)

--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -1,4 +1,5 @@
 class Cbv::PaymentDetailsController < Cbv::BaseController
+  before_action :set_cbv_flow
   helper_method :employer_name,
     :start_date,
     :end_date,
@@ -20,14 +21,13 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
 
   def update
     account_id = params[:user][:account_id]
-    cbv_flow = CbvFlow.find(session[:cbv_flow_id])
     comment = params[:cbv_flow][:additional_information]
-    additional_information = parse_additional_information(cbv_flow.additional_information)
+    additional_information = parse_additional_information(@cbv_flow.additional_information)
     additional_information[account_id] = {
       comment: sanitize_comment(comment),
       updated_at: Time.current
     }
-    cbv_flow.update(additional_information: additional_information.to_json)
+    @cbv_flow.update(additional_information: additional_information.to_json)
     redirect_to cbv_flow_add_job_path
   end
 
@@ -92,8 +92,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
   end
 
   def get_additional_information
-    cbv_flow = CbvFlow.find(session[:cbv_flow_id])
-    parse_additional_information(cbv_flow.additional_information)
+    parse_additional_information(@cbv_flow.additional_information)
   end
 
   def get_comment_by_account_id(account_id)

--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -22,7 +22,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
   def update
     account_id = params[:user][:account_id]
     comment = params[:cbv_flow][:additional_information]
-    additional_information = parse_additional_information(@cbv_flow.additional_information)
+    additional_information = @cbv_flow.additional_information
     additional_information[account_id] = {
       comment: sanitize_comment(comment),
       updated_at: Time.current
@@ -91,12 +91,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     ActionController::Base.helpers.sanitize(comment)
   end
 
-  def get_additional_information
-    parse_additional_information(@cbv_flow.additional_information)
-  end
-
   def get_comment_by_account_id(account_id)
-    additional_information = get_additional_information
-    additional_information.fetch(account_id, { comment: nil, updated_at: nil })
+    @cbv_flow.additional_information[account_id] || { comment: nil, updated_at: nil }
   end
 end

--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -7,13 +7,33 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     :employment_end_date,
     :employment_status,
     :pay_period_frequency,
-    :compensation_amount
+    :compensation_amount,
+    :account_comment
 
   def show
     account_id = params[:user][:account_id]
     @employment = pinwheel.fetch_employment(account_id: account_id)["data"]
     @income_metadata = pinwheel.fetch_income_metadata(account_id: account_id)["data"]
     @payments = set_payments account_id
+    @account_comment = account_comment
+  end
+
+  def update
+    account_id = params[:user][:account_id]
+    cbv_flow = CbvFlow.find(session[:cbv_flow_id])
+    comment = params[:cbv_flow][:additional_information]
+    additional_information = parse_additional_information(cbv_flow.additional_information)
+    additional_information[account_id] = {
+      comment: sanitize_comment(comment),
+      updated_at: Time.current
+    }
+    cbv_flow.update(additional_information: additional_information.to_json)
+    redirect_to cbv_flow_add_job_path
+  end
+
+  def account_comment
+    account_id = params[:user][:account_id]
+    get_comment_by_account_id(account_id)["comment"]
   end
 
   private
@@ -58,5 +78,26 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     @payments
       .map { |payment| payment[:gross_pay_amount] }
       .reduce(:+)
+  end
+
+  def parse_additional_information(json_string)
+    return {} if json_string.nil?
+    JSON.parse(json_string)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def sanitize_comment(comment)
+    ActionController::Base.helpers.sanitize(comment)
+  end
+
+  def get_additional_information
+    cbv_flow = CbvFlow.find(session[:cbv_flow_id])
+    parse_additional_information(cbv_flow.additional_information)
+  end
+
+  def get_comment_by_account_id(account_id)
+    additional_information = get_additional_information
+    additional_information.fetch(account_id, { comment: nil, updated_at: nil })
   end
 end

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -5,12 +5,6 @@
     <%= t(".header_no_employer_name") %>
   <% end %>
 </h1>
-<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-  <use xlink:href="/assets/img/sprite.svg#account_circle"></use>
-</svg>
-<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-  <use xlink:href="/assets/img/sprite.svg#accessible_forward"></use>
-</svg>
 
 <% if @payments.any? %>
   <p><%= t(".subheader", start_date: format_date(start_date), end_date: format_date(end_date)) %></p>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -18,7 +18,7 @@
   <p><%= t(".total_gross_description") %></p>
 
   <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch) do |form| %>
-    <%= hidden_field_tag 'user[account_id]', params[:user][:account_id] %>
+    <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
     <table class="usa-table usa-table--borderless width-full">
       <thead class="border-top-05">
       <tr>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -17,8 +17,7 @@
   <h2><%= t(".total_gross_income", amount: number_to_currency(gross_pay)) %></h2>
   <p><%= t(".total_gross_description") %></p>
 
-  <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch) do |form| %>
-    <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
+  
     <table class="usa-table usa-table--borderless width-full">
       <thead class="border-top-05">
       <tr>
@@ -87,6 +86,8 @@
     </table>
 
     <div class="usa-form-group">
+      <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch) do |form| %>
+      <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
       <%= form.label :additional_information, t(".additional_information_label"), class: "usa-label" %>
       <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment %>
       <%= form.submit t(".continue"), class: "usa-button usa-button--outline margin-top-3" %>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -1,45 +1,53 @@
 <h1>
-<% if employer_name %>
-  <%= t(".header", employer_name: employer_name) %>
-<% else %>
-  <%= t(".header_no_employer_name") %>
-<% end %>
+  <% if employer_name %>
+    <%= t(".header", employer_name: employer_name) %>
+  <% else %>
+    <%= t(".header_no_employer_name") %>
+  <% end %>
 </h1>
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use xlink:href="/assets/img/sprite.svg#account_circle"></use>
+</svg>
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use xlink:href="/assets/img/sprite.svg#accessible_forward"></use>
+</svg>
 
 <% if @payments.any? %>
   <p><%= t(".subheader", start_date: format_date(start_date), end_date: format_date(end_date)) %></p>
-    <h2><%= t(".total_gross_income", amount: number_to_currency(gross_pay)) %></h2>
-    <p><%= t(".total_gross_description") %></p>
+  <h2><%= t(".total_gross_income", amount: number_to_currency(gross_pay)) %></h2>
+  <p><%= t(".total_gross_description") %></p>
 
+  <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch) do |form| %>
+    <%= hidden_field_tag 'user[account_id]', params[:user][:account_id] %>
     <table class="usa-table usa-table--borderless width-full">
       <thead class="border-top-05">
-        <tr>
-          <th class="padding-3" style="background-color: #d9e8f6;" colspan="2">
-            <h3 class="margin-0"><%= t(".payments_and_deductions") %></h3>
-          </th>
-        </tr>
+      <tr>
+        <th class="padding-3" style="background-color: #d9e8f6;" colspan="2">
+          <h3 class="margin-0"><%= t(".payments_and_deductions") %></h3>
+        </th>
+      </tr>
       </thead>
       <tbody>
-        <tr>
-          <td><%= t(".employment_start_date") %></td>
-          <td><%= format_date(employment_start_date) %></td>
-        </tr>
-        <tr>
-          <td><%= t(".employment_end_date") %></td>
-          <td><%= employment_end_date ? employment_end_date : "N/A" %></td>
-        </tr>
-        <tr>
-          <td><%= t(".employment_status") %></td>
-          <td><%= employment_status %></td>
-        </tr>
-        <tr>
-          <td><%= t(".pay_period_frequency") %></td>
-          <td><%= pay_period_frequency %></td>
-        </tr>
-        <tr>
-          <td><%= t(".hourly_rate") %></td>
-          <td><%= number_to_currency(compensation_amount) %></td>
-        </tr>
+      <tr>
+        <td><%= t(".employment_start_date") %></td>
+        <td><%= format_date(employment_start_date) %></td>
+      </tr>
+      <tr>
+        <td><%= t(".employment_end_date") %></td>
+        <td><%= employment_end_date ? employment_end_date : "N/A" %></td>
+      </tr>
+      <tr>
+        <td><%= t(".employment_status") %></td>
+        <td><%= employment_status %></td>
+      </tr>
+      <tr>
+        <td><%= t(".pay_period_frequency") %></td>
+        <td><%= pay_period_frequency %></td>
+      </tr>
+      <tr>
+        <td><%= t(".hourly_rate") %></td>
+        <td><%= number_to_currency(compensation_amount) %></td>
+      </tr>
       </tbody>
     </table>
 
@@ -52,34 +60,37 @@
       </tr>
       </thead>
       <tbody>
-        <% @payments.each do |payment| %>
+      <% @payments.each do |payment| %>
+        <tr>
+          <td colspan="2">
+            <h4 class="margin-0"><%= t(".payment_of", amount: number_to_currency(payment[:amount])) %>
+              on <%= format_date(payment[:pay_date]) %></h4>
+          </td>
+        </tr>
+        <tr>
+          <td><%= t(".pay_period") %></td>
+          <td><%= format_date(payment[:start]) %> to <%= format_date(payment[:end]) %></td>
+        </tr>
+        <tr>
+          <td><%= t(".number_of_hours_worked") %></td>
+          <td><%= t(".payment_hours", amount: payment[:hours]) %></td>
+        </tr>
+        <% payment[:deductions].each do |deduction| %>
           <tr>
-            <td colspan="2">
-              <h4 class="margin-0"><%= t(".payment_of", amount: number_to_currency(payment[:amount])) %> on <%= format_date(payment[:pay_date]) %></h4>
-            </td>
+            <td><%= t(".deductions", category: deduction[:category]) %></td>
+            <td><%= number_to_currency(deduction[:amount]) %></td>
           </tr>
-          <tr>
-            <td><%= t(".pay_period") %></td>
-            <td><%= format_date(payment[:start]) %> to <%= format_date(payment[:end]) %></td>
-          </tr>
-          <tr>
-            <td><%= t(".number_of_hours_worked") %></td>
-            <td><%= t(".payment_hours", amount: payment[:hours]) %></td>
-          </tr>
-          <% payment[:deductions].each do |deduction| %>
-            <tr>
-              <td><%= t(".deductions", category: deduction[:category]) %></td>
-              <td><%= number_to_currency(deduction[:amount]) %></td>
-            </tr>
-          <% end %>
         <% end %>
+      <% end %>
+
       </tbody>
     </table>
 
-  <%= link_to next_path do %>
-    <button class="usa-button usa-button--outline" type="button">
-      <%= t(".continue") %>
-    </button>
+    <div class="usa-form-group">
+      <%= form.label :additional_information, t(".additional_information_label"), class: "usa-label" %>
+      <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment %>
+      <%= form.submit t(".continue"), class: "usa-button usa-button--outline margin-top-3" %>
+    </div>
   <% end %>
 <% else %>
   <h3 class="site-preview-heading">

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -16,8 +16,6 @@
   <p><%= t(".subheader", start_date: format_date(start_date), end_date: format_date(end_date)) %></p>
   <h2><%= t(".total_gross_income", amount: number_to_currency(gross_pay)) %></h2>
   <p><%= t(".total_gross_description") %></p>
-
-  
     <table class="usa-table usa-table--borderless width-full">
       <thead class="border-top-05">
       <tr>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
         header: If you can’t find your employer or payroll provider, you’ll need to provide income information separately.
     payment_details:
       show:
+        additional_information_label: Is there anything else you'd like your caseworker to know about your income?
         continue: Continue
         deductions: 'Deduction: %{category}'
         employment_end_date: Employment end date
@@ -80,8 +81,6 @@ en:
         subheader: We have gathered your payment records from the past 90 days, from %{start_date} to %{end_date}. Review them and add any comments for your caseworker in the additional comments section. This will be included in your income report.
         total_gross_description: This is the total income from your job before taxes, benefits and deductions were taken out of your paycheck.
         total_gross_income: 'Total income before taxes: %{amount}'
-        additional_information_label: Is there anything else you'd like your caseworker to know about your income?
-        save_additional_information: Save additional information
     shares:
       show:
         body: Thank you for completing income verification. Click the button below to preview your results and share it with your caseworker.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
         subheader: We have gathered your payment records from the past 90 days, from %{start_date} to %{end_date}. Review them and add any comments for your caseworker in the additional comments section. This will be included in your income report.
         total_gross_description: This is the total income from your job before taxes, benefits and deductions were taken out of your paycheck.
         total_gross_income: 'Total income before taxes: %{amount}'
+        additional_information_label: Is there anything else you'd like your caseworker to know about your income?
+        save_additional_information: Save additional information
     shares:
       show:
         body: Thank you for completing income verification. Click the button below to preview your results and share it with your caseworker.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
         header: If you can’t find your employer or payroll provider, you’ll need to provide income information separately.
     payment_details:
       show:
-        additional_information_label: Is there anything else you'd like your caseworker to know about your income?
+        additional_information_label: Share any comments or additional information about the payment details above that you’d like your caseworker to know.
         continue: Continue
         deductions: 'Deduction: %{category}'
         employment_end_date: Employment end date

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       resource :success, only: %i[show]
       resource :agreement, only: %i[show create]
       resource :add_job, only: %i[show create]
-      resource :payment_details, only: %i[show]
+      resource :payment_details, only: %i[show update]
 
       # Utility route to clear your session; useful during development
       resource :reset, only: %i[show]

--- a/app/db/migrate/20240715203948_change_additional_information_to_jsonb_column_on_cbv_flows.rb
+++ b/app/db/migrate/20240715203948_change_additional_information_to_jsonb_column_on_cbv_flows.rb
@@ -1,16 +1,6 @@
 class ChangeAdditionalInformationToJsonbColumnOnCbvFlows < ActiveRecord::Migration[7.1]
   def change
-    # empty existing non-null and non-empty values
-    execute <<-SQL
-      UPDATE cbv_flows
-      SET additional_information = '{}'
-      WHERE additional_information IS NOT NULL
-        AND additional_information != ''
-    SQL
-
-    # change column type to JSONB and add a default value
-    change_column :cbv_flows, :additional_information, :jsonb,
-                  default: {},
-                  using: "COALESCE(additional_information::jsonb, '{}'::jsonb)"
+    remove_column :cbv_flows, :additional_information
+    add_column :cbv_flows, :additional_information, :jsonb, default: {}
   end
 end

--- a/app/db/migrate/20240715203948_change_additional_information_to_jsonb_column_on_cbv_flows.rb
+++ b/app/db/migrate/20240715203948_change_additional_information_to_jsonb_column_on_cbv_flows.rb
@@ -1,0 +1,16 @@
+class ChangeAdditionalInformationToJsonbColumnOnCbvFlows < ActiveRecord::Migration[7.1]
+  def change
+    # empty existing non-null and non-empty values
+    execute <<-SQL
+      UPDATE cbv_flows
+      SET additional_information = '{}'
+      WHERE additional_information IS NOT NULL
+        AND additional_information != ''
+    SQL
+
+    # change column type to JSONB and add a default value
+    change_column :cbv_flows, :additional_information, :jsonb,
+                  default: {},
+                  using: "COALESCE(additional_information::jsonb, '{}'::jsonb)"
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_154226) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_15_203948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_154226) do
     t.datetime "updated_at", null: false
     t.date "payroll_data_available_from"
     t.bigint "cbv_flow_invitation_id"
-    t.text "additional_information"
+    t.jsonb "additional_information"
     t.string "pinwheel_token_id"
     t.uuid "pinwheel_end_user_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["cbv_flow_invitation_id"], name: "index_cbv_flows_on_cbv_flow_invitation_id"

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -34,9 +34,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_15_203948) do
     t.datetime "updated_at", null: false
     t.date "payroll_data_available_from"
     t.bigint "cbv_flow_invitation_id"
-    t.jsonb "additional_information"
     t.string "pinwheel_token_id"
     t.uuid "pinwheel_end_user_id", default: -> { "gen_random_uuid()" }, null: false
+    t.jsonb "additional_information", default: {}
     t.index ["cbv_flow_invitation_id"], name: "index_cbv_flows_on_cbv_flow_invitation_id"
   end
 

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -1,3 +1,4 @@
+# spec/controllers/cbv/payment_details_controller_spec.rb
 require "rails_helper"
 
 RSpec.describe Cbv::PaymentDetailsController do
@@ -6,7 +7,9 @@ RSpec.describe Cbv::PaymentDetailsController do
   describe "#show" do
     render_views
 
-    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi") }
+    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi") }
+    let(:account_id) { SecureRandom.uuid }
+    let(:comment) { "This is a test comment" }
 
     before do
       session[:cbv_flow_id] = cbv_flow.id
@@ -17,8 +20,51 @@ RSpec.describe Cbv::PaymentDetailsController do
     end
 
     it "renders properly" do
-      get :show, params: { user: { account_id: '123456789012345678901234567890123456' } }
+      get :show, params: { user: { account_id: account_id } }
       expect(response).to be_successful
+    end
+
+    context "when account comment exists" do
+      let(:updated_at) { Time.current.iso8601 }
+
+      before do
+        additional_information = { account_id => { comment: comment, updated_at: updated_at } }
+        cbv_flow.update!(additional_information: additional_information.to_json)
+
+        # Verify that the comment was saved
+        loaded_info = JSON.parse(cbv_flow.reload.additional_information)
+        expect(loaded_info[account_id]["comment"]).to eq(comment)
+        
+        expect(loaded_info[account_id]["updated_at"]).to eq(updated_at)
+      end
+
+      it "includes the account comment in the response" do
+        get :show, params: { user: { account_id: account_id } }
+        expect(response.body).to include(comment)
+      end
+    end
+
+    context "when account comment does not exist" do
+      it "does not include an account comment in the response" do
+        get :show, params: { user: { account_id: account_id } }
+        expect(response.body).not_to include(comment)
+      end
+    end
+  end
+
+  describe "#update" do
+    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi") }
+    let(:account_id) { SecureRandom.uuid }
+    let(:comment) { "This is a test comment" }
+
+    before do
+      session[:cbv_flow_id] = cbv_flow.id
+    end
+
+    it "updates the account comment" do
+      patch :update, params: { user: { account_id: account_id }, cbv_flow: { additional_information: comment } }
+      additional_information = JSON.parse(cbv_flow.reload.additional_information)
+      expect(additional_information[account_id]["comment"]).to eq(comment)
     end
   end
 end

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -1,4 +1,3 @@
-# spec/controllers/cbv/payment_details_controller_spec.rb
 require "rails_helper"
 
 RSpec.describe Cbv::PaymentDetailsController do
@@ -89,10 +88,18 @@ RSpec.describe Cbv::PaymentDetailsController do
 
     before do
       session[:cbv_flow_id] = cbv_flow.id
+      # update the cbv_flow to have an account comment
+      additional_information = { account_id => { comment: "Old comment", updated_at: Time.current.iso8601 } }
+      cbv_flow.update!(additional_information: additional_information)
     end
 
-    it "updates the account comment" do
+    it "updates the account comment through invoking the controller" do
+      additional_information = cbv_flow.additional_information
+      # a bit redundant, but prior to invoking the controller action- the comment should be different
+      expect(additional_information[account_id]["comment"]).not_to eq(comment)
+      # invoke the controller action
       patch :update, params: { user: { account_id: account_id }, cbv_flow: { additional_information: comment } }
+      # verify that the comment was updated. the reload method does not deserialize the JSON field
       additional_information = JSON.parse(cbv_flow.reload.additional_information)
       expect(additional_information[account_id]["comment"]).to eq(comment)
     end

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Cbv::PaymentDetailsController do
         # Verify that the comment was saved
         loaded_info = JSON.parse(cbv_flow.reload.additional_information)
         expect(loaded_info[account_id]["comment"]).to eq(comment)
-        
+
         expect(loaded_info[account_id]["updated_at"]).to eq(updated_at)
       end
 

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -18,19 +18,5 @@ RSpec.describe Cbv::SummariesController do
       get :show
       expect(response).to be_successful
     end
-
-    context "when saving additional information for the caseworker" do
-      let(:additional_information) { "This is some additional information for the caseworker" }
-
-      it "saves and redirects to the next page" do
-        expect do
-          patch :update, params: { cbv_flow: { additional_information: additional_information } }
-        end.to change { cbv_flow.reload.additional_information }
-                 .from(nil)
-                 .to(additional_information)
-
-        expect(response).to redirect_to(cbv_flow_share_path)
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR modifies the existing `additional_info` column of the `cbv_flows` table from string column to a JSONB column. The JSON object is a hash consisting of keys which reference applicant payment account_id to an end user supplied comment.

## Ticket

Resolves [FFS-1087](https://jiraent.cms.gov/browse/FFS-1087)

## Changes

> - Added migration that sets the default column value to an empty object e.g. `{}`
> - Adds new functionality to the Payment Details Controllers
> - Adds a comment box on the payment details page
> - Adds a form to the `payment_details` page that posts to the itself and then redirects to the `add_job` url
> - Adds unit and integration tests
> - Navigating back to the payment details page preserves the comment

![Screenshot 2024-07-15 at 8 35 49 PM](https://github.com/user-attachments/assets/0bdf5577-1207-4029-b5f2-c09d0f72d349)

## Context for reviewers

The continue button for the `payment_details` page now acts a form submission which submits a form to itself. Upon updating the comment for the respective payment details the user is redirected to the jobs page where they can add another source of income.

## Testing

![Screenshot 2024-07-15 at 8 37 11 PM](https://github.com/user-attachments/assets/78c61a9f-5a39-40a1-b2d7-94ddec7d141e)
