### PR TITLE
Updated NYC/MA required and optional fields

### DIFF
--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -5,11 +5,11 @@ class CbvFlowInvitation < ApplicationRecord
 
   has_secure_token :auth_token, length: 36
   validates :site_id, inclusion: Rails.application.config.sites.site_ids
-  validates :client_id_number, presence: true, if: :nyc_site?
   validates :case_number, presence: true, if: :nyc_site?
   validates :agency_id_number, presence: true, if: :ma_site?
   validates :beacon_id, presence: true, if: :ma_site?
   validates :email_address, presence: true
+  validates :snap_application_date, presence: true
 
   include Redactable
   has_redactable_fields(
@@ -52,7 +52,7 @@ class CbvFlowInvitation < ApplicationRecord
 
   def parse_snap_application_date
     raw_snap_application_date = @attributes["snap_application_date"]&.value_before_type_cast
-    return if raw_snap_application_date.blank? || raw_snap_application_date.is_a?(Date)
+    return if raw_snap_application_date.is_a?(Date)
 
     begin
       new_date_format = Date.strptime(raw_snap_application_date.to_s, "%m/%d/%Y")

--- a/app/db/migrate/20240814192234_change_requirements_for_cbv_flow_invitations_fields.rb
+++ b/app/db/migrate/20240814192234_change_requirements_for_cbv_flow_invitations_fields.rb
@@ -1,6 +1,6 @@
 class ChangeRequirementsForCbvFlowInvitationsFields < ActiveRecord::Migration[7.1]
   def change
     change_column_null :cbv_flow_invitations, :middle_name, true
-    change_column_null :cbv_flow_invitations, :snap_application_date, true
+    change_column_null :cbv_flow_invitations, :snap_application_date, false, Time.zone.now
   end
 end

--- a/app/db/migrate/20240814192234_change_requirements_for_cbv_flow_invitations_fields.rb
+++ b/app/db/migrate/20240814192234_change_requirements_for_cbv_flow_invitations_fields.rb
@@ -1,0 +1,6 @@
+class ChangeRequirementsForCbvFlowInvitationsFields < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :cbv_flow_invitations, :middle_name, true
+    change_column_null :cbv_flow_invitations, :snap_application_date, true
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_13_181942) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_192234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_13_181942) do
     t.datetime "updated_at", null: false
     t.string "site_id"
     t.string "first_name", null: false
-    t.string "middle_name", null: false
+    t.string "middle_name"
     t.string "last_name", null: false
     t.string "agency_id_number"
     t.string "client_id_number"

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_192234) do
     t.string "last_name", null: false
     t.string "agency_id_number"
     t.string "client_id_number"
-    t.date "snap_application_date"
+    t.date "snap_application_date", null: false
     t.string "beacon_id"
   end
 

--- a/app/spec/controllers/cbv_flow_invitations/ma_spec.rb
+++ b/app/spec/controllers/cbv_flow_invitations/ma_spec.rb
@@ -29,15 +29,12 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
   end
 
   describe "#create" do
-    let(:custom_params) { {
-      site_id: "ma",
-      snap_application_date: Date.today.strftime("%m/%d/%Y"),
-      beacon_id: "ABC123",
-      agency_id_number: "789012"
-    } }
-
     let(:cbv_flow_invitation_params) do
-      attributes_for(:cbv_flow_invitation, custom_params)
+      attributes_for(:cbv_flow_invitation,
+             site_id: "ma",
+             beacon_id: "ABC123",
+             agency_id_number: "789012",
+             )
     end
 
     it "creates a CbvFlowInvitation record with the ma fields" do
@@ -55,6 +52,14 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
       expect(invitation.email_address).to eq("test@example.com")
       expect(invitation.snap_application_date).to eq(Date.today)
       expect(invitation.beacon_id).to eq("ABC123")
+    end
+
+    it "requires the ma fields" do
+      post :create, params: {
+        secret: invite_secret,
+        site_id: ma_params[:site_id],
+        cbv_flow_invitation: cbv_flow_invitation_params
+      }
     end
   end
 end

--- a/app/spec/controllers/cbv_flow_invitations/ma_spec.rb
+++ b/app/spec/controllers/cbv_flow_invitations/ma_spec.rb
@@ -29,12 +29,13 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
   end
 
   describe "#create" do
+    let(:error_message) do
+      "Error sending invitation to test@example.com: " \
+        "Validation failed: Agency id number can't be blank, Beacon can't be blank."
+    end
+
     let(:cbv_flow_invitation_params) do
-      attributes_for(:cbv_flow_invitation,
-             site_id: "ma",
-             beacon_id: "ABC123",
-             agency_id_number: "789012",
-             )
+      attributes_for(:cbv_flow_invitation, site_id: "ma", beacon_id: "ABC123", agency_id_number: "789012")
     end
 
     it "creates a CbvFlowInvitation record with the ma fields" do
@@ -57,9 +58,10 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
     it "requires the ma fields" do
       post :create, params: {
         secret: invite_secret,
-        site_id: ma_params[:site_id],
-        cbv_flow_invitation: cbv_flow_invitation_params
+        site_id: "ma",
+        cbv_flow_invitation: cbv_flow_invitation_params.except(:beacon_id, :agency_id_number)
       }
