### PR TITLE
Update Gemfile/.lock for rexml upgrade

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -61,8 +61,8 @@ gem "wicked_pdf"
 gem "actioncable-enhanced-postgresql-adapter"
 gem "aws-sdk-rails"
 
-# https://www.ruby-lang.org/en/news/2024/05/16/dos-rexml-cve-2024-35176/
-gem "rexml", "~> 3.3.2"
+# https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/
+gem "rexml", "~> 3.3.3"
 
 group :development, :test do
   gem "brakeman", "~> 5.2"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -473,7 +473,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-erd (~> 1.7)
   redis (~> 4.0)
-  rexml (~> 3.3.2)
+  rexml (~> 3.3.3)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails-omakase
@@ -494,4 +494,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.3.26
+   2.4.0


### PR DESCRIPTION
## Ticket

NA

## Changes

PRs are blocked because of a required [security upgrade to rexml](https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/). This updates that.

## Context for reviewers

To upgrade I ran, I updated the `Gemfile` and then ran:

```bash
docker compose exec app_rails bundle config set --local deployment false
docker compose exec app_rails bundle install
```

The first was necessary because I got an error `You are trying to install in deployment mode after changing your Gemfile.` when running bundle install. I did not see a documented way to upgrade gems, but figure doing it from within the container is the best way to do so since they will be running in that env.
