### PR TITLE
Update production domain to snap-income-pilot.com

### DIFF
--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -1,5 +1,5 @@
 data "external" "account_ids_by_name" {
-  program = ["../../../bin/account-ids-by-name.sh"]
+  program = ["${path.module}/../../../bin/account-ids-by-name.sh"]
 }
 
 locals {

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -5,7 +5,7 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   network_name                    = "prod"
-  domain_name                     = "verify-prod.navapbc.cloud"
+  domain_name                     = "snap-income-pilot.com"
   enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -45,10 +45,10 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "verify-prod.navapbc.cloud" # TODO: Replace this with our production product name
+        hosted_zone = "snap-income-pilot.com"
 
         certificate_configs = {
-          "verify-prod.navapbc.cloud" = {
+          "snap-income-pilot.com" = {
             source = "issued"
           }
         }


### PR DESCRIPTION

## Ticket

Resolves FFS-1219.

## Changes

It's really this easy! I just had to run the `make` commands to update
the network and the service, after deleting the duplicate Route53 zone
that was automatically created after registering the domain.

(Also fixed a bug in accessing the `account-ids-by-name` script that was
preventing it from being run in the `make infra-update-network` target.)

## Context for reviewers


## Testing

https://snap-income-pilot.com
