### PR TITLE
Fix healthchecks by not requiring SSL

### DIFF
--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -46,6 +46,11 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = {
+    redirect: {
+      exclude: ->(request) { %r{^/health}.match?(request.path) }
+    }
+  }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## Ticket

FFS-1212

## Changes

Healthchecks are failing after 7befe96 because they now try to redirect
to HTTPS. Since we can't configure the health checker to pass the
"X-Forwarded-Proto" header, let's just exempt this one path from the SSL
check.

## Context for reviewers

Fixes a configuration bug preventing the deploy of new code.

## Testing

I tested in development that the regex works as intended to exempt /health from
the SSL requirement.
