### PR TITLE
Fix SSO bug for email addresses with capital letters

### DIFF
--- a/app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -27,7 +27,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def login_with_oauth(email, site_id)
     # TODO: Check that the email is permissible according to its domain
-    @user = User.find_or_create_by(email: email, site_id: site_id)
+    @user = User.find_for_authentication(email: email, site_id: site_id)
+    @user ||= User.create(email: email, site_id: site_id)
 
     if @user&.persisted?
       flash[:notice] = "Signed in!"

--- a/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Users::OmniauthCallbacksController do
           .not_to change(User, :count)
         expect(controller.current_user).to eq(existing_user)
       end
+
+      context "when the email address has a capital letter in it" do
+        let(:test_email) { "FOO@example.com" }
+
+        it "logs the user into the existing User" do
+          expect { post :ma_dta }
+            .not_to change(User, :count)
+          expect(controller.current_user).to eq(existing_user)
+        end
+      end
     end
 
     # Re-using the same email across multiple sites should be only


### PR DESCRIPTION
## Ticket

N/A - Needed for NYC to log in for dynamic security scan.

## Changes

Devise will convert the `email` field to lowercase, as configured by
config.case_insensitive_keys. When searching for an account, we need to
use Devise's `find_for_authentication` method so it will apply the same
transformation.

## Context for reviewers

N/A

## Testing

Regression test included. I also tested logging into an existing account as
well as a new account to verify it works.
