### PR TITLE
Update MA invitation email to include DTA logo

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_site
-    site_config[params[:site_id]]
+    @current_site ||= site_config[params[:site_id]]
   end
 
   protected

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -48,7 +48,7 @@ class Cbv::BaseController < ApplicationController
   def current_site
     return unless @cbv_flow.present? && @cbv_flow.site_id.present?
 
-    site_config[@cbv_flow.site_id]
+    @current_site ||= site_config[@cbv_flow.site_id]
   end
 
   def next_path

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -14,8 +14,8 @@ module ApplicationHelper
   def site_translation(i18n_base_key, **options)
     default_key = "#{i18n_base_key}.default"
     i18n_key =
-      if current_site
-        "#{i18n_base_key}.#{current_site.id}"
+      if @current_site
+        "#{i18n_base_key}.#{@current_site.id}"
       else
         default_key
       end

--- a/app/app/mailers/applicant_mailer.rb
+++ b/app/app/mailers/applicant_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicantMailer < ApplicationMailer
-  helper :view
+  helper :view, :application
   before_action :set_params
 
   def invitation_email
@@ -13,6 +13,6 @@ class ApplicantMailer < ApplicationMailer
 
   def set_params
     @cbv_flow_invitation = params[:cbv_flow_invitation]
-    @site_config = site_config[@cbv_flow_invitation.site_id]
+    @current_site = site_config[@cbv_flow_invitation.site_id]
   end
 end

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -1,40 +1,42 @@
-<section class="grid-container usa-section">
-  <div class="grid-row flex-justify-center">
-    <div class="bg-white padding-y-7 padding-x-7 border border-base-lighter measure-5 line-height-sans-4">
-      <h3>
-        <span class="text-primary"><%= t("shared.pilot_name") %> | </span>
-        <%= @site_config.agency_name %>
-      </h3>
-      <h1>
-        <%= @site_config.agency_short_name %> has sent you an invitation to verify your income
-      </h1>
-      <div class="line-height-sans-5">
-        <p>
-          <%= t(".greeting") %>
-        </p>
-
-        <p>
-          <%= t(".body_html",
-            agency_acronym: @site_config.agency_short_name,
-            deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %>
-        </p>
-
-        <p>
-          To verify your income, click the button below:
-        </p>
-      </div>
-
-      <p class="margin-y-5">
-        <a href="<%= @cbv_flow_invitation.to_url %>" class="usa-button width-auto" type="button">
-          Verify your income
-        </a>
+<section class="usa-section">
+  <div class="bg-white padding-y-7 padding-x-7 border border-base-lighter measure-5 line-height-sans-4 margin-x-auto font-body-xs">
+    <h3>
+      <span class="text-primary"><%= t("shared.pilot_name") %> | </span>
+      <% if @current_site.id == "ma" %>
+        <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
+      <% else %>
+        <%= site_translation("shared.header.cbv_flow_title") %>
+      <% end %>
+    </h3>
+    <h1>
+      <%= site_translation(".header") %>
+    </h1>
+    <div class="line-height-sans-5">
+      <p>
+        <%= t(".greeting") %>
       </p>
 
-      <hr >
+      <p>
+        <%= t(".body_html",
+          agency_acronym: @current_site.agency_short_name,
+          deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %>
+      </p>
 
-      <p class="font-body-2xs">
-        This is an automatically generated message from your benefits agency. Please don’t reply to this email.
+      <p>
+        To verify your income, click the button below:
       </p>
     </div>
+
+    <p class="margin-y-5">
+      <a href="<%= @cbv_flow_invitation.to_url %>" class="usa-button width-auto" type="button">
+        Verify your income
+      </a>
+    </p>
+
+    <hr >
+
+    <p class="font-body-3xs">
+      This is an automatically generated message from your benefits agency. Please don’t reply to this email.
+    </p>
   </div>
 </section>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -4,6 +4,10 @@ en:
     invitation_email:
       body_html: We need to verify your income as part of your benefits application, as requested by %{agency_acronym}. This process is unique to you, so please do not share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.
       greeting: Hello,
+      header:
+        ma: DTA has sent you an invitation to verify your income
+        nyc: HRA has sent you an invitation to verify your income
+        sandbox: CBV Test Agency has sent you an invitation to verify your income
       subject: Verify your income for your benefit application
   caseworker_mailer:
     summary_email:

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cbv::EntriesController do
     end
 
     context "when following a link from a flow invitation" do
-      let(:invitation) { create(:cbv_flow_invitation) }
+      let(:invitation) { create(:cbv_flow_invitation, case_number: "ABC1234") }
 
       it "sets a CbvFlow object based on the invitation" do
         expect { get :show, params: { token: invitation.auth_token } }
@@ -28,9 +28,9 @@ RSpec.describe Cbv::EntriesController do
 
         cbv_flow = CbvFlow.find(session[:cbv_flow_id])
         expect(cbv_flow).to have_attributes(
-                              case_number: "ABC1234",
-                              cbv_flow_invitation: invitation
-                            )
+          case_number: "ABC1234",
+          cbv_flow_invitation: invitation
+        )
       end
 
       context "when returning to an already-visited flow invitation" do

--- a/app/spec/factories/cbv_flow_invitation.rb
+++ b/app/spec/factories/cbv_flow_invitation.rb
@@ -3,9 +3,20 @@ FactoryBot.define do
     first_name { "Jane" }
     middle_name { "Sue" }
     last_name { "Doe" }
-    case_number { "ABC1234" }
     site_id { "sandbox" }
     email_address { "test@example.com" }
     snap_application_date { Date.today.strftime("%m/%d/%Y") }
+
+    trait :nyc do
+      site_id { "nyc" }
+      case_number { "ABC1234" }
+      client_id_number { "001111111" }
+    end
+
+    trait :ma do
+      site_id { "ma" }
+      agency_id_number { "0001112222" }
+      beacon_id { "123456" }
+    end
   end
 end

--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
   end
 
   let(:email) { 'me@email.com' }
-  let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :nyc, email_address: email) }
+  let(:cbv_flow_invitation) { create(:cbv_flow_invitation, email_address: email) }
   let(:mail) { ApplicantMailer.with(cbv_flow_invitation: cbv_flow_invitation).invitation_email }
 
   it "renders the subject" do
