### PR TITLE
Enable NYC SSO callback

### DIFF
--- a/app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,11 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def nyc_dss
+    response_params = request.env["omniauth.auth"]["info"]
+    email = response_params["email"]
+
+    login_with_oauth(email, "nyc")
+  end
+
   def ma_dta
     response_params = request.env["omniauth.auth"]["info"]
     email = response_params["email"]

--- a/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,21 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Users::OmniauthCallbacksController do
-  describe "#ma_dta" do
-    let(:test_email) { "test@example.com" }
-    let(:valid_auth_info) do
-      {
-        "info" => {
-          "email" => test_email
-        }
+  let(:test_email) { "test@example.com" }
+  let(:valid_auth_info) do
+    {
+      "info" => {
+        "email" => test_email
       }
-    end
+    }
+  end
 
-    before do
-      request.env["devise.mapping"] = Devise.mappings[:user]
-      request.env["omniauth.auth"] = valid_auth_info
-    end
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    request.env["omniauth.auth"] = valid_auth_info
+  end
 
+  describe "#ma_dta" do
     it "creates a User object and logs in as them" do
       expect { post :ma_dta }
         .to change(User, :count)
@@ -56,6 +56,30 @@ RSpec.describe Users::OmniauthCallbacksController do
         )
         expect(controller.current_user).to eq(new_user)
       end
+    end
+  end
+
+  describe "#nyc_dss" do
+    let(:test_email) { "test@example.com" }
+    let(:valid_auth_info) do
+      {
+        "info" => {
+          "email" => test_email
+        }
+      }
+    end
+
+    it "creates a User in the correct site and logs them in" do
+      expect { post :nyc_dss }
+        .to change(User, :count)
+        .by(1)
+
+      new_user = User.last
+      expect(new_user).to have_attributes(
+        email: test_email,
+        site_id: "nyc"
+      )
+      expect(controller.current_user).to eq(new_user)
     end
   end
 end


### PR DESCRIPTION
## Ticket

N/A - Prioritized for family-and-friends testing.

## Changes

Although we don't know what data we will get from the NYC callback,
let's add the handler for it here.

We will also have to add the URL to the list of Redirect URIs for our
"StagingIDP" Azure AD app.

## Context for reviewers

N/A

## Testing

Unable to test this locally due to being temporarily locked out of my Microsoft account.
