### PR TITLE
Create new `CbvFlow` object every time an invite link is clicked

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -13,12 +13,11 @@ class Cbv::BaseController < ApplicationController
       if invitation.expired?
         return redirect_to(cbv_flow_expired_invitation_path)
       end
-
-      @cbv_flow = invitation.cbv_flow || CbvFlow.create_from_invitation(invitation)
-      if @cbv_flow.complete?
+      if invitation.complete?
         return redirect_to(cbv_flow_expired_invitation_path)
       end
 
+      @cbv_flow = CbvFlow.create_from_invitation(invitation)
       session[:cbv_flow_id] = @cbv_flow.id
       NewRelicEventTracker.track("ClickedCBVInvitationLink", {
         timestamp: Time.now.to_i,
@@ -27,13 +26,6 @@ class Cbv::BaseController < ApplicationController
         site_id: @cbv_flow.site_id,
         seconds_since_invitation: (Time.now - invitation.created_at).to_i
       })
-
-      if @cbv_flow.pinwheel_accounts.any?
-        latest_connected_account = @cbv_flow.pinwheel_accounts.order(created_at: :desc).first
-        redirect_to cbv_flow_payment_details_path(
-          user: { account_id: latest_connected_account.pinwheel_account_id }
-        )
-      end
     elsif session[:cbv_flow_id]
       begin
         @cbv_flow = CbvFlow.find(session[:cbv_flow_id])

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -28,8 +28,8 @@ class CbvFlowInvitation < ApplicationRecord
   INVITATION_VALIDITY_TIME_ZONE = "America/New_York"
   PAYSTUB_REPORT_RANGE = 90.days
 
-  has_one :cbv_flow
-  scope :unstarted, -> { left_outer_joins(:cbv_flow).where(cbv_flows: { id: nil }) }
+  has_many :cbv_flows
+  scope :unstarted, -> { left_outer_joins(:cbv_flows).where(cbv_flows: { id: nil }) }
 
   # Invitations are valid until 11:59pm Eastern Time on the (e.g.) 14th day
   # after sending the invitation.
@@ -42,6 +42,10 @@ class CbvFlowInvitation < ApplicationRecord
 
   def expired?
     Time.now.after?(expires_at) || redacted_at?
+  end
+
+  def complete?
+    cbv_flows.any?(&:complete?)
   end
 
   def to_url

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -48,6 +48,6 @@ class DataRetentionService
   def self.manually_redact_by_case_number!(case_number)
     invitation = CbvFlowInvitation.find_by!(case_number: case_number)
     invitation.redact!
-    invitation.cbv_flow.redact! if invitation.cbv_flow
+    invitation.cbv_flows.map(&:redact!)
   end
 end

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -170,11 +170,16 @@ RSpec.describe DataRetentionService do
   describe ".manually_redact_by_case_number!" do
     let(:cbv_flow_invitation) { create(:cbv_flow_invitation, case_number: "DELETEME001") }
     let!(:cbv_flow) { create(:cbv_flow, cbv_flow_invitation: cbv_flow_invitation) }
+    let!(:second_cbv_flow) { create(:cbv_flow, cbv_flow_invitation: cbv_flow_invitation) }
 
-    it "redacts the invitation and the flow object" do
+    it "redacts the invitation and all flow objects" do
       DataRetentionService.manually_redact_by_case_number!("DELETEME001")
 
       expect(cbv_flow.reload).to have_attributes(
+        case_number: "REDACTED",
+        redacted_at: within(1.second).of(Time.now)
+      )
+      expect(second_cbv_flow.reload).to have_attributes(
         case_number: "REDACTED",
         redacted_at: within(1.second).of(Time.now)
       )


### PR DESCRIPTION

## Ticket

Resolves FFS-1416.

## Changes
This converts the invitation's `has_one :cbv_flow` into a `has_many`.
Every time the user clicks the tokenized link again, they will have a
new CbvFlow started. This will prevent any compromise of the tokenized
link during the time between a user linking their payroll account and
completing the flow from revealing their session's data.

## Context for reviewers

This is a launch requirement from NYC.

## Testing

I will acceptance test this with Eryn by walking through various scenarios of
linking Pinwheel accounts, letting the session expire, and then clicking the
link again to verify that the associated payroll data is gone.
