### PR TITLE
Expire session cookies after 30 minutes of inactivity

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   helper_method :current_site
   around_action :switch_locale
 
+  rescue_from ActionController::InvalidAuthenticityToken do
+    redirect_to root_url, notice: t("cbv.error_missing_token")
+  end
+
   def after_sign_in_path_for(user)
     invitations_new_url(user.site_id)
   end

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -18,25 +18,33 @@ class Cbv::BaseController < ApplicationController
       if @cbv_flow.complete?
         return redirect_to(cbv_flow_expired_invitation_path)
       end
+
+      session[:cbv_flow_id] = @cbv_flow.id
       NewRelicEventTracker.track("ClickedCBVInvitationLink", {
         timestamp: Time.now.to_i,
         invitation_id: invitation.id,
         cbv_flow_id: @cbv_flow.id
       })
+
+      if @cbv_flow.pinwheel_accounts.any?
+        latest_connected_account = @cbv_flow.pinwheel_accounts.order(created_at: :desc).first
+        redirect_to cbv_flow_payment_details_path(
+          user: { account_id: latest_connected_account.pinwheel_account_id }
+        )
+      end
     elsif session[:cbv_flow_id]
       begin
         @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
       rescue ActiveRecord::RecordNotFound
-        return redirect_to root_url
+        redirect_to root_url
       end
     elsif params[:controller] == "cbv/entries"
       # TODO: Restrict ability to enter the flow without a valid token
       @cbv_flow = CbvFlow.create(site_id: "sandbox")
+      session[:cbv_flow_id] = @cbv_flow.id
     else
-      return redirect_to root_url, notice: t("cbv.error_missing_token")
+      redirect_to root_url, notice: t("cbv.error_missing_token")
     end
-
-    session[:cbv_flow_id] = @cbv_flow.id
   end
 
   def ensure_cbv_flow_not_yet_complete

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -30,6 +30,11 @@ export default class extends Controller {
         }
       }
     });
+    this.errorHandler = document.addEventListener("turbo:frame-missing", this.onTurboError)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:frame-missing", this.errorHandler)
   }
 
   onSignInSuccess() {
@@ -37,8 +42,12 @@ export default class extends Controller {
     this.modalTarget.click();
   }
 
-  onAccountError(event) {
-    console.log(event);
+  onTurboError(event) {
+    console.warn("Got turbo error, redirecting:", event)
+
+    const location = event.detail.response.url
+    event.detail.visit(location)
+    event.preventDefault()
   }
 
   async select(event) {

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+Rails.application.config.session_store :cookie_store,
+  key: "_iv_cbv_payroll_session",
+  expire_after: 30.minutes

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -88,7 +88,7 @@ en:
         your_employers_name: Your employer's name or the name of their payroll provider
         your_login_credentials: Your login credentials for the payroll provider account
     error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
-    error_missing_token: This page must be accessed by using an invitation link. Make sure you are clicking through the link you received in your email. If you continue experiencing issues, contact your caseworker.
+    error_missing_token: Your session has timed out due to inactivity. Click the link you received from your benefits agency to start from where you left off, or contact your benefits agency if you are having trouble.
     manual_flow_start: Start Flow Manually
     missing_results:
       show:

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Cbv::EntriesController do
       end
 
       context "when returning to an already-visited flow invitation" do
-        let(:existing_cbv_flow) { CbvFlow.create(case_number: "ABC1234", cbv_flow_invitation: invitation, site_id: "sandbox") }
+        let(:existing_cbv_flow) { create(:cbv_flow, cbv_flow_invitation: invitation) }
 
         it "uses the existing CbvFlow object" do
           expect { get :show, params: { token: invitation.auth_token } }
@@ -43,9 +43,44 @@ RSpec.describe Cbv::EntriesController do
                   .to(existing_cbv_flow.id)
         end
 
+        context "when the CbvFlow has already linked a employer/employers" do
+          let!(:older_connected_account) do
+            PinwheelAccount.create!(
+              cbv_flow: existing_cbv_flow,
+              pinwheel_account_id: SecureRandom.uuid,
+              created_at: 15.minutes.ago
+            )
+          end
+          let!(:connected_account) do
+            PinwheelAccount.create!(
+              cbv_flow: existing_cbv_flow,
+              pinwheel_account_id: SecureRandom.uuid,
+              created_at: 4.minutes.ago
+            )
+          end
+
+          it "redirects to the payment details page for the more recently linked employer" do
+            expect { get :show, params: { token: invitation.auth_token } }
+              .to change { session[:cbv_flow_id] }
+              .from(nil)
+              .to(existing_cbv_flow.id)
+
+            expect(response).to redirect_to(
+              cbv_flow_payment_details_path(user: { account_id: connected_account.pinwheel_account_id })
+            )
+          end
+        end
+
         context "when the CbvFlow was already completed" do
           before do
             existing_cbv_flow.update(confirmation_code: "FOOBAR")
+          end
+          let!(:connected_account) do
+            PinwheelAccount.create!(
+              cbv_flow: existing_cbv_flow,
+              pinwheel_account_id: SecureRandom.uuid,
+              created_at: 4.minutes.ago
+            )
           end
 
           it "redirects to the expired invitation URL" do


### PR DESCRIPTION
## Ticket

Finishes FFS-1294.

## Changes

This commit tweaks the session logic by:
1. Configuring Rails to set the `Expires` cookie header, so browsers
   will automatically stop sending the cookie. In this case, the user
   will be redirected to the homepage with a message telling them to go
   back and click the link again.
2. If the user clicks the invitation link again, they will resume from
   the /entry page if they haven't connected any Pinwheel accounts, or,
   if they have, they will resume from the payment details page of the
   most recently-connected account.

## Context for reviewers

N/A

## Testing

Tested locally by deleting my cookie and checking that:
* Deleting cookie returns me to homepage with "session expired" message
* Deleting cookie after linking 1 employer, and clicking the link again takes
  me to the payment details page for the employer I had just linked
* Linking another employer, and then deleting the cookie again and clicking the
  link again takes me to the payment details page of the second employer
