### PR TITLE
Expire CBV invitations after 14 days or completion

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -1,6 +1,6 @@
 class Cbv::BaseController < ApplicationController
   include Cbv::PaymentsHelper
-  before_action :set_cbv_flow
+  before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete
   helper_method :agency_url, :next_path, :get_comment_by_account_id, :current_site
 
   private
@@ -27,12 +27,21 @@ class Cbv::BaseController < ApplicationController
       rescue ActiveRecord::RecordNotFound
         return redirect_to root_url
       end
-    else
+    elsif params[:controller] == "cbv/entries"
       # TODO: Restrict ability to enter the flow without a valid token
       @cbv_flow = CbvFlow.create(site_id: "sandbox")
+    else
+      return redirect_to root_url, notice: t("cbv.error_missing_token")
     end
 
     session[:cbv_flow_id] = @cbv_flow.id
+  end
+
+  def ensure_cbv_flow_not_yet_complete
+    return unless @cbv_flow && @cbv_flow.complete?
+
+    session[:cbv_flow_id] = nil
+    redirect_to(cbv_flow_expired_invitation_path)
   end
 
   def current_site

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -11,6 +11,9 @@ class Cbv::BaseController < ApplicationController
       if invitation.blank?
         return redirect_to(root_url, flash: { alert: t("cbv.error_invalid_token") })
       end
