### PR TITLE
Permit PDF for summary view

### DIFF
--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
     scope "/cbv", as: :cbv_flow, module: :cbv do
       resource :entry, only: %i[show]
       resource :employer_search, only: %i[show]
-      resource :summary, only: %i[show update]
+      resource :summary, only: %i[show update], format: %i[html pdf]
       resource :share, only: %i[show update]
       resource :missing_results, only: %i[show]
       resource :success, only: %i[show]

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -18,5 +18,11 @@ RSpec.describe Cbv::SummariesController do
       get :show
       expect(response).to be_successful
     end
+
+    it "renders pdf properly" do
+      get :show, format: :pdf
+      expect(response).to be_successful
+      expect(response.header['Content-Type']).to include 'pdf'
+    end
   end
 end


### PR DESCRIPTION
## Changes

Permits PDF format for the PDF view.

## Context for reviewers

Adds a test for the pdf format, but it's a false positive because it doesn't integrate with the full routing system. 

## Testing

I arrived at the PDF page.