### PR TITLE
Change Pinwheel environment to "development" for NYC/MA

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -1,6 +1,6 @@
 NGROK_URL=
 CBV_INVITE_SECRET=development
 DOMAIN_NAME=localhost
-PINWHEEL_API_TOKEN=API secret
+PINWHEEL_API_TOKEN_SANDBOX=API secret
 SLACK_TEST_EMAIL=test@email.com
 NYC_HRA_EMAIL=test@email.com

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -1,22 +1,22 @@
 - id: nyc
   agency_name: NYC Human Resources Administration
   pinwheel:
-    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
-    environment: sandbox
+    api_token: <%= ENV['PINWHEEL_API_TOKEN_DEVELOPMENT'] %>
+    environment: development
   transmission_method: shared_email
   transmission_method_configuration:
     email: <%= ENV['NYC_HRA_EMAIL'] %>
 - id: ma
   agency_name: Massachusetts Department of Transitional Assistance
   pinwheel:
-    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
-    environment: sandbox
+    api_token: <%= ENV['PINWHEEL_API_TOKEN_DEVELOPMENT'] %>
+    environment: development
   transmission_method: null
   transmission_method_configuration: {}
 - id: sandbox
   agency_name: CBV Test Agency
   pinwheel:
-    api_token: <%= ENV['PINWHEEL_API_TOKEN'] %>
+    api_token: <%= ENV['PINWHEEL_API_TOKEN_SANDBOX'] %>
     environment: sandbox
   transmission_method: shared_email
   transmission_method_configuration:

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::PinwheelController do
   include PinwheelApiHelper
 
   context "#create_token" do
-    let(:cbv_flow) { CbvFlow.create(case_number: "TEST123", site_id: "nyc") }
+    let(:cbv_flow) { CbvFlow.create(case_number: "TEST123", site_id: "sandbox") }
     let(:valid_params) do
       {
         pinwheel: { response_type: "employer", id: "123" }

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cbv::EntriesController do
     end
 
     context "when following a link from a flow invitation" do
-      let(:invitation) { CbvFlowInvitation.create(case_number: "ABC1234", site_id: "nyc") }
+      let(:invitation) { CbvFlowInvitation.create(case_number: "ABC1234", site_id: "sandbox") }
 
       it "sets a CbvFlow object based on the invitation" do
         expect { get :show, params: { token: invitation.auth_token } }
@@ -34,7 +34,7 @@ RSpec.describe Cbv::EntriesController do
       end
 
       context "when returning to an already-visited flow invitation" do
-        let(:existing_cbv_flow) { CbvFlow.create(case_number: "ABC1234", cbv_flow_invitation: invitation, site_id: "nyc") }
+        let(:existing_cbv_flow) { CbvFlow.create(case_number: "ABC1234", cbv_flow_invitation: invitation, site_id: "sandbox") }
 
         it "uses the existing CbvFlow object" do
           expect { get :show, params: { token: invitation.auth_token } }
@@ -45,7 +45,7 @@ RSpec.describe Cbv::EntriesController do
       end
 
       context "when there is already a CbvFlow in the session" do
-        let(:other_cbv_flow) { CbvFlow.create(case_number: "ZZZ0000", site_id: "nyc") }
+        let(:other_cbv_flow) { CbvFlow.create(case_number: "ZZZ0000", site_id: "sandbox") }
 
         before do
           session[:cbv_flow_id] = other_cbv_flow.id

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Cbv::PaymentDetailsController do
   describe "#show" do
     render_views
 
-    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "nyc") }
+    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "sandbox") }
     let(:account_id) { SecureRandom.uuid }
     let(:comment) { "This is a test comment" }
 
@@ -82,7 +82,7 @@ RSpec.describe Cbv::PaymentDetailsController do
   end
 
   describe "#update" do
-    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "nyc") }
+    let!(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "sandbox") }
     let(:account_id) { SecureRandom.uuid }
     let(:comment) { "This is a test comment" }
 

--- a/app/spec/controllers/cbv/shares_controller_spec.rb
+++ b/app/spec/controllers/cbv/shares_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Cbv::SharesController do
   include PinwheelApiHelper
 
