### PR TITLE
Add support to infra template for cron jobs

### DIFF
--- a/infra/app/app-config/env-config/jobs.tf
+++ b/infra/app/app-config/env-config/jobs.tf
@@ -11,4 +11,18 @@ locals {
     #   task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]
     # }
   }
+
+  # Configuration for cron jobs to run in every environment.
+
+  # The `schedule_expression` supports cron format (min, hour, day_of_month,
+  # month, day_of_week, year) and runs in the `America/New_York` time zone.
+  #
+  # See description of `cron_jobs` variable in the service module (infra/modules/service/variables.tf)
+  cron_jobs = {
+    # TODO: Uncomment when https://github.com/DSACMS/iv-cbv-payroll/pull/155 is merged.
+    # redact_data = {
+    #   schedule_expression = "cron(0 * * * ? *)"
+    #   task_command        = ["bin/rails", "data_deletion:redact_all"]
+    # }
+  }
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -37,6 +37,7 @@ output "service_config" {
       # For job configs that don't define a source_bucket, add the source_bucket config property
       job_name => merge({ source_bucket = local.bucket_name }, job_config)
     }
+    cron_jobs = local.cron_jobs
   }
 }
 

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -155,6 +155,7 @@ module "service" {
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 
   file_upload_jobs = local.service_config.file_upload_jobs
+  cron_jobs        = local.service_config.cron_jobs
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/task-scheduler-role.tf
+++ b/infra/modules/service/task-scheduler-role.tf
@@ -12,6 +12,13 @@ resource "aws_iam_role" "events" {
   assume_role_policy  = data.aws_iam_policy_document.events_assume_role.json
 }
 
+# The role allows EventBridge Scheduler to run tasks on the ECS cluster
+resource "aws_iam_role" "cron" {
+  name                = "${local.cluster_name}-cron"
+  managed_policy_arns = [aws_iam_policy.run_task.arn]
+  assume_role_policy  = data.aws_iam_policy_document.cron_assume_role.json
+}
+
 data "aws_iam_policy_document" "events_assume_role" {
   statement {
     effect  = "Allow"
@@ -19,6 +26,17 @@ data "aws_iam_policy_document" "events_assume_role" {
     principals {
       type        = "Service"
       identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cron_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
     }
   }
 }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -156,6 +156,30 @@ variable "file_upload_jobs" {
   default     = {}
 }
 
+variable "cron_jobs" {
+  type = map(object({
+    schedule_expression = string
+    task_command        = list(string)
+  }))
+  description = <<EOT
+    Configurations for jobs that trigger on recurring interval (cron-like).
+
+    Each configuration is a map from the job name to an object defining the
+    event's schedule and command.
+
+    For schedule_expression documentation, see:
+      https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#cron-based
+    Some examples are:
+      cron(0 * * * ? *)              # Run every hour on the hour (the 0th minute)
+      cron(*/15 9-17 * * ? *)        # Run every 15 minutes between 9 a.m. and 5 p.m. (Eastern Time)
+
+    The task command is a string-array of command-line arguments, for example:
+
+      ["bin/calculate-widgets", "--target", "widget-factory"]
+  EOT
+  default     = {}
+}
+
 variable "is_temporary" {
   description = "Whether the service is meant to be spun up temporarily (e.g. for automated infra tests). This is used to disable deletion protection for the load balancer."
   type        = bool


### PR DESCRIPTION
## Ticket

Resolves FFS-1272.

## Changes

We want to run a job every hour to redact data older than a threshold (7
days). This is pretty similar to the support the infra template already
has for file-upload-triggered jobs, so I've put the configuration right
alongside those.

The task is scheduled with EventBridge Scheduler, which runs a
serverless cron. The Scheduler itself has a different service identifier
than the event manager used for the file-upload jobs, so I created a
separate IAM user and policy to allow it to AssumeRole.

## Context for reviewers

This can be merged independently of https://github.com/DSACMS/iv-cbv-payroll/pull/155.

## Testing

Tested by provisioning the scheduled task and watching it run at the top of the next hour.