+      expect(flash[:alert]).to eq(error_message)
     end
   end
 end

--- a/app/spec/controllers/cbv_flow_invitations/nyc_spec.rb
+++ b/app/spec/controllers/cbv_flow_invitations/nyc_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
           expect(invitation.case_number).to eq("ABC1234")
           expect(invitation.email_address).to eq("test@example.com")
         end
+
+        it "creates a CbvFlowInvitation record without optional fields" do
+          post :create, params: {
+            secret: invite_secret,
+            site_id: nyc_params[:site_id],
+            cbv_flow_invitation: cbv_flow_invitation_params.except(:middle_name, :client_id_number)
+          }
+          invitation = CbvFlowInvitation.last
+          expect(invitation.middle_name).to be_nil
+        end
       end
     end
 end

--- a/app/spec/controllers/cbv_flow_invitations/nyc_spec.rb
+++ b/app/spec/controllers/cbv_flow_invitations/nyc_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
   let(:user) { User.create(email: "test@test.com", site_id: 'nyc') }
   let(:invite_secret) { "FAKE_INVITE_SECRET" }
   let(:nyc_params) { { site_id: "nyc", secret: invite_secret } }
-  let(:client_id_number) { "123456" }
 
   before do
     sign_in user
   end
 
   describe "#new" do
+    let(:valid_params) { nyc_params }
+
     context "loads the nyc fields" do
       render_views
 
@@ -28,21 +29,26 @@ RSpec.describe CbvFlowInvitationsController, type: :controller do
   end
 
   describe "#create" do
-    it "creates a CbvFlowInvitation record with the nyc fields" do
-      post :create, params: {
-        secret: invite_secret,
-        site_id: "nyc",
-        cbv_flow_invitation: attributes_for(:cbv_flow_invitation, site_id: "nyc", client_id_number: client_id_number, case_number: "ABC1234"),
-        client_id_number: client_id_number
-      }
+      let(:cbv_flow_invitation_params) do
+        attributes_for(:cbv_flow_invitation, site_id: "nyc", client_id_number: "123456", case_number: "ABC1234")
+      end
 
-      invitation = CbvFlowInvitation.last
-      expect(invitation.first_name).to eq("Jane")
-      expect(invitation.middle_name).to eq("Sue")
-      expect(invitation.last_name).to eq("Doe")
-      expect(invitation.client_id_number).to eq("123456")
-      expect(invitation.case_number).to eq("ABC1234")
-      expect(invitation.email_address).to eq("test@example.com")
+      context "successfully creates a CbvFlowInvitation record with the nyc fields" do
+        it "creates a CbvFlowInvitation record with the nyc fields" do
+          post :create, params: {
+            secret: invite_secret,
+            site_id: nyc_params[:site_id],
+            cbv_flow_invitation: cbv_flow_invitation_params
+          }
+
+          invitation = CbvFlowInvitation.last
+          expect(invitation.first_name).to eq("Jane")
+          expect(invitation.middle_name).to eq("Sue")
+          expect(invitation.last_name).to eq("Doe")
+          expect(invitation.client_id_number).to eq("123456")
+          expect(invitation.case_number).to eq("ABC1234")
+          expect(invitation.email_address).to eq("test@example.com")
+        end
+      end
     end
-  end
 end

--- a/app/spec/models/cbv_flow_invitation_spec.rb
+++ b/app/spec/models/cbv_flow_invitation_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe CbvFlowInvitation, type: :model do
 
     describe "validations" do
       context "when site_id is 'nyc'" do
-        it "requires client_id_number" do
-          invitation = CbvFlowInvitation.new(valid_attributes.merge(site_id: 'nyc'))
-          invitation.valid?
-          expect(invitation.errors[:client_id_number]).to include("can't be blank")
-        end
-
         it "requires case_number" do
           invitation = CbvFlowInvitation.new(valid_attributes.merge(site_id: 'nyc'))
           invitation.valid?
@@ -54,6 +48,21 @@ RSpec.describe CbvFlowInvitation, type: :model do
           invitation = CbvFlowInvitation.new(valid_attributes.merge(snap_application_date: "invalid"))
           invitation.valid?
           expect(invitation.errors[:snap_application_date]).to include("is not a valid date")
+        end
+      end
+
+      context "requires snap_application_date" do
+        it "adds an error" do
+          invitation = CbvFlowInvitation.new(valid_attributes.merge(snap_application_date: nil))
+          invitation.valid?
+          expect(invitation.errors[:snap_application_date]).to include("can't be blank")
+        end
+      end
+
+      context "middle_name is optional" do
+        it "is valid" do
+          invitation = CbvFlowInvitation.new(valid_attributes.merge(middle_name: nil))
+          expect(invitation).to be_valid
         end
       end
     end


### PR DESCRIPTION
Closes [FFS-1300](https://jiraent.cms.gov/browse/FFS-1300)

## Changes

- Updated `snap_application_date` to be required for all agencies
- `client_id_number` is now optional for NYC
- `middle_name` is now optional for all agencies

## Testing

I've tested things locally and created tests to assert that the requirements are met