### PR TITLE
Address "Medium" security issues on latest NYC scan

### DIFF
--- a/app/app/views/application/_footer.html.erb
+++ b/app/app/views/application/_footer.html.erb
@@ -4,7 +4,7 @@
       <strong><%= t("shared.pilot_name") %></strong>
     </div>
     <div class="cbv-footer__item grid-col-12 tablet:grid-col-4">
-      <%= link_to t("shared.footer.feedback"), feedback_form_url, target: "_blank" %>
+      <%= link_to t("shared.footer.feedback"), feedback_form_url, target: "_blank", rel: "noopener noreferrer" %>
     </div>
   </div>
 </footer>

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -13,12 +13,12 @@
   <p><%= t(".check_status") %></p>
 </div>
 
-<%= link_to cbv_flow_summary_path(format: "pdf"), target: "_blank", class: "usa-button margin-top-3 usa-button--primary" do %>
+<%= link_to cbv_flow_summary_path(format: "pdf"), target: "_blank", rel: "noopener noreferrer", class: "usa-button margin-top-3 usa-button--primary" do %>
   <%= t(".download") %>
 <% end %>
 
 <div>
-  <%= link_to agency_url, target: "_blank", class: "usa-button margin-top-3 usa-button usa-button--outline" do %>
+  <%= link_to agency_url, target: "_blank", rel: "noopener noreferrer", class: "usa-button margin-top-3 usa-button usa-button--outline" do %>
     <%= t(".back_to_agency", agency_short_name: current_site.agency_short_name) %>
   <% end %>
 </div>

--- a/app/config/environments/ci.rb
+++ b/app/config/environments/ci.rb
@@ -3,6 +3,7 @@ require_relative "production"
 Rails.application.configure do
   config.public_file_server.enabled = true
   config.force_ssl = false
+  config.hosts << "localhost"
 
   logger = ActiveSupport::Logger.new($stdout)
   logger.formatter = config.log_formatter

--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   routes.default_url_options[:host] = ENV["DOMAIN_NAME"]
+  config.hosts << ENV["DOMAIN_NAME"]
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache

--- a/app/config/initializers/devise.rb
+++ b/app/config/initializers/devise.rb
@@ -275,7 +275,8 @@ Devise.setup do |config|
     :ma_dta,
     {
       **Rails.application.config.sites["ma"].sso,
-      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2
+      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2,
+      pkce: true
     }
   )
 
@@ -283,7 +284,8 @@ Devise.setup do |config|
     :nyc_dss,
     {
       **Rails.application.config.sites["nyc"].sso,
-      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2
+      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2,
+      pkce: true
     }
   )
 
@@ -291,7 +293,8 @@ Devise.setup do |config|
     :sandbox,
     {
       **Rails.application.config.sites["sandbox"].sso,
-      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2
+      strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2,
+      pkce: true
     }
   )
 

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -252,7 +252,7 @@ en:
     home:
       description_1: The SNAP Income Pilot is a new tool designed to help you connect your income details from your employer or payroll provider directly to your benefits agency. We're currently testing this tool to ensure it works effectively.
       description_2: Please note this pilot is currently available only to SNAP participants in New York City and Massachusetts.
-      description_3_html: '<p>To participate, you can request an invitation from your benefits agency:</p><ul><li>Massachusetts applicants: Contact the <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank">Department of Transitional Assistance (DTA)</a></li><li>New York City applicants: Contact the <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Human Resources Administration (HRA)</a></li></ul>'
+      description_3_html: '<p>To participate, you can request an invitation from your benefits agency:</p><ul><li>Massachusetts applicants: Contact the <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank" rel="noopener noreferrer">Department of Transitional Assistance (DTA)</a></li><li>New York City applicants: Contact the <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Human Resources Administration (HRA)</a></li></ul>'
       header: Welcome to the SNAP Income Pilot
   shared:
     banner:


### PR DESCRIPTION
## Ticket

N/A - Security review

## Changes
- **Add rel="nooopener noreferrer" to external links**
- **Set `config.hosts` in production**
- **Use PKCE for Single Sign On**

## Context for reviewers
I'm not sure whether PKCE will break something else. Matt - can you test this locally with your NYC login?

## Testing
Tested SSO locally. The `hosts` change will have to be tested in production.
