### PR TITLE
Re-enable ci-docs action

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,12 +1,11 @@
 name: CI Documentation Checks
 
-# TODO: Re-enable me!
-on: []
-  # push:
-  #   branches: [ main ]
-  #   paths: ['app/**']
-  # pull_request:
-  #   paths: ['app/**']
+on:
+  push:
+    branches: [ main ]
+    paths: ['app/**']
+  pull_request:
+    paths: ['app/**']
 
 jobs:
   lint-markdown:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,11 +164,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
+<!-- markdown-link-check-disable -->
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
+<!-- markdown-link-check-enable -->
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ We know that we can learn from a wide variety of communities, including those wh
 We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets. 
 
 ## Community Guidelines
-See [COMMUNITY_GUIDELINES.md](./docs/COMMUNITY_GUIDELINES.md).
+See [COMMUNITY_GUIDELINES.md](./COMMUNITY_GUIDELINES.md).
 
 ## Governance
 
@@ -224,7 +224,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ TBD
 The system's Content-Security-Policy header prevents `<script>` and `<style>` tags from working without further
 configuration. Use `<%= javascript_tag nonce: true %>` for inline javascript.
 
-See the [CSP compliant script tag helpers](./app/doc/adr/0004-rails-csp-compliant-script-tag-helpers.md) ADR for
-more information on setting these up successfully.
-
 # Internationalization
 
 ## Managing locale files
@@ -224,7 +221,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/README.md
+++ b/README.md
@@ -219,11 +219,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
+<!-- markdown-link-check-disable -->
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
+<!-- markdown-link-check-enable -->
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The Centers for Medicare & Medicaid Services is committed to ensuring the securi
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,13 @@
 
 The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
 
