### PR TITLE
Fix 2 bugs in the `site_translation` helper

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -19,6 +19,15 @@ module ApplicationHelper
       else
         default_key
       end
+    is_html_key = /(?:_|\b)html\z/.match?(i18n_base_key)
+    if is_html_key
+      options.each do |name, value|
+        next if name == :count && value.is_a?(Numeric)
+
+        # Sanitize values being interpolated into this string.
+        options[name] = ERB::Util.html_escape(value.to_s)
+      end
+    end
 
     translated =
       if I18n.exists?(scope_key_by_partial(i18n_key))
@@ -32,7 +41,7 @@ module ApplicationHelper
     # We have to replicate the logic from ActiveSupport::HtmlSafeTranslation
     # because the base key is the one that ends with "_html", not the one we
     # ultimately pass into the translation library.
-    if /(?:_|\b)html\z/.match?(i18n_base_key) && translated.present?
+    if is_html_key && translated.present?
       translated.html_safe
     else
       translated

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -8,14 +8,15 @@ module ApplicationHelper
   #   default: Default String
   #
   # Then call this method with, `site_translation("foo")` and it will attempt
-  # to render the nested translation according to the current site ID, or use
-  # the "default" string if the translation is either missing or there is no
-  # current site.
+  # to render the nested translation according to the site returned by a
+  # `current_site` method defined by your controller/mailer. If the translation
+  # is either missing or there is no current site, it will attempt to render a
+  # "default" key.
   def site_translation(i18n_base_key, **options)
     default_key = "#{i18n_base_key}.default"
     i18n_key =
-      if @current_site
-        "#{i18n_base_key}.#{@current_site.id}"
+      if current_site
+        "#{i18n_base_key}.#{current_site.id}"
       else
         default_key
       end

--- a/app/app/mailers/applicant_mailer.rb
+++ b/app/app/mailers/applicant_mailer.rb
@@ -1,5 +1,6 @@
 class ApplicantMailer < ApplicationMailer
   helper :view, :application
+  helper_method :current_site
   before_action :set_params
 
   def invitation_email
@@ -13,6 +14,9 @@ class ApplicantMailer < ApplicationMailer
 
   def set_params
     @cbv_flow_invitation = params[:cbv_flow_invitation]
-    @current_site = site_config[@cbv_flow_invitation.site_id]
+  end
+
+  def current_site
+    site_config[@cbv_flow_invitation.site_id]
   end
 end

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -2,7 +2,7 @@
   <div class="bg-white padding-y-7 padding-x-7 border border-base-lighter measure-5 line-height-sans-4 margin-x-auto font-body-xs">
     <h3>
       <span class="text-primary"><%= t("shared.pilot_name") %> | </span>
-      <% if @current_site.id == "ma" %>
+      <% if current_site.id == "ma" %>
         <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
       <% else %>
         <%= site_translation("shared.header.cbv_flow_title") %>
