### PR TITLE
Implement welcome page designs on homepage

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -8,7 +8,11 @@ html {
   min-width: 360px;
 }
 #main-content {
-  min-height: 70vh; // Push the footer down lower if the page is short
+  // These are rough approximations just to roughly get the footer to show up
+  // at the bottom of the screen by default.
+  $header-height: 4.5rem;
+  $footer-height: 5rem;
+  min-height: calc(100vh - $header-height - $footer-height);
 }
 
 /*

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -38,12 +38,8 @@ class Cbv::BaseController < ApplicationController
       rescue ActiveRecord::RecordNotFound
         redirect_to root_url
       end
-    elsif params[:controller] == "cbv/entries"
-      # TODO: Restrict ability to enter the flow without a valid token
-      @cbv_flow = CbvFlow.create(site_id: "sandbox")
-      session[:cbv_flow_id] = @cbv_flow.id
     else
-      redirect_to root_url, notice: t("cbv.error_missing_token")
+      redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
     end
   end
 

--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -40,10 +40,14 @@
             <div class="usa-alert usa-alert--<%= flash[:slim_alert]["type"] %> usa-alert--slim">
               <div class="usa-alert__body">
                 <p class="usa-alert__text">
-                  <%= flash[:slim_alert]["message"] %>
+                  <% if flash[:slim_alert]["message_html"] %>
+                    <%= flash[:slim_alert]["message_html"].html_safe %>
+                  <% elsif flash[:slim_alert]["message"] %>
+                    <%= flash[:slim_alert]["message"] %>
+                  <% end %>
                 </p>
               </div>
-          </div>
+            </div>
           <% end %>
           <%= yield %>
         </section>

--- a/app/app/views/pages/home.html.erb
+++ b/app/app/views/pages/home.html.erb
@@ -1,10 +1,7 @@
-<% welcome = t("shared.verify.welcome") %>
+<% welcome = t(".header") %>
 <% content_for :title, welcome %>
 <h1><%= welcome %></h1>
-<h2><%= t("shared.verify.description") %></h2>
 
-<p><%= t("shared.verify.subheader") %></p>
-
-<%= link_to cbv_flow_entry_path do %>
-  <button class="usa-button usa-button--outline" type="button"><%= t("cbv.manual_flow_start") %></button>
-<% end %>
+<p><%= t(".description_1") %></p>
+<p><%= t(".description_2") %></p>
+<%= t(".description_3_html") %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -148,8 +148,7 @@ en:
         your_employers_name: Your employer's name or the name of their payroll provider
         your_login_credentials: Your login credentials for the payroll provider account
     error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
-    error_missing_token: Your session has timed out due to inactivity. Click the link you received from your benefits agency to start from where you left off, or contact your benefits agency if you are having trouble.
-    manual_flow_start: Start Flow Manually
+    error_missing_token_html: "<strong>Your session has timed out due to inactivity.</strong> To continue where you left off, please click the link you received from your benefits agency in your email. If you encounter any issues, contact your benefits agency for assistance."
     missing_results:
       show:
         back_button: Go back to employer search
@@ -230,6 +229,12 @@ en:
         total_payments_desc: This is the total income from your job(s) before taxes, benefits and deductions were taken out of your paycheck.
       update:
         consent_to_authorize_warning: You must check the legal agreement checkbox to proceed.
+  pages:
+    home:
+      description_1: The SNAP Income Pilot is a new tool designed to help you connect your income details from your employer or payroll provider directly to your benefits agency. We're currently testing this tool to ensure it works effectively.
+      description_2: Please note this pilot is currently available only to SNAP participants in New York City and Massachusetts.
+      description_3_html: '<p>To participate, you can request an invitation from your benefits agency:</p><ul><li>Massachusetts applicants: Contact the <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank">Department of Transitional Assistance (DTA)</a></li><li>New York City applicants: Contact the <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Human Resources Administration (HRA)</a></li></ul>'
+      header: Welcome to the SNAP Income Pilot
   shared:
     banner:
       lock: Lock
@@ -259,10 +264,6 @@ en:
     skip_link: Skip to main content
     sso:
       sign_in: Sign in
-    verify:
-      description: This website can help you get approved for your benefits.
-      subheader: Get started here by requesting a link from your caseworker.
-      welcome: Welcome to Verify.gov
   us_form_with:
     boolean_false: 'No'
     boolean_true: 'Yes'

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -4,21 +4,20 @@ RSpec.describe Cbv::EntriesController do
   describe "#show" do
     render_views
 
-    it "renders properly" do
-      get :show
-
-      expect(response).to be_successful
-    end
-
-    it "sets a CbvFlow object in the session" do
+    it "redirects the user back to the homepage" do
       expect { get :show }
-        .to change { session[:cbv_flow_id] }
-              .from(nil)
-              .to(be_an(Integer))
+        .not_to change { session[:cbv_flow_id] }
+      expect(response).to redirect_to(root_url)
     end
 
     context "when following a link from a flow invitation" do
       let(:invitation) { create(:cbv_flow_invitation, case_number: "ABC1234") }
+
+      it "renders properly" do
+        get :show, params: { token: invitation.auth_token }
+
+        expect(response).to be_successful
+      end
 
       it "sets a CbvFlow object based on the invitation" do
         expect { get :show, params: { token: invitation.auth_token } }


### PR DESCRIPTION
## Ticket

Resolves FFS-1373.

## Changes

* This implements the "/welcome" styles on the homepage
* I've made a second attempt at moving the footer down so it's not so
  big for short pages (like the homepage).
* Since the homepage no longer has the "Start flow manually" button,
  I've removed the functionality allowing starting a flow without an
  invitation.
* Adds a "message_html" option to slim alert in case you want to do some
  bold text or something in one of those alerts

## Context for reviewers

N/A

## Testing

Screenshots below.
