### PR TITLE
Fix production deploy by pushing built images to prod registry

### DIFF
--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments          = ["dev", "staging", "prod"]
+  environments          = ["dev", "prod"]
   project_name          = module.project_config.project_name
   image_repository_name = "${local.project_name}-${local.app_name}"
 
@@ -26,7 +26,7 @@ locals {
 
   environment_configs = {
     dev     = module.dev_config
-    staging = module.staging_config
+    # staging = module.staging_config
     prod    = module.prod_config
   }
 
@@ -64,9 +64,9 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared  = "nava-ffs"
     dev     = "nava-ffs"
-    staging = "nava-ffs"
+    # staging = "nava-ffs"
+    shared  = "nava-ffs-prod"   # ECS Container Registry lives here
     prod    = "nava-ffs-prod"
   }
 }

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -1,17 +1,17 @@
-module "staging_config" {
-  source                          = "./env-config"
-  project_name                    = local.project_name
-  app_name                        = local.app_name
-  default_region                  = module.project_config.default_region
-  environment                     = "staging"
-  network_name                    = "staging"
-  domain_name                     = null
-  enable_https                    = false
-  has_database                    = local.has_database
-  has_incident_management_service = local.has_incident_management_service
-
-  # Enables ECS Exec access for debugging or jump access.
-  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
-  # Defaults to `false`. Uncomment the next line to enable.
-  # enable_command_execution = true
-}
+# module "staging_config" {
+#   source                          = "./env-config"
+#   project_name                    = local.project_name
+#   app_name                        = local.app_name
+#   default_region                  = module.project_config.default_region
+#   environment                     = "staging"
+#   network_name                    = "staging"
+#   domain_name                     = null
+#   enable_https                    = false
+#   has_database                    = local.has_database
+#   has_incident_management_service = local.has_incident_management_service
+#
+#   # Enables ECS Exec access for debugging or jump access.
+#   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+#   # Defaults to `false`. Uncomment the next line to enable.
+#   # enable_command_execution = true
+# }


### PR DESCRIPTION
## Ticket

No ticket.

## Changes
Production deploys are currently failing due to the task not being able
to [pull the built image from the registry][1]. Upon further inspection,
this is probably because there is a mismatch between the configuration
for the "shared" AWS environment (which points to the "nava-ffs" dev
account and will be used by GH Actions when [building and pushing the
image][2]) and the actual [configuration of the "shared" Terraform
backend][3] (which points to the production account).

This commit harmonizes these environments in a hope that it just works.
I can't test this, since it's Github Actions, so I'm going to rely on
merging and seeing how it goes after that.

I also removed "staging" config for now, since we don't intend to have a
staging environment right now. I've left it commented-out so we can
quickly retrieve it if we see the need for it later.

## Context for reviewers

No additional context.

## Testing

Merge and then test once it's on "main".

[1]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/10171383905/job/28134142130
[2]: https://github.com/DSACMS/iv-cbv-payroll/blob/82a4f2b2/.github/workflows/build-and-publish.yml#L45-L52
[3]: https://github.com/DSACMS/iv-cbv-payroll/blob/82a4f2b2/infra/app/build-repository/shared.s3.tfbackend
