### PR TITLE
Redirect to caseworker entry page when Omniauth fails

### DIFF
--- a/app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -48,4 +48,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       user_id: @user.id
     })
   end
+
+  def after_omniauth_failure_path_for(scope)
+    case failed_strategy.name
+    when "sandbox"
+      new_user_session_path(site_id: "sandbox")
+    when "nyc_dss"
+      new_user_session_path(site_id: "nyc")
+    when "ma_dta"
+      new_user_session_path(site_id: "ma")
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

N/A - An attempt to debug OTI issues.

## Changes

Rather than giving a big scary red error, let's redirect back to the
authentication page so the proper Omniauth error will be displayed to
the user.

## Context for reviewers

N/A

## Testing

I verified this worked by clearing my cookie while doing a Microsoft SSO.