@@ -18,7 +18,7 @@
 
       <p>
         <%= t(".body_html",
-          agency_acronym: @current_site.agency_short_name,
+          agency_acronym: current_site.agency_short_name,
           deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %>
       </p>
 

--- a/app/spec/controllers/caseworker/cbv_flow_invitations/ma_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations/ma_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
         expect(response.body).to include("snap_application_date")
         expect(response.body).to include("beacon_id")
       end
+
+      it "renders the header for MA" do
+        get :new, params: ma_params
+        expect(response.body).to include(I18n.t("shared.header.cbv_flow_title.ma"))
+      end
     end
   end
 

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe ApplicationHelper do
     YAML
 
     before do
-      helper.instance_variable_set(:@current_site, current_site)
+      without_partial_double_verification do
+        allow(helper).to receive(:current_site).and_return(current_site)
+      end
     end
 
     around do |example|
@@ -23,7 +25,7 @@ RSpec.describe ApplicationHelper do
       I18n.backend = previous_backend
     end
 
-    context "when the @current_site is specified" do
+    context "when the current_site is specified" do
       it "uses the translation for the proper key" do
         expect(helper.site_translation("some_prefix")).to eq("some string")
       end
@@ -37,7 +39,7 @@ RSpec.describe ApplicationHelper do
       end
     end
 
-    context "when the @current_site is nil" do
+    context "when the current_site is nil" do
       let(:current_site) { nil }
 
       it "uses the translation for the default key" do

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#site_translation" do
+    let(:current_site) { Rails.application.config.sites["nyc"] }
+    let(:available_translations) { <<~YAML }
+      some_prefix:
+        nyc: some string
+        default: default string
+    YAML
+
+    before do
+      helper.instance_variable_set(:@current_site, current_site)
+    end
+
+    around do |example|
+      # Replace our actual I18n strings with the ones specified in the test
+      # variable (available_translations) above.
+      previous_backend = I18n.backend
+      I18n.backend = I18n::Backend::Simple.new
+      I18n.backend.store_translations(:en, YAML.load(available_translations))
+      example.run
+      I18n.backend = previous_backend
+    end
+
+    context "when the @current_site is specified" do
+      it "uses the translation for the proper key" do
+        expect(helper.site_translation("some_prefix")).to eq("some string")
+      end
+
+      context "when there is not a translation for that site" do
+        let(:current_site) { Rails.application.config.sites["ma"] }
+
+        it "uses the translation for the default key" do
+          expect(helper.site_translation("some_prefix")).to eq("default string")
+        end
+      end
+    end
+
+    context "when the @current_site is nil" do
+      let(:current_site) { nil }
+
+      it "uses the translation for the default key" do
+        expect(helper.site_translation("some_prefix")).to eq("default string")
+      end
+    end
+
+    context "when there are variables to interpolate" do
+      let(:available_translations) { <<~YAML }
+        some_prefix:
+          nyc: some %{variable}
+          default: default string
+      YAML
+
+      it "interpolates the variables" do
+        expect(helper.site_translation("some_prefix", variable: "string")).to eq("some string")
+      end
+    end
+
+    context "when the key ends with _html" do
+      let(:available_translations) { <<~YAML }
+        some_prefix_html:
+          nyc: some <strong>bold</strong> text
+          ma: some %{variable} text
+          default: default string
+      YAML
+
+      it "marks the string as HTML safe" do
+        expect(helper.site_translation("some_prefix_html")).to eq("some <strong>bold</strong> text")
+        expect(helper.site_translation("some_prefix_html")).to be_html_safe
+      end
+
+      context "when interpolating a variable" do
+        let(:current_site) { Rails.application.config.sites["ma"] }
+
+        it "sanitizes input parameters" do
+          expect(helper.site_translation("some_prefix_html", variable: "<strong>bold</strong>"))
+            .to eq("some &lt;strong&gt;bold&lt;/strong&gt; text")
+          expect(helper.site_translation("some_prefix_html")).to be_html_safe
+        end
+
+        it "does not sanitize html_safe input parameters" do
+          expect(helper.site_translation("some_prefix_html", variable: "<strong>bold</strong>".html_safe))
+            .to eq("some <strong>bold</strong> text")
+          expect(helper.site_translation("some_prefix_html")).to be_html_safe
+        end
+      end
+    end
+  end
+end

--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
     let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :nyc, email_address: email) }
 
     it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.header.nyc'))
       expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
         agency_acronym: 'HRA',
         deadline: "July 21, 2024")
@@ -50,6 +51,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
     let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :ma, email_address: email) }
 
     it "renders the body" do
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.header.ma'))
       expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
         agency_acronym: 'DTA',
         deadline: "July 21, 2024")


### PR DESCRIPTION
## Ticket

N/A - Bug I noticed

## Changes

This fixes two bugs in the `site_translation` helper:

1. I realized that the `site_translation` helper wasn't sanitizing HTML the
same way that Rails's `t` helper does. I copied the implementation here.
Since it's getting unwieldly, I wrote some unit tests.

2. It wasn't displaying the correct header on the invitations page, because
the `@current_site` variable wasn't being set by the controller. Since this is
very weird for a function to rely on the definition of an
instance variable, let's go back to it just calling the `current_site`
method and make it explicit in the documentation string that each
controller/mailer has to define a `current_site` method.

## Context for reviewers

N/A

## Testing

Unit tests included, and I'm going to run through the site end-to-end to verify that no translations are double-escaped now.
