### PR TITLE
fixed header/title error occurring on payment details page

### DIFF
--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -1,10 +1,7 @@
-<% content_for :title, t(".header") %>
+<% header = employer_name ? t(".header", employer_name: employer_name) : t(".header_no_employer_name") %>
+<% content_for :title, header %>
 <h1>
-  <% if employer_name %>
-    <%= t(".header", employer_name: employer_name) %>
-  <% else %>
-    <%= t(".header_no_employer_name") %>
-  <% end %>
+  <%= header %>
 </h1>
 
 <p><%= t(".subheader", start_date: format_date(start_date), end_date: format_date(end_date)) %></p>


### PR DESCRIPTION
## Ticket

Resolves https://nava.slack.com/archives/C06FC5TPAR3/p1724254549569479

## Changes

Fixes a bug whereas the header and title for the payment details page was not being properly interpolated.

## Tests
Visually inspected the browser page and compared the updated title with the current title

### previous
![image_480](https://github.com/user-attachments/assets/cad62027-6326-4864-974f-b17e8451875c)

### new
![Screenshot 2024-08-21 at 3 20 52 PM](https://github.com/user-attachments/assets/28d28f22-9261-496a-b73c-2850b1696b80)