-  let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "nyc") }
+  let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "sandbox") }
 
   describe "#show" do
     render_views
@@ -26,12 +26,12 @@ RSpec.describe Cbv::SharesController do
         expect(cbv_flow.confirmation_code).to be_blank
         put :update
         expect(cbv_flow.reload.confirmation_code).not_to be_blank
-        expect(cbv_flow.reload.confirmation_code).to start_with("NYC")
+        expect(cbv_flow.reload.confirmation_code).to start_with("SANDBOX")
       end
     end
 
     context "when confirmation_code already exists" do
-      let(:existing_confirmation_code) { "NYC0000" }
+      let(:existing_confirmation_code) { "SANDBOX000" }
 
       before do
         cbv_flow.update(confirmation_code: existing_confirmation_code)

--- a/app/spec/controllers/cbv/successes_controller_spec.rb
+++ b/app/spec/controllers/cbv/successes_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Cbv::SuccessesController do
   describe "#show" do
-    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", site_id: "nyc", confirmation_code: "NYC12345") }
+    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", site_id: "sandbox", confirmation_code: "NYC12345") }
 
     before do
       session[:cbv_flow_id] = cbv_flow.id

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Cbv::SummariesController do
   describe "#show" do
     render_views
 
-    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "nyc") }
+    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "sandbox") }
 
     before do
       session[:cbv_flow_id] = cbv_flow.id

--- a/app/spec/controllers/cbv_flow_invitations_controller_spec.rb
+++ b/app/spec/controllers/cbv_flow_invitations_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CbvFlowInvitationsController do
   end
 
   describe "#new" do
-    let(:valid_params) { { site_id: "nyc", secret: invite_secret } }
+    let(:valid_params) { { site_id: "sandbox", secret: invite_secret } }
 
     context "without the invite secret" do
       it "redirects to the homepage" do

--- a/app/spec/models/cbv_flow_spec.rb
+++ b/app/spec/models/cbv_flow_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe CbvFlow, type: :model do
   describe ".create_from_invitation" do
-    let(:cbv_flow_invitation) { CbvFlowInvitation.create!(case_number: "ABC1234", site_id: "nyc") }
+    let(:cbv_flow_invitation) { CbvFlowInvitation.create!(case_number: "ABC1234", site_id: "sandbox") }
 
     it "copies over relevant fields" do
       cbv_flow = CbvFlow.create_from_invitation(cbv_flow_invitation)
-      expect(cbv_flow).to have_attributes(case_number: "ABC1234", site_id: "nyc")
+      expect(cbv_flow).to have_attributes(case_number: "ABC1234", site_id: "sandbox")
     end
   end
 end

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -30,8 +30,16 @@ locals {
       ssm_param_name = "/service/${var.app_name}-${var.environment}/rails-master-key"
     },
     {
-      name           = "PINWHEEL_API_TOKEN"
-      ssm_param_name = "/service/${var.app_name}-${var.environment}/pinwheel-api-token"
+      name           = "PINWHEEL_API_TOKEN_PRODUCTION"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/pinwheel-api-token-production"
+    },
+    {
+      name           = "PINWHEEL_API_TOKEN_DEVELOPMENT"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/pinwheel-api-token-development"
+    },
+    {
+      name           = "PINWHEEL_API_TOKEN_SANDBOX"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/pinwheel-api-token-sandbox"
     },
     {
       name           = "CBV_INVITE_SECRET"


### PR DESCRIPTION
## Ticket

Resolves FFS-1179.

## Changes

This will allow us to test with real data for NYC/MA. To continue
testing with sandbox data, the "sandbox" site is left using a Sandbox
API key.

Deployment steps:
1. Rename the PINWHEEL_API_TOKEN in demo/prod to
   PINWHEEL_API_TOKEN_SANDBOX. Generate a new API key for the
   "development" and "production" Pinwheel environments and store them
   in the respective env vars.
2. Deploy this.
3. Verify that the webhooks still work or set them back up again if they
   don't.
4. Done.
5. Document it.


## Context for reviewers

N/A

## Testing

We'll test once it's live.
