### PR TITLE
Add `site_translation` helper for site-specific copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ $ i18n-tasks remove-unused # removes unused keys across locale files
 
 For more information on usage and helpful rake tasks to manage locale files, see [the documentation](https://github.com/glebm/i18n-tasks#usage).
 
+## "Site-specific" translations
+
+The CBV pilot project is architected to be multi-tenant across jurisdictions we
+are actively piloting with. Each jurisdiction's agency is configured as a
+"site" in app/config/site-config.yml and has a short "id", e.g. "nyc", "ma",
+and "sandbox".
+
+We often need to adjust copy specific to each site. The preferred way to do it
+is by using the `site_translation` helper, which wraps Rails's `t` view helper
+and looks for the current site's "id" as a sub-key of the given prefix.
+
+Usage:
+
+```erb
+<%= site_translation(".learn_more_html") %>
+```
+
+And the corresponding locale file:
+
+
+```yaml
+learn_more_html:
+  nyc: Learn more about <strong>NYC Human Resources Administration</strong>
+  ma: Learn more about <strong>Massachusetts Department of Transitional Assistance</strong>
+  sandbox: Learn more about <strong>CBV Test Agency</strong>
+  default: Learn more about <strong>Default Agency</strong>
+```
+
+Similar to Rails's `t` helper, the string will be marked HTML-safe if its key
+prefix ends with `_html`.
+
 # Testing
 
 ## Running tests

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -1,0 +1,41 @@
+module ApplicationHelper
+  # Render a translation that is specific to the current site. Define
+  # site-specific translations as:
+  #
+  # foo:
+  #   nyc: Some String
+  #   ma: Other String
+  #   default: Default String
+  #
+  # Then call this method with, `site_translation("foo")` and it will attempt
+  # to render the nested translation according to the current site ID, or use
+  # the "default" string if the translation is either missing or there is no
+  # current site.
+  def site_translation(i18n_base_key, **options)
+    default_key = "#{i18n_base_key}.default"
+    i18n_key =
+      if current_site
+        "#{i18n_base_key}.#{current_site.id}"
+      else
+        default_key
+      end
+
+    translated =
+      if I18n.exists?(scope_key_by_partial(i18n_key))
+        t(i18n_key, **options)
+      elsif I18n.exists?(scope_key_by_partial(default_key))
+        t(default_key, **options)
+      end
+
+    # Mark as html_safe if the base key ends with `_html`.
+    #
+    # We have to replicate the logic from ActiveSupport::HtmlSafeTranslation
+    # because the base key is the one that ends with "_html", not the one we
+    # ultimately pass into the translation library.
+    if /(?:_|\b)html\z/.match?(i18n_base_key) && translated.present?
+      translated.html_safe
+    else
+      translated
+    end
+  end
+end

--- a/app/app/views/cbv/add_jobs/show.html.erb
+++ b/app/app/views/cbv/add_jobs/show.html.erb
@@ -21,7 +21,7 @@
 
   <div class="margin-bottom-2">
     <%= t(".criteria_disclaimer", pay_income_days: current_site.pay_income_days) %>
-    <%= link_to(current_site.learn_more_link_text, current_site.learn_more_link_url) %>
+    <%= site_translation(".learn_more_link_html") %>
   </div>
 
   <%= form_with(url: cbv_flow_add_job_path, builder: UswdsFormBuilder, data: { "add-job-target": "addJobForm", turbo: "false" }, id: "add_job_form") do |f| %>

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -44,7 +44,7 @@
       <li><%= t("cbv.employer_searches.show.no_results_desc1") %></li>
       <li><%= t("cbv.employer_searches.show.no_results_desc2") %></li>
     </ol>
-    <p><%= t("cbv.employer_searches.show.no_results_desc3") %> <%= link_to t("cbv.employer_searches.show.no_results_link", agency_short_name: current_site.agency_short_name), current_site.agency_help_link %></p>
+    <p><%= t("cbv.employer_searches.show.no_results_desc3") %> <%= site_translation("cbv.employer_searches.show.no_results_link_html") %></p>
     <%= link_to cbv_flow_missing_results_path, class: "usa-button margin-top-5", data: { turbo_frame: "_top" } do %>
       <%= t("cbv.employer_searches.show.exit_button_text") %>
     <% end %>

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -1,12 +1,10 @@
 <h1><%= t(".header") %></h1>
 <p class="line-height-sans-5"><%= t(".not_listed_p1") %></p>
 <p class="line-height-sans-5"><%= t(".not_listed_p2", agency_short_name: current_site.agency_short_name) %></p>
-<%= link_to current_site.agency_help_link, class: "usa-button" do %>
-  <%= t(".exit_button", agency_short_name: current_site.agency_short_name) %>
-<% end %>
+<%= site_translation(".exit_button_html") %>
 <hr class="margin-top-5 margin-bottom-5 border-base-light border-top-0">
 <h2><%= t(".more_jobs") %></h2>
 <p class="line-height-sans-5"><%= t(".you_can_search") %></p>
-<%= link_to cbv_flow_employer_search_path, class: "usa-button usa-button--outline" do %>
+<%= link_to cbv_flow_employer_search_path, class: "usa-button usa-button--outline", data: { turbo: "false" } do %>
   <%= t(".back_button") %>
 <% end %>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -121,7 +121,8 @@ ignore_missing:
 # - '{devise,simple_form}.*'
 
 ## Consider these keys used:
-# ignore_unused:
+ignore_unused:
+  - "*.{nyc,ma,sandbox,default}" # site-specific translations
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -27,6 +27,10 @@ en:
         continue: Continue
         criteria_disclaimer: 'Note: If you''ve had other jobs in the past %{pay_income_days} days that don''t meet these criteria, you may need to submit that income information separately. Contact your agency for assistance.'
         header: Do you have another job to report?
+        learn_more_link_html:
+          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta">Learn more at Mass.gov</a>
+          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Learn more on nyc.gov</a>
+          sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta">Learn more at CBV Test Agency</a>
         no_radio: No, I don’t have another job that meets the criteria
         subheader: Please add other jobs you’ve had in the past %{pay_income_days} days, even if you're no longer at that job.
         yes_radio: Yes, I have another job that meets the criteria
@@ -53,7 +57,10 @@ en:
         no_results_desc1: Check if your employer uses another business name or a payroll provider.
         no_results_desc2: Make sure you have spelled names correctly, then search again.
         no_results_desc3: If you still donʼt see your employer or payroll provider listed, you will need to submit that income information separately.
-        no_results_link: Learn more on %{agency_short_name}'s website.
+        no_results_link_html:
+          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta">Learn more on DTA's website.</a>
+          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Learn more on HRA's website.</a>
+          sandbox: <a href="https://example.com">Learn more on CBV Test Agency's website.</a>
         no_results_title: We couldn’t find your employer or payroll provider.
         results: Results
         search: Search
@@ -86,7 +93,10 @@ en:
     missing_results:
       show:
         back_button: Go back to employer search
-        exit_button: Exit and go to %{agency_short_name}
+        exit_button_html:
+          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Exit and go to DTA</a>
+          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page" class="usa-button">Exit and go to HRA</a>
+          sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Exit and go to CBV Test Agency</a>
         header: How to report income if your employer or payroll provider isn’t listed
         more_jobs: If you have more jobs to report
         not_listed_p1: If your employer or payroll provider isn’t listed on this site, you’ll need to share your income information for this job directly with your benefits agency.

--- a/app/config/site-config.yml
+++ b/app/config/site-config.yml
@@ -7,7 +7,6 @@
   transmission_method_configuration:
     email: <%= ENV['NYC_HRA_EMAIL'] %>
   agency_short_name: HRA
-  agency_help_link: https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page
   sso:
     client_id:     <%= ENV["AZURE_NYC_DSS_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_NYC_DSS_CLIENT_SECRET"] %>
@@ -16,8 +15,6 @@
     name: "nyc_dss"
   pay_income_days: 90
   invitation_valid_days: 14
-  learn_more_link_text: Learn more on nyc.gov
-  learn_more_link_url: https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page
 - id: ma
   agency_name: Massachusetts Department of Transitional Assistance
   pinwheel:
@@ -26,7 +23,6 @@
   transmission_method: null
   transmission_method_configuration: {}
   agency_short_name: DTA
-  agency_help_link: https://www.mass.gov/guides/how-to-contact-dta
   sso:
     client_id:     <%= ENV["AZURE_MA_DTA_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_MA_DTA_CLIENT_SECRET"] %>
@@ -35,8 +31,6 @@
     name: "ma_dta"
   pay_income_days: 90
   invitation_valid_days: 14
-  learn_more_link_text: Learn more at Mass.gov
-  learn_more_link_url: https://www.mass.gov/guides/how-to-contact-dta
 - id: sandbox
   agency_name: CBV Test Agency
   pinwheel:
@@ -46,7 +40,6 @@
   transmission_method_configuration:
     email: <%= ENV['SLACK_TEST_EMAIL'] %>
   agency_short_name: CBV
-  agency_help_link: https://example.com/dept-of-helping
   sso:
     client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>
@@ -55,5 +48,3 @@
     name: "sandbox"
   pay_income_days: 90
   invitation_valid_days: 14
-  learn_more_link_text: Learn more at CBV Test Agency
-  learn_more_link_url: https://www.mass.gov/guides/how-to-contact-dta

--- a/app/lib/site_config.rb
+++ b/app/lib/site_config.rb
@@ -22,10 +22,7 @@ class SiteConfig
       id
       agency_name
       agency_short_name
-      agency_help_link
       invitation_valid_days
-      learn_more_link_text
-      learn_more_link_url
       pay_income_days
       pinwheel_api_token
       pinwheel_environment
@@ -36,12 +33,9 @@ class SiteConfig
 
     def initialize(yaml)
       @id = yaml["id"]
-      @agency_help_link = yaml["agency_help_link"]
       @agency_name = yaml["agency_name"]
       @agency_short_name = yaml["agency_short_name"]
       @invitation_valid_days = yaml["invitation_valid_days"]
-      @learn_more_link_text = yaml["learn_more_link_text"]
-      @learn_more_link_url = yaml["learn_more_link_url"]
       @pay_income_days = yaml["pay_income_days"]
       @pinwheel_api_token = yaml["pinwheel"]["api_token"]
       @pinwheel_environment = yaml["pinwheel"]["environment"]


### PR DESCRIPTION
## Ticket

Prerequisite to FFS-1235.

## Changes

We've needed this ever since the initial concept of site config: a way
to differentiate copy based on which site is being viewed. Rather than
adding all of these strings to the site-config.yml, let's create a
helper method that looks for the key dynamically based on the current
site.

This commit removes the site config for `agency_help_link`,
`learn_more_link_text` and `learn_more_link_url` by replacing them with
some site-specific translations.

## Context for reviewers


## Testing

Confirmed that the following pages render properly:
* Add jobs
* Employer search ("0 results" message)
* Missing results
