### PR TITLE
Use `_html` suffix for I18n string on invitations page

### DIFF
--- a/app/app/views/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/cbv_flow_invitations/new.html.erb
@@ -1,5 +1,5 @@
 <h1><%= t(".header") %></h1>
-<%= raw t(".description", pay_income_days: current_site.pay_income_days) %>
+<%= t(".description_html", pay_income_days: current_site.pay_income_days) %>
 
 <%= form_with(model: @cbv_flow_invitation, url: invitations_path, builder: UswdsFormBuilder) do |f| %>
   <%= hidden_field_tag :secret, params[:secret] %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
         middle_name: Client's middle name
         snap_application_date: SNAP application date
     new:
-      description: "<p>Provide some details about the client so we can send them a link to verify their pay information. We'll request the past %{pay_income_days} days of income, based on the client's application date.</p><p>If multiple members of the household earn income, send an invite link to each household member.</p>"
+      description_html: "<p>Provide some details about the client so we can send them a link to verify their pay information. We'll request the past %{pay_income_days} days of income, based on the client's application date.</p><p>If multiple members of the household earn income, send an invite link to each household member.</p>"
       form:
         submit: Send Invitation
       header: Send an invite link


### PR DESCRIPTION
## Ticket

N/A - Fixes issue in #150.

## Changes

We should be using the built-in support for HTML in I18n strings via an
`_html` suffix of the I18n key, as all variables interpolated into the
string are automatically HTML-sanitized.

## Context for reviewers

See https://guides.rubyonrails.org/i18n.html#using-safe-html-translations

## Testing

N/A
