### PR TITLE
Use NYC-specific copy in applicant invitation email

### DIFF
--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -17,7 +17,7 @@
       </p>
 
       <p>
-        <%= t(".body_html",
+        <%= site_translation(".body_html",
           agency_acronym: current_site.agency_short_name,
           deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %>
       </p>

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -23,20 +23,20 @@
       </p>
 
       <p>
-        To verify your income, click the button below:
+        <%= t(".button_caption") %>
       </p>
     </div>
 
     <p class="margin-y-5">
       <a href="<%= @cbv_flow_invitation.to_url %>" class="usa-button width-auto" type="button">
-        Verify your income
+        <%= t(".button") %>
       </a>
     </p>
 
     <hr >
 
     <p class="font-body-3xs">
-      This is an automatically generated message from your benefits agency. Please don’t reply to this email.
+      <%= t(".footer") %>
     </p>
   </div>
 </section>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
       body_html:
         default: "<p>%{agency_acronym} wants you to verify your income as part of your benefits application. The SNAP Income Pilot is a new tool designed to help you share your income data directly with your benefits agency by logging into your payroll provider.</p><p>This process is unique to you, so please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.</p>"
         nyc: "<p>%{agency_acronym} wants you to verify your income as part of your benefits application. The SNAP Income Pilot is a new tool designed to help you share your income data directly with your benefits agency by logging into your payroll provider.</p><p>This process is unique to you, so please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.</p><p>This is an optional tool. If you decide that you don't want to use it, you can provide income documents via the ACCESS HRA app, fax, mail, or in-person.</p>"
+      button: Verify your income
+      button_caption: 'To verify your income with the SNAP Income Pilot, click the button below:'
+      footer: This is an automatically generated message from your benefits agency. Please don’t reply to this email.
       greeting: Hello,
       header:
         ma: DTA has sent you an invitation to verify your income

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -2,7 +2,9 @@
 en:
   applicant_mailer:
     invitation_email:
-      body_html: We need to verify your income as part of your benefits application, as requested by %{agency_acronym}. This process is unique to you, so please do not share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.
+      body_html:
+        default: "<p>%{agency_acronym} wants you to verify your income as part of your benefits application. The SNAP Income Pilot is a new tool designed to help you share your income data directly with your benefits agency by logging into your payroll provider.</p><p>This process is unique to you, so please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.</p>"
+        nyc: "<p>%{agency_acronym} wants you to verify your income as part of your benefits application. The SNAP Income Pilot is a new tool designed to help you share your income data directly with your benefits agency by logging into your payroll provider.</p><p>This process is unique to you, so please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you'll need to request a new invitation.</p><p>This is an optional tool. If you decide that you don't want to use it, you can provide income documents via the ACCESS HRA app, fax, mail, or in-person.</p>"
       greeting: Hello,
       header:
         ma: DTA has sent you an invitation to verify your income

--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
   end
 
   it "renders the body" do
-    expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
+    expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html.default',
       agency_acronym: 'CBV',
       deadline: "July 21, 2024")
     )
@@ -40,7 +40,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.header.nyc'))
-      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html.nyc',
         agency_acronym: 'HRA',
         deadline: "July 21, 2024")
       )
@@ -52,7 +52,7 @@ RSpec.describe ApplicantMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.header.ma'))
-      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html',
+      expect(mail.body.encoded).to match(I18n.t('applicant_mailer.invitation_email.body_html.default',
         agency_acronym: 'DTA',
         deadline: "July 21, 2024")
       )


### PR DESCRIPTION
## Ticket

Resolves FFS-1415

## Changes

Modifies the copy for the body of the invitation email.

## Context for reviewers

N/A

## Testing

Screenshots will be provided for acceptance testing.
