### PR TITLE
Add MA MOVEIt bucket configuration

### DIFF
--- a/infra/app/app-config/env-config/main.tf
+++ b/infra/app/app-config/env-config/main.tf
@@ -5,4 +5,6 @@ locals {
   prefix = terraform.workspace == "default" ? "" : "${terraform.workspace}-"
 
   bucket_name = "${local.prefix}${var.project_name}-${var.app_name}-${var.environment}"
+
+  massachusetts_moveit_bucket_name = "${local.prefix}${var.project_name}-${var.app_name}-ma-moveit-${var.environment}"
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -42,8 +42,8 @@ output "service_config" {
 
 output "storage_config" {
   value = {
-    # Include project name in bucket name since buckets need to be globally unique across AWS
     bucket_name = local.bucket_name
+    massachusetts_moveit_bucket_name = local.massachusetts_moveit_bucket_name
   }
 }
 

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -169,6 +169,7 @@ module "service" {
   extra_environment_variables = merge({
     FEATURE_FLAGS_PROJECT = module.feature_flags.evidently_project_name
     BUCKET_NAME           = local.storage_config.bucket_name
+    MA_MOVEIT_BUCKET_NAME = local.storage_config.massachusetts_moveit_bucket_name
   }, local.service_config.extra_environment_variables)
 
   secrets = local.service_config.secrets
@@ -176,6 +177,7 @@ module "service" {
   extra_policies = {
     feature_flags_access = module.feature_flags.access_policy_arn,
     storage_access       = module.storage.access_policy_arn,
+    ma_moveit_access     = module.storage_ma_moveit.access_policy_arn,
     email_access         = aws_iam_policy.email_access_policy.arn
   }
 

--- a/infra/app/service/massachusetts.tf
+++ b/infra/app/service/massachusetts.tf
@@ -1,0 +1,20 @@
+# For the MA pilot, we will send files to an S3 bucket monitored by MA's MOVEIt
+# system. For now, let's re-use the "storage" module.
+module "storage_ma_moveit" {
+  source = "../../modules/storage"
+  name   = local.storage_config.massachusetts_moveit_bucket_name
+}
+
+# IAM user shared with MA DTA for purposes of pulling files
+resource "aws_iam_user" "ma_moveit" {
+  name = "ma-moveit-${var.environment_name}"
+}
+
+resource "aws_iam_user_policy_attachment" "ma_moveit" {
+  user       = aws_iam_user.ma_moveit.name
+  policy_arn = module.storage_ma_moveit.access_policy_arn
+}
+
+resource "aws_iam_access_key" "ma_moveit" {
+  user = aws_iam_user.ma_moveit.name
+}

--- a/infra/app/service/outputs.tf
+++ b/infra/app/service/outputs.tf
@@ -22,3 +22,12 @@ output "application_log_stream_prefix" {
 output "migrator_role_arn" {
   value = module.service.migrator_role_arn
 }
+
+output "ma_moveit_access_key_id" {
+  value = aws_iam_access_key.ma_moveit.id
+}
+
+output "ma_moveit_secret_access_key" {
+  value = aws_iam_access_key.ma_moveit.secret
+  sensitive = true
+}


### PR DESCRIPTION
## Ticket

Resolves FFS-1197.

## Changes

* Add env_config for MA MOVEIt bucket name
* Create the bucket and an IAM user to access it in a new
  `massachusetts.tf` file.
* Output the access key details so we can send it to them

Co-Authored-By: George Byers <georgebyers@navapbc.com>

## Context for reviewers

N/A

## Testing

Already deployed. We tested that the credentials are able to access the bucket (and nothing more).
