### PR TITLE
Implement remaining product metrics

### DIFF
--- a/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
+++ b/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
@@ -11,7 +11,7 @@ class Caseworker::CbvFlowInvitationsController < ApplicationController
   def create
     begin
       invitation_params = base_params.merge(site_specific_params)
-      CbvInvitationService.new.invite(invitation_params)
+      CbvInvitationService.new.invite(invitation_params, current_user)
     rescue => ex
       flash[:alert] = t(".invite_failed",
                         email_address: cbv_flow_invitation_params[:email_address],

--- a/app/app/controllers/cbv/agreements_controller.rb
+++ b/app/app/controllers/cbv/agreements_controller.rb
@@ -6,6 +6,7 @@ class Cbv::AgreementsController < Cbv::BaseController
     if params["agreement"] == "1"
       NewRelicEventTracker.track("ApplicantAgreed", {
         timestamp: Time.now.to_i,
+        site_id: @cbv_flow.site_id,
         cbv_flow_id: @cbv_flow.id
       })
       redirect_to next_path

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -24,7 +24,8 @@ class Cbv::BaseController < ApplicationController
         timestamp: Time.now.to_i,
         invitation_id: invitation.id,
         cbv_flow_id: @cbv_flow.id,
-        site_id: @cbv_flow.site_id
+        site_id: @cbv_flow.site_id,
+        seconds_since_invitation: (Time.now - invitation.created_at).to_i
       })
 
       if @cbv_flow.pinwheel_accounts.any?

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -23,7 +23,8 @@ class Cbv::BaseController < ApplicationController
       NewRelicEventTracker.track("ClickedCBVInvitationLink", {
         timestamp: Time.now.to_i,
         invitation_id: invitation.id,
-        cbv_flow_id: @cbv_flow.id
+        cbv_flow_id: @cbv_flow.id,
+        site_id: @cbv_flow.site_id
       })
 
       if @cbv_flow.pinwheel_accounts.any?

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -15,6 +15,7 @@ class Cbv::SummariesController < Cbv::BaseController
       format.pdf do
         NewRelicEventTracker.track("ApplicantDownloadedIncomePDF", {
           timestamp: Time.now.to_i,
+          site_id: @cbv_flow.site_id,
           cbv_flow_id: @cbv_flow.id
         })
 
@@ -75,6 +76,7 @@ class Cbv::SummariesController < Cbv::BaseController
 
     NewRelicEventTracker.track("IncomeSummarySharedWithCaseworker", {
       timestamp: Time.now.to_i,
+      site_id: @cbv_flow.site_id,
       cbv_flow_id: @cbv_flow.id
     })
   end

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -85,7 +85,8 @@ class Cbv::SummariesController < Cbv::BaseController
       account_count: payments.map { |p| p[:account_id] }.uniq.count,
       paystub_count: payments.count,
       account_count_with_additional_information:
-        cbv_flow.additional_information.values.count { |info| info["comment"].present? }
+        cbv_flow.additional_information.values.count { |info| info["comment"].present? },
+      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i
     })
   rescue => ex
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"

--- a/app/app/services/cbv_invitation_service.rb
+++ b/app/app/services/cbv_invitation_service.rb
@@ -1,13 +1,11 @@
 class CbvInvitationService
-  def invite(cbv_flow_invitation_params)
+  def invite(cbv_flow_invitation_params, current_user)
     begin
       cbv_flow_invitation = CbvFlowInvitation.create!(cbv_flow_invitation_params)
       send_invitation_email(cbv_flow_invitation)
-      NewRelicEventTracker.track("ApplicantInvitedToFlow", {
-        timestamp: Time.now.to_i,
-        site_id: cbv_flow_invitation.site_id,
-        invitation_id: cbv_flow_invitation.id
-      })
+      track_event(cbv_flow_invitation, current_user)
+
+      cbv_flow_invitation
     rescue => e
       Rails.logger.error("Error inviting applicant: #{e.message}")
       raise e
@@ -15,6 +13,15 @@ class CbvInvitationService
   end
 
   private
+
+  def track_event(cbv_flow_invitation, current_user)
+    NewRelicEventTracker.track("ApplicantInvitedToFlow", {
+      timestamp: Time.now.to_i,
+      user_id: current_user.id,
+      site_id: cbv_flow_invitation.site_id,
+      invitation_id: cbv_flow_invitation.id
+    })
+  end
 
   def send_invitation_email(cbv_flow_invitation)
     ApplicantMailer.with(cbv_flow_invitation: cbv_flow_invitation).invitation_email.deliver_now

--- a/app/app/services/cbv_invitation_service.rb
+++ b/app/app/services/cbv_invitation_service.rb
@@ -5,6 +5,7 @@ class CbvInvitationService
       send_invitation_email(cbv_flow_invitation)
       NewRelicEventTracker.track("ApplicantInvitedToFlow", {
         timestamp: Time.now.to_i,
+        site_id: cbv_flow_invitation.site_id,
         invitation_id: cbv_flow_invitation.id
       })
     rescue => e

--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -56,9 +56,9 @@ ci:
   # It doesn't make sense to report to New Relic from automated test runs.
   monitor_mode: false
 
-staging:
+demo:
   <<: *default_settings
-  app_name: Iv Cbv Payroll (Staging)
+  app_name: Iv Cbv Payroll (Demo)
 
 production:
   <<: *default_settings

--- a/app/spec/controllers/caseworker/cbv_flow_invitations/auth_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations/auth_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
     before do
       allow_any_instance_of(CbvInvitationService)
         .to receive(:invite)
-        .with(ActionController::Parameters.new(email_address: "test@example.com", case_number: "ABC1234", site_id: site_id).permit!)
     end
 
     context "without authentication" do
