### PR TITLE
Add terraform config for CBV production environment

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -4,7 +4,6 @@ name: Deploy App
 run-name: Deploy ${{ github.ref_name }} to App ${{ inputs.environment || 'dev' }}
 
 on:
-  # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
   push:
     branches:
       - "main"
@@ -21,7 +20,6 @@ on:
         type: choice
         options:
           - dev
-          - staging
           - prod
 permissions:
     id-token: write

--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ TK
 
 ## Demo
 
-TK
+This repo's `main` branch automatically deploys to our demo environment via [a GitHub action](/.github/workflows/cd-app.yml).
 
 ## Production
 
-TK
+To deploy to production, go to the repo's "Actions" tab on Github, [click "Deploy App"](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/cd-app.yml), and "Run Workflow".
 
 # Credentials and other Secrets
 

--- a/docs/infra/set-up-aws-account.md
+++ b/docs/infra/set-up-aws-account.md
@@ -21,6 +21,18 @@ The account set up sets up whatever account you're authenticated into. To see wh
 aws sts get-caller-identity
 ```
 
+If you are in the wrong account, add the right account to your `~/.aws/credentials` under a different block, for example:
+```ini
+[default]
+# ...
+
+[other_account]
+aws_access_key_id = "<SOME STRING>"
+aws_secret_access_key = "<SOME STRING>"
+```
+
+Then, run future commands prefixed with `AWS_PROFILE=other_account` to use those credentials.
+
 To see a more human readable account alias instead of the account, run
 
 ```bash

--- a/infra/accounts/nava-ffs-prod.730335532059.s3.tfbackend
+++ b/infra/accounts/nava-ffs-prod.730335532059.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "iv-cbv-payroll-730335532059-us-east-1-tf"
-key            = "infra/app/build-repository/shared.tfstate"
+key            = "infra/account.tfstate"
 dynamodb_table = "iv-cbv-payroll-730335532059-us-east-1-tf-state-locks"
 region         = "us-east-1"

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -67,7 +67,7 @@ locals {
     shared  = "nava-ffs"
     dev     = "nava-ffs"
     staging = "nava-ffs"
-    prod    = "nava-ffs"
+    prod    = "nava-ffs-prod"
   }
 }
 

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -5,8 +5,8 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   network_name                    = "prod"
-  domain_name                     = null
-  enable_https                    = false
+  domain_name                     = "verify-prod.navapbc.cloud"
+  enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 

--- a/infra/app/database/prod.s3.tfbackend
+++ b/infra/app/database/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "iv-cbv-payroll-730335532059-us-east-1-tf"
-key            = "infra/app/build-repository/shared.tfstate"
+key            = "infra/app/database/prod.tfstate"
 dynamodb_table = "iv-cbv-payroll-730335532059-us-east-1-tf-state-locks"
 region         = "us-east-1"

--- a/infra/app/service/prod.s3.tfbackend
+++ b/infra/app/service/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "iv-cbv-payroll-730335532059-us-east-1-tf"
-key            = "infra/app/build-repository/shared.tfstate"
+key            = "infra/app/service/prod.tfstate"
 dynamodb_table = "iv-cbv-payroll-730335532059-us-east-1-tf-state-locks"
 region         = "us-east-1"

--- a/infra/networks/prod.s3.tfbackend
+++ b/infra/networks/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "iv-cbv-payroll-730335532059-us-east-1-tf"
-key            = "infra/app/build-repository/shared.tfstate"
+key            = "infra/networks/prod.tfstate"
 dynamodb_table = "iv-cbv-payroll-730335532059-us-east-1-tf-state-locks"
 region         = "us-east-1"

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -45,10 +45,16 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "hosted.zone.for.prod.network.com"
+        hosted_zone = "verify-prod.navapbc.cloud" # TODO: Replace this with our production product name
 
-        certificate_configs = {}
+        certificate_configs = {
+          "verify-prod.navapbc.cloud" = {
+            source = "issued"
+          }
+        }
       }
+
+      single_nat_gateway = true
     }
   }
 }


### PR DESCRIPTION
## Ticket

Resolves FFS-1048.

## Changes

This commit is the result of:
1. Adding AWS access keys to my local ~/.aws/credentials file (under a
   new section for "prod")
2. Running:
   ```
   AWS_PROFILE=prod make infra-set-up-account ACCOUNT_NAME=nava-ffs-prod
   AWS_PROFILE=prod make infra-configure-app-service APP_NAME=app ENVIRONMENT=prod
   AWS_PROFILE=prod make infra-configure-app-build-repository APP_NAME=app
   AWS_PROFILE=prod make infra-configure-app-database APP_NAME=app ENVIRONMENT=prod
   ```
   and their corresponding `update` make targets that actually create the AWS
   resources.
3. Reviewing and making minor updates to the deploy documentation

## Context for reviewers

One note is that this changes the shared build repository to be hosted
in production. It appears the infra template is architected around a
single shared container image registry, so, keeping that in production
probably makes more sense than having it in dev(/demo) and having
production pull from there.

## Testing

See it at verify-prod.navapbc.cloud.
