### PR TITLE
Fix downloading PDF after completing CBV flow

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -15,6 +15,9 @@ class Cbv::BaseController < ApplicationController
       end
 
       @cbv_flow = invitation.cbv_flow || CbvFlow.create_from_invitation(invitation)
+      if @cbv_flow.complete?
+        return redirect_to(cbv_flow_expired_invitation_path)
+      end
       NewRelicEventTracker.track("ClickedCBVInvitationLink", {
         timestamp: Time.now.to_i,
         invitation_id: invitation.id,
@@ -39,8 +42,7 @@ class Cbv::BaseController < ApplicationController
   def ensure_cbv_flow_not_yet_complete
     return unless @cbv_flow && @cbv_flow.complete?
 
-    session[:cbv_flow_id] = nil
-    redirect_to(cbv_flow_expired_invitation_path)
+    redirect_to(cbv_flow_success_path)
   end
 
   def current_site

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -3,6 +3,7 @@ class Cbv::SummariesController < Cbv::BaseController
 
   helper_method :payments_grouped_by_employer, :total_gross_income
   before_action :set_payments, only: %i[show]
+  skip_before_action :ensure_cbv_flow_not_yet_complete, if: -> { params[:format] == "pdf" }
 
   def show
     respond_to do |format|

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Cbv::EntriesController do
         session[:cbv_flow_id] = -1
       end
 
-      it "uses the existing CbvFlow object" do
+      it "redirects to the homepage" do
         get :show
 
         expect(response).to redirect_to(root_url)

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Cbv::SummariesController do
   include PinwheelApiHelper
 
   describe "#show" do
-    render_views
-
     let(:cbv_flow) { CbvFlow.create(case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", site_id: "sandbox") }
 
     before do
@@ -14,15 +12,41 @@ RSpec.describe Cbv::SummariesController do
       stub_request_end_user_paystubs_response
     end
 
-    it "renders properly" do
-      get :show
-      expect(response).to be_successful
+    context "when rendering views" do
+      render_views
+
+      it "renders properly" do
+        get :show
+        expect(response).to be_successful
+      end
+
+      it "renders pdf properly" do
+        get :show, format: :pdf
+        expect(response).to be_successful
+        expect(response.header['Content-Type']).to include 'pdf'
+      end
     end
 
-    it "renders pdf properly" do
-      get :show, format: :pdf
-      expect(response).to be_successful
-      expect(response.header['Content-Type']).to include 'pdf'
+    context "for a completed CbvFlow" do
+      let(:cbv_flow) do
+        CbvFlow.create(
+          case_number: "ABC1234",
+          pinwheel_token_id: "abc-def-ghi",
+          site_id: "sandbox",
+          confirmation_code: "ABC1234"
+        )
+      end
+
+      it "allows the user to download the PDF summary" do
+        get :show, format: :pdf
+        expect(response).to be_successful
+        expect(response.header['Content-Type']).to include 'pdf'
+      end
+
+      it "redirects the user to the success page if the user goes back to the page" do
+        get :show
+        expect(response).to redirect_to(cbv_flow_success_path)
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves FFS-1302.

## Changes

It was broken because it was mistakenly redirecting to the expired
tokens URL. This commit tweaks how we do session management like so:

1. If the user hits the "Back" button after reaching the "success" page
   (or goes to any other /cbv/ url), they will be redirected back to the
   success page, with the CbvFlow still in their session (so the page
   can render). This will create consistency so people don't
   accidentally get locked out of their session after it's complete. We
   will rely on session expiration (coming in the future) so that
   reopening the browser after a long time does not return the user to
   the success page.
2. That makes the "expired" page only used when *starting* a new flow
   from a token.
3. After those changes, we can just skip the completeness check when
   downloading the PDF to ensure that it is always possible.


## Context for reviewers

N/A

## Testing

Tested the CBV flow locally: downloading the PDF works.
