### PR TITLE
Update invitation expiry to be a configurable number of days

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -77,6 +77,7 @@ group :development, :test do
   gem "rubocop-rspec"
   gem "rubocop-rails-omakase"
   gem "standard", "~> 1.7"
+  gem "timecop"
   gem "wkhtmltopdf-binary"
 end
 

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -452,6 +452,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
+    timecop (0.9.10)
     timeout (0.4.1)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
@@ -530,6 +531,7 @@ DEPENDENCIES
   sprockets-rails
   standard (~> 1.7)
   stimulus-rails
+  timecop
   turbo-rails
   tzinfo-data
   web-console

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -2,12 +2,21 @@ class CbvFlowInvitation < ApplicationRecord
   has_secure_token :auth_token, length: 36
   validates :site_id, inclusion: Rails.application.config.sites.site_ids
 
+  INVITATION_VALIDITY_TIME_ZONE = "America/New_York"
+
   has_one :cbv_flow
 
-  VALID_FOR = 14.days
+  # Invitations are valid until 11:59pm Eastern Time on the (e.g.) 14th day
+  # after sending the invitation.
+  def expires_at
+    end_of_day_sent = created_at.in_time_zone(INVITATION_VALIDITY_TIME_ZONE).end_of_day
+    days_valid_for = Rails.application.config.sites[site_id].invitation_valid_days
+
+    end_of_day_sent + days_valid_for.days
+  end
 
   def expired?
-    created_at < VALID_FOR.ago
+    Time.now.after?(expires_at)
   end
 
   def to_url

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -15,6 +15,7 @@
     scope: "openid"
     name: "nyc_dss"
   pay_income_days: 90
+  invitation_valid_days: 14
   learn_more_link_text: Learn more on nyc.gov
   learn_more_link_url: https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page
 - id: ma
@@ -33,6 +34,7 @@
     scope: "openid"
     name: "ma_dta"
   pay_income_days: 90
+  invitation_valid_days: 21
   learn_more_link_text: Learn more at Mass.gov
   learn_more_link_url: https://www.mass.gov/guides/how-to-contact-dta
 - id: sandbox
@@ -52,5 +54,6 @@
     scope: "openid"
     name: "sandbox"
   pay_income_days: 90
+  invitation_valid_days: 14
   learn_more_link_text: Learn more at CBV Test Agency
   learn_more_link_url: https://www.mass.gov/guides/how-to-contact-dta

--- a/app/lib/site_config.rb
+++ b/app/lib/site_config.rb
@@ -23,26 +23,28 @@ class SiteConfig
       agency_name
       agency_short_name
       agency_help_link
+      invitation_valid_days
       learn_more_link_text
       learn_more_link_url
       pay_income_days
       pinwheel_api_token
       pinwheel_environment
+      sso
       transmission_method
       transmission_method_configuration
-      sso
     ])
 
     def initialize(yaml)
       @id = yaml["id"]
+      @agency_help_link = yaml["agency_help_link"]
       @agency_name = yaml["agency_name"]
       @agency_short_name = yaml["agency_short_name"]
-      @agency_help_link = yaml["agency_help_link"]
-      @pinwheel_api_token = yaml["pinwheel"]["api_token"]
-      @pinwheel_environment = yaml["pinwheel"]["environment"]
-      @pay_income_days = yaml["pay_income_days"]
+      @invitation_valid_days = yaml["invitation_valid_days"]
       @learn_more_link_text = yaml["learn_more_link_text"]
       @learn_more_link_url = yaml["learn_more_link_url"]
+      @pay_income_days = yaml["pay_income_days"]
+      @pinwheel_api_token = yaml["pinwheel"]["api_token"]
+      @pinwheel_environment = yaml["pinwheel"]["environment"]
       @transmission_method = yaml["transmission_method"]
       @transmission_method_configuration = yaml["transmission_method_configuration"]
       @sso = yaml["sso"]

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe Cbv::EntriesController do
 
       context "when the invitation is expired" do
         before do
-          invitation.update(created_at: CbvFlowInvitation::VALID_FOR.ago - 1.minute)
+          allow_any_instance_of(CbvFlowInvitation)
+            .to receive(:expired?)
+            .and_return(true)
         end
 
         it "redirects to the expired invitations page" do

--- a/app/spec/models/cbv_flow_invitation_spec.rb
+++ b/app/spec/models/cbv_flow_invitation_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe CbvFlowInvitation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#expired?" do
+    let(:site_id) { "sandbox" }
+    let(:invitation_valid_days) { 14 }
+    let(:invitation) do
+      CbvFlowInvitation.create!(
+        email_address: "foo@example.com",
+        site_id: site_id,
+        created_at: invitation_sent_at
+      )
+    end
+    let(:now) { Time.now }
+
+    before do
+      allow(Rails.application.config.sites[site_id])
+        .to receive(:invitation_valid_days)
+        .and_return(invitation_valid_days)
+    end
+
+    around do |ex|
+      Timecop.freeze(now, &ex)
+    end
+
+    subject { invitation.expired? }
+
+    context "within the validity window" do
+      let(:invitation_sent_at) { Time.new(2024, 8,  1, 12, 0, 0, "-04:00") }
+      let(:now)                { Time.new(2024, 8, 14, 12, 0, 0, "-04:00") }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "before 11:59pm ET on the 14th day after the invitation was sent" do
+      let(:invitation_sent_at) { Time.new(2024, 8,  1, 12, 0, 0, "-04:00") }
+      let(:now)                { Time.new(2024, 8, 15, 23, 0, 0, "-04:00") }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "after 11:59pm ET on the day of the validity window" do
+      let(:invitation_sent_at) { Time.new(2024, 8,  1, 12, 0, 0, "-04:00") }
+      let(:now)                { Time.new(2024, 8, 16,  0, 1, 0, "-04:00") }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#expires_at" do
+    let(:site_id) { "sandbox" }
+    let(:invitation_valid_days) { 14 }
+    let(:invitation) do
+      CbvFlowInvitation.create!(
+        email_address: "foo@example.com",
+        site_id: site_id,
+        created_at: invitation_sent_at
+      )
+    end
+    let(:invitation_sent_at) { Time.new(2024, 8,  1, 12, 0, 0, "-04:00") }
+
+    before do
+      allow(Rails.application.config.sites[site_id])
+        .to receive(:invitation_valid_days)
+        .and_return(invitation_valid_days)
+    end
+
+    it "returns the end of the day the 14th day after the invitation was sent" do
+      expect(invitation.expires_at).to have_attributes(
+        hour: 23,
+        min: 59,
+        sec: 59,
+        month: 8,
+        day: 15,
+        utc_offset: -14400
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

Resolves FFS-1200.

## Changes

* Change the expiry logic to allow for usage until 11:59pm Eastern on
  the 14th day after the invitation has been sent
* Allow configuring the number of days per site
* Write tests to hopefully verify this (using the `timecop` library to
  stub out the current time)

## Context for reviewers

N/A

## Testing

Tested locally to ensure the expiration logic generally worked. I didn't test setting my time zone to Eastern but I think that part will work.