@@ -103,7 +102,7 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
       it "sends an invitation" do
         expect_any_instance_of(CbvInvitationService)
           .to receive(:invite)
-          .with(ActionController::Parameters.new(email_address: "test@example.com", case_number: "ABC1234", site_id: site_id).permit!)
+          .with(hash_including(email_address: "test@example.com", case_number: "ABC1234", site_id: site_id), nyc_user)
 
         post :create, params: valid_params
 
@@ -120,14 +119,14 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
         before do
           allow_any_instance_of(CbvInvitationService)
             .to receive(:invite)
-            .with(ActionController::Parameters.new(email_address: "bad-email@", case_number: "ABC1234", site_id: site_id).permit!)
+            .with(hash_including(email_address: "bad-email@", case_number: "ABC1234", site_id: site_id), nyc_user)
             .and_raise(StandardError.new("Some random error, like a bad email address or something."))
         end
 
         it "redirects back to the invitation form with the error" do
           expect_any_instance_of(CbvInvitationService)
             .to receive(:invite)
-            .with(ActionController::Parameters.new(email_address: "bad-email@", case_number: "ABC1234", site_id: site_id).permit!)
+            .with(hash_including(email_address: "bad-email@", case_number: "ABC1234", site_id: site_id), nyc_user)
 
           post :create, params: broken_params
 

--- a/app/spec/controllers/caseworker/cbv_flow_invitations/nyc_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations/nyc_spec.rb
@@ -68,5 +68,23 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
       expect(response).to redirect_to(caseworker_dashboard_path(site_id: nyc_params[:site_id]))
     end
+
+    it "sends an event to NewRelic" do
+      allow(NewRelicEventTracker).to receive(:track)
+
+      post :create, params: {
+        secret: invite_secret,
+        site_id: nyc_params[:site_id],
+        cbv_flow_invitation: cbv_flow_invitation_params
+      }
+
+      invitation = CbvFlowInvitation.last
+      expect(NewRelicEventTracker).to have_received(:track).with("ApplicantInvitedToFlow", {
+        timestamp: be_a(Integer),
+        user_id: user.id,
+        site_id: "nyc",
+        invitation_id: invitation.id
+      })
+    end
   end
 end

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -140,6 +140,19 @@ RSpec.describe Cbv::SummariesController do
         patch :update
         expect(response).to redirect_to({ controller: :successes, action: :show })
       end
+
+      it "sends a NewRelic event" do
+        allow(NewRelicEventTracker).to receive(:track)
+        patch :update
+        expect(NewRelicEventTracker).to have_received(:track).with("IncomeSummarySharedWithCaseworker", {
+          timestamp: be_a(Integer),
+          site_id: cbv_flow.site_id,
+          cbv_flow_id: cbv_flow.id,
+          account_count: 1,
+          paystub_count: 1,
+          account_count_with_additional_information: 0
+        })
+      end
     end
   end
 end

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -3,11 +3,18 @@ require "rails_helper"
 RSpec.describe Cbv::SummariesController do
   include PinwheelApiHelper
 
-  let(:cbv_flow) { create(:cbv_flow, case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi") }
+  let(:flow_started_seconds_ago) { 300 }
+  let(:cbv_flow) do
+    create(:cbv_flow, case_number: "ABC1234", pinwheel_token_id: "abc-def-ghi", created_at: flow_started_seconds_ago.seconds.ago)
+  end
   let(:cbv_flow_invitation) { cbv_flow.cbv_flow_invitation }
 
   before do
     session[:cbv_flow_invitation] = cbv_flow_invitation
+  end
+
+  around do |ex|
+    Timecop.freeze(&ex)
   end
 
   describe "#show" do
@@ -150,7 +157,8 @@ RSpec.describe Cbv::SummariesController do
           cbv_flow_id: cbv_flow.id,
           account_count: 1,
           paystub_count: 1,
-          account_count_with_additional_information: 0
+          account_count_with_additional_information: 0,
+          flow_started_seconds_ago: flow_started_seconds_ago
         })
       end
     end

--- a/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe Users::OmniauthCallbacksController do
       expect(controller.current_user).to eq(new_user)
     end
 
+    it "tracks a NewRelic event" do
+      expect(NewRelicEventTracker).to receive(:track).with("CaseworkerLogin", {
+        site_id: "ma",
+        user_id: be_a(Integer)
+      })
+
+      post :ma_dta
+    end
+
     context "when the user already has authenticated before" do
       let!(:existing_user) { User.create(email: test_email, site_id: "ma") }
 

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -41,6 +41,10 @@ locals {
       name           = "NEWRELIC_KEY"
       ssm_param_name = "/service/${var.app_name}-${var.environment}/newrelic-key"
     },
+    {
+      name           = "NEW_RELIC_ENV"
+      ssm_param_name = "/service/${var.app_name}-${var.environment}/new-relic-env"
+    },
 
     # Transmission Configuration:
     {


### PR DESCRIPTION
## Ticket

Resolves FFS-705.

## Changes

- **Track NewRelic event for CaseworkerLogin**
- **Add `site_id` to all NewRelic events**
- **Add `user_id` to ApplicantInvitedToFlow NewRelic events**
- **Add more metadata when tracking PDF share event**
- **Track seconds between invitation sent, flow start, and completion**

## Context for reviewers

When we initially implemented NewRelic, it was too early and we didn't have all
the constructs necessary to instrument these product metrics. Now, we do, so
I've added metadata to various parts in order to capture all the metrics in the
attached ticket.

## Testing

Now that the NewRelic account is set up, the easiest way to validate this change
is to merge this, build the dashboards, and then accept the ticket based off of
the dashboards as data flows in.