### PR TITLE
Change MA invites to be only valid for 14 days

### DIFF
--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -34,7 +34,7 @@
     scope: "openid"
     name: "ma_dta"
   pay_income_days: 90
-  invitation_valid_days: 21
+  invitation_valid_days: 14
   learn_more_link_text: Learn more at Mass.gov
   learn_more_link_url: https://www.mass.gov/guides/how-to-contact-dta
 - id: sandbox


### PR DESCRIPTION
## Ticket

N/A

## Changes

Per meeting on August 13 with DTA, 21 days is too long and 14 days feels
better. (It may still be too long, but at least it aligns with NYC's
timeline.)

## Context for reviewers

N/A

## Testing

N/A - We'll test with backdated invites during final bug bash.
