### PR TITLE
Revert "Use "Strict" Set-Cookie SameSite value"

### DIFF
--- a/app/config/environments/development.rb
+++ b/app/config/environments/development.rb
@@ -26,9 +26,6 @@ Rails.application.configure do
   routes.default_url_options[:host] = ENV.fetch("DOMAIN_NAME", "localhost")
   routes.default_url_options[:port] = ENV.fetch("PORT", 3000)
 
-  # Don't send cookies on requests to other origins
-  config.action_dispatch.cookies_same_site_protection = :strict
-
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?

--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -43,9 +43,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Don't send cookies on requests to other origins
-  config.action_dispatch.cookies_same_site_protection = :strict
-
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"


### PR DESCRIPTION
## Ticket

N/A - Reported by the team.

## Changes

This reverts commit 5b788c91a1a1fb8192d805d017cf117284f8dd64.


## Context for reviewers

Reading the definition of "SameSite=Strict" a bit closer, it says

> If a request originates from a different domain or scheme (even with
> the same domain), no cookies with the SameSite=Strict attribute are
> sent.

This was breaking SSO because the session cookie wasn't being sent to
the OmniAuth callbacks controller, since the navigation request
originates from a different domain (Microsoft's SSO page).

We don't actually need Set-Cookie=Strict for security reasons, it's only
a nice-to-have.

## Testing

Tested locally - it was reproducible in an incognito window, and I was able to verify that this fix works.
