### PR TITLE
Add NYC_HRA_EMAIL as environment variable

### DIFF
--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -42,6 +42,12 @@ locals {
       ssm_param_name = "/service/${var.app_name}-${var.environment}/newrelic-key"
     },
 
+    # Transmission Configuration:
+    {
+      name           = "NYC_HRA_EMAIL"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/nyc-hra-email"
+    },
+
     # Pinwheel Configuration:
     {
       name           = "PINWHEEL_API_TOKEN_PRODUCTION"


### PR DESCRIPTION
## Ticket

N/A

## Changes

I added this to demo and prod ParamaterStores. The value in dev is our
eng team's google group, and the value in prod is the actual value.

## Context for reviewers

## Testing

We will test during E2E testing with NYC.
