### PR TITLE
Update the <title> doc tag for pages to reference the first H1 on a given page. 

### DIFF
--- a/app/app/views/cbv/add_jobs/show.html.erb
+++ b/app/app/views/cbv/add_jobs/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
 <p><%= t(".subheader", pay_income_days: current_site.pay_income_days) %></p>
 

--- a/app/app/views/cbv/agreements/show.html.erb
+++ b/app/app/views/cbv/agreements/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
 <h2><%= t(".subheader") %></h2>
 <ol class="usa-process-list">

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1>
   <%= t(".header") %>
 </h1>

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
 
 <p><%= t(".subheader") %></p>

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
 <p class="line-height-sans-5"><%= t(".not_listed_p1") %></p>
 <p class="line-height-sans-5"><%= t(".not_listed_p2", agency_short_name: current_site.agency_short_name) %></p>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1>
   <% if employer_name %>
     <%= t(".header", employer_name: employer_name) %>

--- a/app/app/views/cbv/shares/show.html.erb
+++ b/app/app/views/cbv/shares/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1>
   <%= t(".header") %>
 </h1>

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
 
 <ul>

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -1,13 +1,15 @@
-<h2>
+<% content_for :title, t(".header") %>
+
+<h1>
   <%= t(".header") %>
-</h2>
+</h1>
 
 <% if @payments.any? %>
   <div class="width-full margin-bottom-6">
     <p>
       <%= t(".description") %>
     </p>
-    <h3 class="site-preview-heading"><%= t(".total_payments", amount: format_money(total_gross_income)) %></h3>
+    <h2 class="site-preview-heading"><%= t(".total_payments", amount: format_money(total_gross_income)) %></h2>
 
     <% payments_grouped_by_employer.each_with_index do |(account_id, summary), index| %>
       <table class="usa-table usa-table--borderless width-full">
@@ -45,9 +47,9 @@
     <% end %>
   </div>
 <% else %>
-  <h3 class="site-preview-heading">
+  <h2 class="site-preview-heading">
     <%= t(".none_found") %>
-  </h3>
+  </h2>
 <% end %>
 
 <%= form_for(@cbv_flow, url: cbv_flow_summary_path, builder: UswdsFormBuilder) do |f| %>

--- a/app/app/views/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/cbv_flow_invitations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".header") %>
+
 <h1><%= t(".header") %></h1>
 <%= t(".description_html", pay_income_days: current_site.pay_income_days) %>
 

--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title>Verify.gov</title>
+    <title><%= content_for?(:title) ? yield(:title) : "" %> | SNAP Income Pilot</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/app/views/pages/home.html.erb
+++ b/app/app/views/pages/home.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t(".header") %>
+
 <h1><%= t("shared.verify.welcome") %></h1>
 <h2><%= t("shared.verify.description") %></h2>
 

--- a/app/app/views/sso/index.html.erb
+++ b/app/app/views/sso/index.html.erb
@@ -1,1 +1,2 @@
+<% content_for :title, t("shared.sso.sign_in") %>
 <%= render partial: "sso/#{@current_site.sso['name']}_signin_button" %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -221,6 +221,8 @@ en:
     not_applicable: N/A
     pilot_name: SNAP Income Pilot
     skip_link: Skip to main content
+    sso:
+      sign_in: Sign in
     verify:
       description: This website can help you get approved for your benefits.
       subheader: Get started here by requesting a link from your caseworker.

--- a/app/spec/support/title_checker_helper.rb
+++ b/app/spec/support/title_checker_helper.rb
@@ -1,0 +1,60 @@
+module AutoTitleTestHelper
+  H1_REGEX = /<h1>(.*?)<\/h1>/im
+  TITLE_REGEX = /<title>(.*?)<\/title>/im
+  INTERPOLATION_REGEX = /%\{.*?}/
+
+  def assert_title_contains_h1(response_body)
+    h1_content = decode_html_entities(extract_content(response_body, H1_REGEX))
+    expect(h1_content).to be_present, "H1 is missing"
+
+    title_content = decode_html_entities(extract_content(response_body, TITLE_REGEX))
+    expect(title_content).to be_present, "Title is missing"
+
+    cleaned_title = remove_interpolation_placeholders(title_content)
+    main_title = cleaned_title.split('|').first.strip
+
+    expect(h1_content).to include(main_title), "H1 and title content differ: `#{h1_content}` vs `#{main_title}`"
+  end
+
+  private
+
+  def extract_content(html, regex)
+    match = html.match(regex)
+    match ? match[1].strip : nil
+  end
+
+  def remove_interpolation_placeholders(text)
+    text.gsub(INTERPOLATION_REGEX, '').squeeze(' ').strip
+  end
+
+  def decode_html_entities(text)
+    CGI.unescapeHTML(text)
+  end
+end
+
+RSpec.configure do |config|
+  config.include AutoTitleTestHelper, type: :controller
+
+  config.before(:suite) do
+    config.instance_variable_set(:@checked_routes, Set.new)
+  end
+
+  config.after(:each, type: :controller) do |example|
+    if should_check_title?(request, response)
+      route_key = "#{request.method}:#{request.path}"
+      checked_routes = config.instance_variable_get(:@checked_routes)
+
+      unless checked_routes.include?(route_key)
+        assert_title_contains_h1(response.body)
+        checked_routes.add(route_key)
+      end
+    end
+  end
+
+  def should_check_title?(request, response)
+    (request.get? || request.params[:action] == 'show') &&
+      !%w[new create].include?(request.params[:action]) &&
+      response.status == 200 &&
+      response.content_type =~ /html/
+  end
+end


### PR DESCRIPTION
Closes FFS-1320

## Changes

- Adds a `content_for` view helper to each page with a `#show` method.
- Adds a `title_check_helper` Test helper which verifies that the title and top H1 tag in a page match
- - Only works on GET requests that return a 200 response.
- - Does not assert requests which are redirected to other pages
- - Fails when no H1 tag is present
- - Fails when no title attribute is found for the given page (not likely)

## Testing

I test this locally in various ways. For verifying that the <title> is updated I visually confirmed that the webpage's title was successfully updated and includes the `| SNAP Income Pilot` suffix. The `title_checker_helper` also uncovered several pages without titles or improper heading hierarchies. 
<img width="1276" alt="Screenshot 2024-08-16 at 5 17 12 PM" src="https://github.com/user-attachments/assets/f8a7ecc3-f7af-4e17-9632-e6ca5f26f3f9">


<img width="819" alt="Screenshot 2024-08-16 at 5 31 35 PM" src="https://github.com/user-attachments/assets/88163d53-4fe8-43e0-ae1c-8b33c3588038">
<img width="403" alt="Screenshot 2024-08-16 at 5 19 21 PM" src="https://github.com/user-attachments/assets/869c8ba6-75b7-4e79-a90e-5c7a6688ba43">
<img width="505" alt="Screenshot 2024-08-16 at 5 18 43 PM" src="https://github.com/user-attachments/assets/fb25b23a-115f-4c39-a492-b897c1ac4440">
<img width="572" alt="Screenshot 2024-08-16 at 5 18 13 PM" src="https://github.com/user-attachments/assets/f6eec89b-5d50-4a72-93a1-06613f491660">

