### PR TITLE
Ignore CMS confluence links in Markdown linting

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -8,6 +8,9 @@
         },
         {
             "pattern": "127.0.0.1"
+        },
+        {
+          "pattern": "^https://confluenceent.cms.gov"
         }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
## Ticket

N/A

## Changes
These are all authenticated pages, so there's no way we'll actually be
able to tell whether the page exists there from our Github Action. And,
we've been getting some flaky failures here lately, so let's just skip
those links.

## Context for reviewers

N/A

## Testing

N/A
