### PR TITLE
Configure premailer to drop the stylesheet

### DIFF
--- a/app/app/views/layouts/mailer.html.erb
+++ b/app/app/views/layouts/mailer.html.erb
@@ -2,9 +2,7 @@
 <html class="bg-primary-lighter">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
-    <style>
-      <%= stylesheet_link_tag "application" %>
-    </style>
+    <%= stylesheet_link_tag "application" %>
   </head>
 
   <body>

--- a/app/config/initializers/premailer.rb
+++ b/app/config/initializers/premailer.rb
@@ -1,0 +1,1 @@
+Premailer::Rails.config.merge!(drop_unmergeable_css_rules: true)


### PR DESCRIPTION
## Changes

Premailer was including the entire stylesheet with every email. This cause the email to be hidden under an "click to expand this message" link in email viewers.

## Context for reviewers

We configured it with the rule, `drop_unmergeable_css_rules`, which was not obvious at first. See discussion: https://github.com/fphilipe/premailer-rails/issues/184

## Testing

![image](https://github.com/user-attachments/assets/3a4c1da5-d8db-4b82-9f09-e913db226547)

