### PR TITLE
Fix sandbox invite page to use date picker

### DIFF
--- a/app/app/views/cbv_flow_invitations/_sandbox.erb
+++ b/app/app/views/cbv_flow_invitations/_sandbox.erb
@@ -3,4 +3,4 @@
 <%= f.text_field :last_name %>
 <%= f.text_field :case_number %>
 <%= f.text_field :email_address %>
-<%= f.date_field :snap_application_date %>
+<%= f.date_picker :snap_application_date, label: t(".invite.snap_application_date"), hint: "mm/dd/yyyy" %>


### PR DESCRIPTION
## Ticket

N/A

## Changes

Change the "sandbox" invitation page to use `date_picker` rather than an
unstyled date field. This makes it match the other invitation pages.

## Context for reviewers

N/A

## Testing

N/A
