### PR TITLE
Remove analytics.usa.gov tracking

### DIFF
--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -10,11 +10,6 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-
-    <% if Rails.env.production? %>
-      <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-      <%= javascript_include_tag "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA", async: true, id: "_fed_an_ua_tag" %>
-    <% end %>
   </head>
 
   <body>


### PR DESCRIPTION

## Ticket

N/A - Prioritized because it is a warning currently occurring in the JS console of the site.

## Changes

This came over by default with the template repo. We don't need it since
we're not intending to use it for metrics.

## Context for reviewers

N/A

## Testing

N/A

