### PR TITLE
Require TLS when sending emails via AWS SES

### DIFF
--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -96,7 +96,10 @@ resource "aws_iam_policy" "email_access_policy" {
 data "aws_iam_policy_document" "email_access_policy" {
   statement {
     actions   = ["ses:SendRawEmail", "ses:SendEmail"]
-    resources = ["arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:identity/*"]
+    resources = [
+      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:identity/*",
+      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:configuration-set/*"
+    ]
   }
 }
 


### PR DESCRIPTION
## Ticket

Finishes FFS-1022.

## Changes

* Create a configuration set that requires TLS
* Set the default configuration set for the AWS SES sending identity

  Note: The `default_configuration_set` parameter is only allowed for
  `aws_sesv2_email_identity` resources (not the previously-used
  `aws_ses_domain_identity` resource), so this commit upgrades the
  resource to that. (It forces recreation.)
* Grant the task executor role permission to send email with the new
  configuration set

## Context for reviewers

See ticket.

## Testing

Tested by running in development environment and verifying that an email still
goes through. I'm not sure how to test the failure mode of a non-TLS email
server. I will run it in production after merging.
