### PR TITLE
Fix demo deploys by pulling image from correct account_id

### DIFF
--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -1,11 +1,14 @@
+data "external" "account_ids_by_name" {
+  program = ["../../../bin/account-ids-by-name.sh"]
+}
+
 locals {
   # app_name is the name of the application, which by convention should match the name of
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments          = ["dev", "prod"]
-  project_name          = module.project_config.project_name
-  image_repository_name = "${local.project_name}-${local.app_name}"
+  environments = ["dev", "prod"]
+  project_name = module.project_config.project_name
 
   # Whether or not the application has a database
   # If enabled:
@@ -31,7 +34,9 @@ locals {
   }
 
   build_repository_config = {
-    region = module.project_config.default_region
+    name       = "${local.project_name}-${local.app_name}"
+    region     = module.project_config.default_region
+    account_id = data.external.account_ids_by_name.result[local.account_names_by_environment["shared"]]
   }
 
   # Map from environment name to the account name for the AWS account that
@@ -66,7 +71,7 @@ locals {
   account_names_by_environment = {
     dev = "nava-ffs"
     # staging = "nava-ffs"
-    shared = "nava-ffs-prod" # ECS Container Registry lives here
+    shared = "nava-ffs-prod"
     prod   = "nava-ffs-prod"
   }
 }

--- a/infra/app/app-config/outputs.tf
+++ b/infra/app/app-config/outputs.tf
@@ -26,10 +26,6 @@ output "has_incident_management_service" {
   value = local.has_incident_management_service
 }
 
-output "image_repository_name" {
-  value = local.image_repository_name
-}
-
 output "build_repository_config" {
   value = local.build_repository_config
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -1,6 +1,5 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-
 data "aws_vpc" "network" {
   tags = {
     project      = module.project_config.project_name
@@ -136,8 +135,9 @@ module "service" {
   source       = "../../modules/service"
   service_name = local.service_config.service_name
 
-  image_repository_name = module.app_config.image_repository_name
-  image_tag             = local.image_tag
+  image_repository_name       = module.app_config.build_repository_config.name
+  image_repository_account_id = module.app_config.build_repository_config.account_id
+  image_tag                   = local.image_tag
 
   vpc_id             = data.aws_vpc.network.id
   public_subnet_ids  = data.aws_subnets.public.ids

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "task_executor" {
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer",
     ]
-    resources = [data.aws_ecr_repository.app.arn]
+    resources = ["arn:aws:ecr:${data.aws_region.current.name}:${var.image_repository_account_id}:repository/${var.image_repository_name}"]
   }
 
   dynamic "statement" {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -1,8 +1,5 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-data "aws_ecr_repository" "app" {
-  name = var.image_repository_name
-}
 
 locals {
   alb_name                = var.service_name
@@ -11,7 +8,7 @@ locals {
   log_group_name          = "service/${var.service_name}"
   log_stream_prefix       = var.service_name
   task_executor_role_name = "${var.service_name}-task-executor"
-  image_url               = "${data.aws_ecr_repository.app.repository_url}:${var.image_tag}"
+  image_url               = "${var.image_repository_account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${var.image_repository_name}:${var.image_tag}"
 
   base_environment_variables = [
     { name : "DOMAIN_NAME", value : tostring(var.domain_name) },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -29,6 +29,11 @@ variable "image_tag" {
   description = "The tag of the image to deploy"
 }
 
+variable "image_repository_account_id" {
+  type        = string
+  description = "The account ID that contains the container image repository"
+}
+
 variable "image_repository_name" {
   type        = string
   description = "The name of the container image repository"


### PR DESCRIPTION
## Ticket

N/A

## Changes

Deploys to our demo (dev) environment were broken because they were
trying to pull the built image from the wrong AWS account (dev instead
of prod). This is because the service module was using a
"data.aws_ecr_repository" module to load the repository by name, despite
the fact that the ECR repository was in another account.

The fix for this is to pass in the "image_repository_account_id" to the
service module. We determine the value when processing the app-config by
calling the bin/account-ids-by-name.sh script, and looking for the
account ID for the account that contains the "shared" environment.

This commit also updates the publish-release.sh script. Although this
script worked (as the Github Action properly ran it in the shared
environment), I thought it would be good to standardize how the image
repository values were accessed.

## Context for reviewers

* I'm not sure whether it's an anti-pattern to pass these values out of app-config (or if some other level of config makes more sense)
* I'm not sure whether it's an anti-pattern to call the bin/account-ids-by-name.sh script in app-config

## Testing

Tested by:
* Locally pushing an image -> it pushes to correct account ID
* Locally running `make release-run-database-migrations` in dev environment -> it pulls image from correct account
* Deleting & recreating the `nava-ffs-prod` account just to ensure that there's no circular dependency on the account ID existing
