### PR TITLE
Only return HTML pages if a request has an HTML extension

### DIFF
--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   if Rails.env.development?
     mount Sidekiq::Web => "/sidekiq"
   end
-  scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+  scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/, format: "html"  do
     # Your application routes go here
     root "pages#home"
 


### PR DESCRIPTION
## Ticket

NA

## Changes

Currently any page route will return a page even if provided a file extension. This has the effect of allowing any random file string to return a page, which fails security tests and could allow someone to provide a link to a working page that has profanities or other embarrassing strings.

This fixes that by only accepting HTML for HTML pages.