+<!-- markdown-link-check-disable -->
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/en-us).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
+<!-- markdown-link-check-enable -->
 
 Review the HHS Disclosure Policy and websites in scope:
 [https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The Centers for Medicare & Medicaid Services is committed to ensuring the securi
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
-[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com/hc/).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 

--- a/app/app/helpers/uswds_form_builder.rb
+++ b/app/app/helpers/uswds_form_builder.rb
@@ -14,7 +14,6 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     self.options[:html][:class] ||= "usa-form usa-form--large"
   end
 
-  
   ########################################
   # Override standard helpers
   ########################################

--- a/app/app/helpers/uswds_form_builder.rb
+++ b/app/app/helpers/uswds_form_builder.rb
@@ -14,6 +14,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     self.options[:html][:class] ||= "usa-form usa-form--large"
   end
 
+  
   ########################################
   # Override standard helpers
   ########################################

--- a/docs/app/runbooks/deploy-failures.md
+++ b/docs/app/runbooks/deploy-failures.md
@@ -29,7 +29,9 @@ If you're not sure what version of code is currently deployed, follow these step
 
 This action sometimes fails when the Docker rate limit has been reached:
 
+<!-- markdown-link-check-disable -->
 > ERROR: failed to solve: registry.docker.com/library/ruby:3.3.0-slim: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry.docker.com/v2/library/ruby/manifests/sha256:{commit sha}: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
+<!-- markdown-link-check-enable -->
 
 Docker is likely rate limiting pulling of the Ruby image. This limit resets every 6 hours. Still, Github uses multiple IPs to make egress calls. **Simply redeploying the workflow usually works.** [Further discussion](https://nava.slack.com/archives/C06FC5TPAR3/p1719865408255839?thread_ts=1719862944.272089&cid=C06FC5TPAR3).
 

--- a/docs/infra/https-support.md
+++ b/docs/infra/https-support.md
@@ -7,7 +7,7 @@ Production systems will want to use HTTPS rather than HTTP to prevent man-in-the
 
 ## Requirements
 
-In order to set up HTTPS support you'll also need to have [set up custom domains](/app/docs/infra/set-up-custom-domains.md). This is because SSL/TLS certificates must be properly configured for the specific domain to support establishing secure connections.
+In order to set up HTTPS support you'll also need to have [set up custom domains](/docs/infra/set-up-custom-domains.md). This is because SSL/TLS certificates must be properly configured for the specific domain to support establishing secure connections.
 
 ## 1. Set desired certificates in domain configuration
 

--- a/docs/infra/module-architecture.md
+++ b/docs/infra/module-architecture.md
@@ -11,8 +11,6 @@ The infrastructure code is organized into:
 
 [Root modules](https://www.terraform.io/language/modules#the-root-module) are modules that are deployed separately from each other, whereas child modules are reusable modules that are called from root modules. To deploy all the resources necessary for a given environment, all the root modules must be deployed independently in the correct order.
 
-For a full list of rationale and factors, see [ADR: Separate app infrastructure into layers](/app/docs/decisions/infra/0009-separate-app-infrastructure-into-layers.md).
-
 ## Module calling structure
 
 The following diagram describes the relationship between modules and their child modules. Arrows go from the caller module to the child module.

--- a/infra/README.md
+++ b/infra/README.md
@@ -23,7 +23,7 @@ Each application directory contains the following:
   service/            [Root module] Configuration for containers, such as load balancer, application service (different config for different environments)
 ```
 
-Details about terraform root modules and child modules are documented in [module-architecture](/app/docs/infra/module-architecture.md).
+Details about terraform root modules and child modules are documented in [module-architecture](/docs/infra/module-architecture.md).
 
 ## 🏗️ Project architecture
 
@@ -51,7 +51,7 @@ The environments share the same root modules but will have different configurati
 
 This project relies on Make targets in the [root Makefile](/Makefile), which in turn call shell scripts in [./bin](/bin). The shell scripts call `terraform` commands. Many of the shell scripts are also called by the [Github Actions CI/CD](/.github/workflows).
 
-Generally, you should use the Make targets or the underlying bin scripts, but you can call the ,nderlying terraform commands if needed. See [making-infra-changes](/app/docs/infra/making-infra-changes.md) for more details.
+Generally, you should use the Make targets or the underlying bin scripts, but you can call the ,nderlying terraform commands if needed. See [making-infra-changes](/docs/infra/making-infra-changes.md) for more details.
 
 ## 💻 Development
 
@@ -63,24 +63,24 @@ To set up this project for the first time (i.e., it has never been deployed to t
 
 1. [Install this template](/README.md#installation) into an application that meets the [Application Requirements](/README.md#application-requirements)
 2. [Configure the project](/infra/project-config/main.tf) (These values will be used in subsequent infra setup steps to namespace resources and add infrastructure tags.)
-3. [Set up infrastructure developer tools](/app/docs/infra/set-up-infrastructure-tools.md)
-4. [Set up AWS account](/app/docs/infra/set-up-aws-account.md)
-5. [Set up the virtual network (VPC)](/app/docs/infra/set-up-network.md)
+3. [Set up infrastructure developer tools](/docs/infra/set-up-infrastructure-tools.md)
+4. [Set up AWS account](/docs/infra/set-up-aws-account.md)
+5. [Set up the virtual network (VPC)](/docs/infra/set-up-network.md)
 6. For each application:
-    1. [Set up application build repository](/app/docs/infra/set-up-app-build-repository.md)
-    2. [Set up application database](/app/docs/infra/set-up-database.md)
-    3. [Set up application environment](/app/docs/infra/set-up-app-env.md)
-    4. [Configure environment variables and secrets](/app/docs/infra/environment-variables-and-secrets.md)
-    5. [Set up background jobs](/app/docs/infra/background-jobs.md)
+    1. [Set up application build repository](/docs/infra/set-up-app-build-repository.md)
+    2. [Set up application database](/docs/infra/set-up-database.md)
+    3. [Set up application environment](/docs/infra/set-up-app-env.md)
+    4. [Configure environment variables and secrets](/docs/infra/environment-variables-and-secrets.md)
+    5. [Set up background jobs](/docs/infra/background-jobs.md)
 
 ### 🆕 New developer
 
 To get set up as a new developer on a project that has already been deployed to the target AWS account:
 
-1. [Set up infrastructure developer tools](/app/docs/infra/set-up-infrastructure-tools.md)
-2. [Review how to make changes to infrastructure](/app/docs/infra/making-infra-changes.md)
-3. (Optional) Set up a [terraform workspace](/app/docs/infra/intro-to-terraform-workspaces.md)
+1. [Set up infrastructure developer tools](/docs/infra/set-up-infrastructure-tools.md)
+2. [Review how to make changes to infrastructure](/docs/infra/making-infra-changes.md)
+3. (Optional) Set up a [terraform workspace](/docs/infra/intro-to-terraform-workspaces.md)
 
 ## 📇 Additional reading
 
-Additional documentation can be found in the [documentation directory](/app/docs/infra).
+Additional documentation can be found in the [documentation directory](/docs/infra).


### PR DESCRIPTION
## Ticket

No ticket that I am aware of.

## Changes

* Re-enable ci-docs job

## Context for reviewers

* Here is it working: https://github.com/joeyg/iv-cbv-payroll/actions/runs/10173505564/job/28137733681?pr=3
* Looks like this was disabled [here](https://github.com/DSACMS/iv-cbv-payroll/commit/722642696bd7fcdead980b558f2b889fd560d57b).
* The links to https://hhs.responsibledisclosure.com/ result in a 403 when the tool runs so I have disabled the check for those links since they do work.

## Testing

Running on PR