@@ -30,8 +30,30 @@ RSpec.describe ApplicantMailer, type: :mailer do
 
   it "renders the body" do
     expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
-      agency_acronym: 'HRA',
+      agency_acronym: 'CBV',
       deadline: "July 21, 2024")
     )
+  end
+
+  context "for a NYC CbvFlowInvitation" do
+    let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :nyc, email_address: email) }
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
+        agency_acronym: 'HRA',
+        deadline: "July 21, 2024")
+      )
+    end
+  end
+
+  context "for a MA CbvFlowInvitation" do
+    let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :ma, email_address: email) }
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
+        agency_acronym: 'DTA',
+        deadline: "July 21, 2024")
+      )
+    end
   end
 end

--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
   end
 
   let(:email) { 'me@email.com' }
-  let(:cbv_flow_invitation) { create(:cbv_flow_invitation, email_address: email, site_id: "nyc", client_id_number: "ABC123") }
+  let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :nyc, email_address: email) }
   let(:mail) { ApplicantMailer.with(cbv_flow_invitation: cbv_flow_invitation).invitation_email }
 
   it "renders the subject" do

--- a/app/spec/mailers/previews/applicant_mailer_preview.rb
+++ b/app/spec/mailers/previews/applicant_mailer_preview.rb
@@ -1,12 +1,16 @@
 # Preview all emails at http://localhost:3000/rails/mailers/applicant_mailer
-require Rails.root.join('spec/support/test_helpers')
-class ApplicantMailerPreview < ActionMailer::Preview
+class ApplicantMailerPreview < BaseMailerPreview
   include ViewHelper
-  include TestHelpers
 
-  def invitation_email
+  def invitation_email_dta
     ApplicantMailer.with(
-      cbv_flow_invitation: create(:cbv_flow_invitation)
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :ma)
+    ).invitation_email
+  end
+
+  def invitation_email_nyc
+    ApplicantMailer.with(
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc)
     ).invitation_email
   end
 end

--- a/app/spec/mailers/previews/base_mailer_preview.rb
+++ b/app/spec/mailers/previews/base_mailer_preview.rb
@@ -1,0 +1,14 @@
+require "factory_bot"
+require Rails.root.join('spec/support/test_helpers')
+
+class BaseMailerPreview < ActionMailer::Preview
+  def initialize(*)
+    if FactoryBot.factories.any?
+      FactoryBot.reload
+    else
+      FactoryBot.find_definitions
+    end
+
+    super
+  end
+end

--- a/app/spec/mailers/previews/caseworker_mailer_preview.rb
+++ b/app/spec/mailers/previews/caseworker_mailer_preview.rb
@@ -1,5 +1,5 @@
 # Preview all emails at http://localhost:3000/rails/mailers/caseworker_mailer
-class CaseworkerMailerPreview < ActionMailer::Preview
+class CaseworkerMailerPreview < BaseMailerPreview
   include ViewHelper
   include TestHelpers
 

--- a/app/spec/models/cbv_flow_spec.rb
+++ b/app/spec/models/cbv_flow_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CbvFlow, type: :model do
   describe ".create_from_invitation" do
-    let(:cbv_flow_invitation) { create(:cbv_flow_invitation) }
+    let(:cbv_flow_invitation) { create(:cbv_flow_invitation, case_number: "ABC1234") }
 
     it "copies over relevant fields" do
       cbv_flow = CbvFlow.create_from_invitation(cbv_flow_invitation)


### PR DESCRIPTION
## Ticket

Resolves FFS-1033.

## Changes

- **Add "nyc" and "ma" versions of cbv_flow_invitation factory**
- **Fix mailer previews so they work with FactoryBot**
- **Update MA invitation email to include DTA logo**

## Context for reviewers

See commit messages for a bit of context on each change.

## Testing

Will do acceptance testing via mailer preview screenshots.

<details>
<summary>
<h2>Acceptance testing screenshots</h2></summary>
MA Applicant Email
<img width="856" alt="image" src="https://github.com/user-attachments/assets/d0183c5d-5df9-4f33-a478-e09b0d21805e">

NYC Applicant Email (this is unchanged)
<img width="842" alt="image" src="https://github.com/user-attachments/assets/6d6978b5-da1d-4544-ba43-2e5e7583f60e">
</details>