### PR TITLE
Allow custom Pinwheel config per-site

### DIFF
--- a/app/app/controllers/api/pinwheel_controller.rb
+++ b/app/app/controllers/api/pinwheel_controller.rb
@@ -2,7 +2,8 @@ class Api::PinwheelController < ApplicationController
   # run the token here with the included employer/payroll provider id
   def create_token
     cbv_flow = CbvFlow.find(session[:cbv_flow_id])
-    token_response = provider.create_link_token(
+    pinwheel = pinwheel_for(cbv_flow)
+    token_response = pinwheel.create_link_token(
       response_type: token_params[:response_type],
       id: token_params[:id],
       end_user_id: cbv_flow.pinwheel_end_user_id
@@ -13,10 +14,6 @@ class Api::PinwheelController < ApplicationController
   end
 
   private
-
-  def provider
-    PinwheelService.new
-  end
 
   def token_params
     params.require(:pinwheel).permit(:response_type, :id)

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -13,7 +13,8 @@ class ApplicationController < ActionController::Base
 
   def pinwheel_for(cbv_flow)
     api_key = site_config[cbv_flow.site_id].pinwheel_api_token
+    environment = site_config[cbv_flow.site_id].pinwheel_environment
 
-    PinwheelService.new(api_key)
+    PinwheelService.new(api_key, environment)
   end
 end

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -10,4 +10,10 @@ class ApplicationController < ActionController::Base
   def site_config
     Rails.application.config.sites
   end
+
+  def pinwheel_for(cbv_flow)
+    api_key = site_config[cbv_flow.site_id].pinwheel_api_token
+
+    PinwheelService.new(api_key)
+  end
 end

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -26,7 +26,7 @@ class Cbv::BaseController < ApplicationController
       end
     else
       # TODO: Restrict ability to enter the flow without a valid token
-      @cbv_flow = CbvFlow.create(site_id: "nyc")
+      @cbv_flow = CbvFlow.create(site_id: "sandbox")
     end
 
     session[:cbv_flow_id] = @cbv_flow.id
@@ -62,7 +62,7 @@ class Cbv::BaseController < ApplicationController
   end
 
   def pinwheel
-    PinwheelService.new
+    pinwheel_for(@cbv_flow)
   end
 
   def fetch_payroll

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -1,27 +1,27 @@
 class Webhooks::Pinwheel::EventsController < ApplicationController
+  DUMMY_API_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
   skip_before_action :verify_authenticity_token
 
   def create
     signature = request.headers["X-Pinwheel-Signature"]
     timestamp = request.headers["X-Timestamp"]
 
-    digest = provider.generate_signature_digest(timestamp, request.raw_post)
-
-    unless provider.verify_signature(signature, digest)
+    # To prevent timing attacks, we attempt to verify the webhook signature
+    # using a same-length DUMMY_API_KEY even if the `end_user_id` does not
+    # match a valid `cbv_flow`.
+    cbv_flow = CbvFlow.find_by_pinwheel_end_user_id(params["payload"]["end_user_id"])
+    pinwheel = cbv_flow.present? ? pinwheel_for(cbv_flow) : PinwheelService.new(DUMMY_API_KEY)
+    digest = pinwheel.generate_signature_digest(timestamp, request.raw_post)
+    unless pinwheel.verify_signature(signature, digest)
       return render json: { error: "Invalid signature" }, status: :unauthorized
     end
 
     if params["event"] == "paystubs.ninety_days_synced"
-      @cbv_flow = CbvFlow.find_by_pinwheel_end_user_id(params["payload"]["end_user_id"])
-
-      if @cbv_flow
-        @cbv_flow.update(payroll_data_available_from: params["payload"]["params"]["from_pay_date"])
-        PaystubsChannel.broadcast_to(@cbv_flow, params)
+      if cbv_flow
+        cbv_flow.update(payroll_data_available_from: params["payload"]["params"]["from_pay_date"])
+        PaystubsChannel.broadcast_to(cbv_flow, params)
       end
     end
-  end
-
-  def provider
-    PinwheelService.new
   end
 end

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -11,7 +11,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
     # using a same-length DUMMY_API_KEY even if the `end_user_id` does not
     # match a valid `cbv_flow`.
     cbv_flow = CbvFlow.find_by_pinwheel_end_user_id(params["payload"]["end_user_id"])
-    pinwheel = cbv_flow.present? ? pinwheel_for(cbv_flow) : PinwheelService.new(DUMMY_API_KEY)
+    pinwheel = cbv_flow.present? ? pinwheel_for(cbv_flow) : PinwheelService.new(DUMMY_API_KEY, "sandbox")
     digest = pinwheel.generate_signature_digest(timestamp, request.raw_post)
     unless pinwheel.verify_signature(signature, digest)
       return render json: { error: "Invalid signature" }, status: :unauthorized

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -3,18 +3,30 @@
 require "faraday"
 
 class PinwheelService
+  ENVIRONMENTS = {
+    sandbox: {
+      base_url: "https://sandbox.getpinwheel.com"
+    },
+    development: {
+      base_url: "https://development.getpinwheel.com"
+    },
+    production: {
+      base_url: "https://api.getpinwheel.com"
+    }
+  }
+
   PINWHEEL_VERSION = "2023-11-22"
-  BASE_URL = "https://sandbox.getpinwheel.com"
   ACCOUNTS_ENDPOINT = "/v1/accounts"
   USER_TOKENS_ENDPOINT = "/v1/link_tokens"
   ITEMS_ENDPOINT = "/v1/search"
   WEBHOOKS_ENDPOINT = "/v1/webhooks"
   END_USERS = "/v1/end_users"
 
-  def initialize(api_key)
+  def initialize(api_key, environment)
     raise "PinwheelService api_key is blank" if api_key.blank?
 
     @api_key = api_key
+    @environment = ENVIRONMENTS.fetch(environment.to_sym) { |env| raise KeyError.new("PinwheelService unknown environment: #{env}") }
 
     client_options = {
       request: {
@@ -24,7 +36,7 @@ class PinwheelService
         # be serialized as `?foo=1&foo=2&foo=3`:
         params_encoder: Faraday::FlatParamsEncoder
       },
-      url: BASE_URL,
+      url: @environment[:base_url],
       headers: {
         "Content-Type" => "application/json",
         "Pinwheel-Version" => PINWHEEL_VERSION,

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -11,8 +11,8 @@ class PinwheelService
   WEBHOOKS_ENDPOINT = "/v1/webhooks"
   END_USERS = "/v1/end_users"
 
-  def initialize(api_key = ENV["PINWHEEL_API_TOKEN"])
-    raise "PINWHEEL_API_TOKEN environment variable is blank. Make sure you have the .env.local.local from 1Password." if api_key.blank?
+  def initialize(api_key)
+    raise "PinwheelService api_key is blank" if api_key.blank?
 
     @api_key = api_key
 

--- a/app/app/services/pinwheel_webhook_manager.rb
+++ b/app/app/services/pinwheel_webhook_manager.rb
@@ -1,4 +1,11 @@
-# This class manages pinwheel webhook subscriptions, and is intended for development environment setup only
+# This class manages pinwheel webhook subscriptions, and is intended for
+# development environment setup only
+#
+# The webhooks will be registered in the Pinwheel environment listed under the
+# "sandbox" site in site-config.yml. Any sites in diffeent environments will
+# not work. (i.e. if the sandbox site is set to Pinwheel environment "sandbox",
+# then any sites with Pinwheel environment "development" will not have their
+# webhooks configured.)
 class PinwheelWebhookManager
   WEBHOOK_EVENTS = %w[
     account.added
@@ -7,7 +14,8 @@ class PinwheelWebhookManager
   ]
 
   def initialize
-    @pinwheel = PinwheelService.new
+    @sandbox_config = Rails.application.config.sites["sandbox"]
+    @pinwheel = PinwheelService.new(@sandbox_config.pinwheel_api_token)
   end
 
   def existing_subscriptions(name)

--- a/app/app/services/pinwheel_webhook_manager.rb
+++ b/app/app/services/pinwheel_webhook_manager.rb
@@ -15,7 +15,7 @@ class PinwheelWebhookManager
 
   def initialize
     @sandbox_config = Rails.application.config.sites["sandbox"]
-    @pinwheel = PinwheelService.new(@sandbox_config.pinwheel_api_token)
+    @pinwheel = PinwheelService.new(@sandbox_config.pinwheel_api_token, @sandbox_config.pinwheel_environment)
   end
 
   def existing_subscriptions(name)
@@ -38,12 +38,12 @@ class PinwheelWebhookManager
     end
 
     if existing_subscription
-      puts "  Existing Pinwheel webhook subscription found: #{existing_subscription["url"]}"
+      puts "  Existing Pinwheel webhook subscription found in Pinwheel #{@sandbox_config.pinwheel_environment}: #{existing_subscription["url"]}"
       remove_subscriptions(subscriptions.excluding(existing_subscription))
     else
       remove_subscriptions(subscriptions)
 
-      puts "  Registering Pinwheel webhooks for Ngrok tunnel..."
+      puts "  Registering Pinwheel webhooks for Ngrok tunnel in Pinwheel #{@sandbox_config.pinwheel_environment}..."
       response = @pinwheel.create_webhook_subscription(WEBHOOK_EVENTS, receiver_url)
       new_webhook_subscription_id = response["data"]["id"]
       puts "  ✅ Set up Pinwheel webhook: #{new_webhook_subscription_id}"

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -7,3 +7,8 @@
   agency_name: Massachusetts Department of Transitional Assistance
   transmission_method: null
   transmission_method_configuration: {}
+- id: sandbox
+  agency_name: CBV Test Agency
+  transmission_method: shared_email
+  transmission_method_configuration:
+    email: <%= ENV['SLACK_TEST_EMAIL'] %>

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -2,6 +2,7 @@
   agency_name: NYC Human Resources Administration
   pinwheel:
     api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
+    environment: sandbox
   transmission_method: shared_email
   transmission_method_configuration:
     email: <%= ENV['NYC_HRA_EMAIL'] %>
@@ -9,12 +10,14 @@
   agency_name: Massachusetts Department of Transitional Assistance
   pinwheel:
     api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
+    environment: sandbox
   transmission_method: null
   transmission_method_configuration: {}
 - id: sandbox
   agency_name: CBV Test Agency
   pinwheel:
     api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
+    environment: sandbox
   transmission_method: shared_email
   transmission_method_configuration:
     email: <%= ENV['SLACK_TEST_EMAIL'] %>

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -1,14 +1,20 @@
 - id: nyc
   agency_name: NYC Human Resources Administration
+  pinwheel:
+    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
   transmission_method: shared_email
   transmission_method_configuration:
     email: <%= ENV['NYC_HRA_EMAIL'] %>
 - id: ma
   agency_name: Massachusetts Department of Transitional Assistance
+  pinwheel:
+    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
   transmission_method: null
   transmission_method_configuration: {}
 - id: sandbox
   agency_name: CBV Test Agency
+  pinwheel:
+    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
   transmission_method: shared_email
   transmission_method_configuration:
     email: <%= ENV['SLACK_TEST_EMAIL'] %>

--- a/app/lib/site_config.rb
+++ b/app/lib/site_config.rb
@@ -18,11 +18,12 @@ class SiteConfig
   end
 
   class Site
-    attr_reader :id, :agency_name, :transmission_method, :transmission_method_configuration
+    attr_reader :id, :agency_name, :pinwheel_api_token, :transmission_method, :transmission_method_configuration
 
     def initialize(yaml)
       @id = yaml["id"]
       @agency_name = yaml["agency_name"]
+      @pinwheel_api_token = yaml["pinwheel"]["api_token"]
       @transmission_method = yaml["transmission_method"]
       @transmission_method_configuration = yaml["transmission_method_configuration"]
 

--- a/app/lib/site_config.rb
+++ b/app/lib/site_config.rb
@@ -18,17 +18,26 @@ class SiteConfig
   end
 
   class Site
-    attr_reader :id, :agency_name, :pinwheel_api_token, :transmission_method, :transmission_method_configuration
+    attr_reader(*%i[
+      id
+      agency_name
+      pinwheel_api_token
+      pinwheel_environment
+      transmission_method
+      transmission_method_configuration
+    ])
 
     def initialize(yaml)
       @id = yaml["id"]
       @agency_name = yaml["agency_name"]
       @pinwheel_api_token = yaml["pinwheel"]["api_token"]
+      @pinwheel_environment = yaml["pinwheel"]["environment"]
       @transmission_method = yaml["transmission_method"]
       @transmission_method_configuration = yaml["transmission_method_configuration"]
 
       raise ArgumentError.new("Site missing id") if @id.blank?
       raise ArgumentError.new("Site #{@id} missing required attribute `agency_name`") if @agency_name.blank?
+      raise ArgumentError.new("Site #{@id} missing required attribute `pinwheel.environment`") if @pinwheel_environment.blank?
       # TODO: Add a validation for the dependent attribute, transmission_method_configuration.email, if transmission_method is present
     end
   end

--- a/app/spec/lib/site_config_spec.rb
+++ b/app/spec/lib/site_config_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe SiteConfig do
   let(:sample_config) { <<~YAML }
     - id: foo
       agency_name: Foo Agency Name
+      pinwheel:
+        api_token: foo
+        environment: foo
     - id: bar
       agency_name: Bar Agency Name
+      pinwheel:
+        api_token: bar
+        environment: bar
   YAML
 
   before do

--- a/app/spec/services/pinwheel_service_spec.rb
+++ b/app/spec/services/pinwheel_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PinwheelService, type: :service do
   include PinwheelApiHelper
-  let(:service) { PinwheelService.new("FAKE_API_KEY") }
+  let(:service) { PinwheelService.new("FAKE_API_KEY", "sandbox") }
   let(:end_user_id) { 'abc123' }
 
   describe '#fetch_items' do
@@ -36,7 +36,7 @@ RSpec.describe PinwheelService, type: :service do
 
   describe "#verify_webhook_signature" do
     # https://docs.pinwheelapi.com/public/docs/webhook-signature-verification
-    let(:service) { PinwheelService.new("TEST_KEY") }
+    let(:service) { PinwheelService.new("TEST_KEY", "sandbox") }
     let(:raw_request_body) {
       load_relative_file('test_data_1_base.json')
     }


### PR DESCRIPTION
## Ticket

First part of FFS-1179

## Changes

- **Create "sandbox" site for internal testing**
- **Move Pinwheel API token into site-config.yml**
- **Allow specifying the Pinwheel environment per site**

## Context for reviewers

Context in commit messages.

Next steps in PRs after this is merged:
* Add environment variables for "development" Pinwheel credentials
* Update NYC and MA sites to use development Pinwheel credentials

## Testing

Tested by going through the flow locally.