+      if invitation.expired?
+        return redirect_to(cbv_flow_expired_invitation_path)
+      end
 
       @cbv_flow = invitation.cbv_flow || CbvFlow.create_from_invitation(invitation)
       NewRelicEventTracker.track("ClickedCBVInvitationLink", {

--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -1,5 +1,5 @@
 class Cbv::ExpiredInvitationsController < Cbv::BaseController
-  skip_before_action :set_cbv_flow
+  skip_before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete
 
   def show
   end

--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -1,0 +1,6 @@
+class Cbv::ExpiredInvitationsController < Cbv::BaseController
+  skip_before_action :set_cbv_flow
+
+  def show
+  end
+end

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -1,4 +1,6 @@
 class Cbv::SuccessesController < Cbv::BaseController
+  skip_before_action :ensure_cbv_flow_not_yet_complete
+
   def show
   end
 end

--- a/app/app/models/cbv_flow.rb
+++ b/app/app/models/cbv_flow.rb
@@ -3,6 +3,10 @@ class CbvFlow < ApplicationRecord
   belongs_to :cbv_flow_invitation, optional: true
   validates :site_id, inclusion: Rails.application.config.sites.site_ids
 
+  def complete?
+    confirmation_code.present?
+  end
+
   def self.create_from_invitation(cbv_flow_invitation)
     create(
       cbv_flow_invitation: cbv_flow_invitation,

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -4,6 +4,12 @@ class CbvFlowInvitation < ApplicationRecord
 
   has_one :cbv_flow
 
+  VALID_FOR = 14.days
+
+  def expired?
+    created_at < VALID_FOR.ago
+  end
+
   def to_url
     Rails.application.routes.url_helpers.cbv_flow_entry_url(token: auth_token)
   end

--- a/app/app/views/cbv/add_jobs/show.html.erb
+++ b/app/app/views/cbv/add_jobs/show.html.erb
@@ -24,7 +24,7 @@
     <%= link_to(current_site.learn_more_link_text, current_site.learn_more_link_url) %>
   </div>
 
-  <%= form_with(url: cbv_flow_add_job_path, builder: UswdsFormBuilder, data: { "add-job-target": "addJobForm" }, id: "add_job_form") do |f| %>
+  <%= form_with(url: cbv_flow_add_job_path, builder: UswdsFormBuilder, data: { "add-job-target": "addJobForm", turbo: "false" }, id: "add_job_form") do |f| %>
     <%= f.radio_button(:additional_jobs, true, { label: t(".yes_radio") }) %>
     <%= f.radio_button(:additional_jobs, false, { label: t(".no_radio") }) %>
     <div class="margin-top-5">

--- a/app/app/views/cbv/expired_invitations/show.html.erb
+++ b/app/app/views/cbv/expired_invitations/show.html.erb
@@ -1,0 +1,5 @@
+<h2>Your invitation to verify income has expired</h2>
+
+<p>You have either completed your verification process or accessed this invitation after too long.</p>
+
+<p>Please contact your caseworker for further instructions.</p>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
         your_employers_name: Your employer's name or the name of their payroll provider
         your_login_credentials: Your login credentials for the payroll provider account
     error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
+    error_missing_token: This page must be accessed by using an invitation link. Make sure you are clicking through the link you received in your email. If you continue experiencing issues, contact your caseworker.
     manual_flow_start: Start Flow Manually
     missing_results:
       show:

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       resource :agreement, only: %i[show create]
       resource :add_job, only: %i[show create]
       resource :payment_details, only: %i[show update]
+      resource :expired_invitation, only: %i[show]
 
       # Utility route to clear your session; useful during development
       resource :reset, only: %i[show]

--- a/app/spec/controllers/cbv/add_jobs_controller_spec.rb
+++ b/app/spec/controllers/cbv/add_jobs_controller_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Cbv::AddJobsController do
+  let(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", site_id: "sandbox") }
+
+  before do
+    session[:cbv_flow_id] = cbv_flow.id
+  end
+
   describe "#show" do
     render_views
 

--- a/app/spec/controllers/cbv/agreements_controller_spec.rb
+++ b/app/spec/controllers/cbv/agreements_controller_spec.rb
@@ -2,6 +2,13 @@ require "rails_helper"
 
 RSpec.describe Cbv::AgreementsController do
   render_views
+
+  let(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", site_id: "sandbox") }
+
+  before do
+    session[:cbv_flow_id] = cbv_flow.id
+  end
+
   it "renders properly" do
     get :show
 

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Cbv::EmployerSearchesController do
   describe "#show" do
-    let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234") }
+    let(:cbv_flow) { CbvFlow.create!(case_number: "ABC1234", site_id: "sandbox") }
 
     let(:pinwheel_token_id) { "abc-def-ghi" }
 

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe Cbv::EntriesController do
                   .from(nil)
                   .to(existing_cbv_flow.id)
         end
+
+        context "when the CbvFlow was already completed" do
+          before do
+            existing_cbv_flow.update(confirmation_code: "FOOBAR")
+          end
+
+          it "redirects to the expired invitation URL" do
+            expect { get :show, params: { token: invitation.auth_token } }
+              .not_to change { session[:cbv_flow_id] }
+
+            expect(response).to redirect_to(cbv_flow_expired_invitation_path)
+          end
+        end
       end
 
       context "when there is already a CbvFlow in the session" do

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -67,6 +67,19 @@ RSpec.describe Cbv::EntriesController do
           expect(response).to redirect_to(root_url)
         end
       end
+
+      context "when the invitation is expired" do
+        before do
+          invitation.update(created_at: CbvFlowInvitation::VALID_FOR.ago - 1.minute)
+        end
+
+        it "redirects to the expired invitations page" do
+          expect { get :show, params: { token: invitation.auth_token } }
+            .not_to change { session[:cbv_flow_id] }
+
+          expect(response).to redirect_to(cbv_flow_expired_invitation_path)
+        end
+      end
     end
 
     context "when the session points to a deleted cbv flow" do

--- a/app/spec/controllers/cbv/shares_controller_spec.rb
+++ b/app/spec/controllers/cbv/shares_controller_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Cbv::SharesController do
   describe "#show" do
     render_views
 
+    before do
+      session[:cbv_flow_id] = cbv_flow.id
+    end
+
     it "renders" do
       get :show
       expect(response).to be_successful


### PR DESCRIPTION
## Ticket

Resolves FFS-1200.

## Changes

- **Add `/cbv/expired_invitation` path for too-old tokens**
- **Redirect to /cbv/expired_invitations after CBV flow is complete**

## Context for reviewers

See commit messages for context/descriptions.

## Testing

Tested that the expired invitation page displays in the following situations:
1. Following an invitation link that has had its `created_at` backdated to 15 days ago
2. Following an invitation link for a CBV flow I've already completed

Tested that we redirect to the homepage with an error message in the following situations:
1. Clicking "Back" on the confirmation page
2. Going to a page within the CBV flow after CBV flow has been previously completed
3. Going to a page within the CBV flow with no session at all

Tested that the following still works:
1. The flow as usual
2. CBV sandbox quickstart button on homepage
