### PR TITLE
Implement /expired page

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -11,10 +11,10 @@ class Cbv::BaseController < ApplicationController
         return redirect_to(root_url, flash: { alert: t("cbv.error_invalid_token") })
       end
       if invitation.expired?
-        return redirect_to(cbv_flow_expired_invitation_path)
+        return redirect_to(cbv_flow_expired_invitation_path(site_id: invitation.site_id))
       end
       if invitation.complete?
-        return redirect_to(cbv_flow_expired_invitation_path)
+        return redirect_to(cbv_flow_expired_invitation_path(site_id: invitation.site_id))
       end
 
       @cbv_flow = CbvFlow.create_from_invitation(invitation)

--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -1,6 +1,15 @@
 class Cbv::ExpiredInvitationsController < Cbv::BaseController
   skip_before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete
+  helper_method :current_site
 
   def show
+  end
+
+  private
+
+  def current_site
+    return unless Rails.application.config.sites.site_ids.include?(params[:site_id])
+
+    Rails.application.config.sites[params[:site_id]]
   end
 end

--- a/app/app/views/cbv/expired_invitations/show.html.erb
+++ b/app/app/views/cbv/expired_invitations/show.html.erb
@@ -1,5 +1,11 @@
-<h2>Your invitation to verify income has expired</h2>
+<% content_for :title, t(".title") %>
+<h1><%= t(".title") %></h1>
 
-<p>You have either completed your verification process or accessed this invitation after too long.</p>
+<div class="usa-prose">
+  <p><%= t(".body_1") %></p>
+  <p><%= t(".body_2") %></p>
+</div>
 
-<p>Please contact your caseworker for further instructions.</p>
+<div class="margin-top-3">
+  <%= site_translation(".cta_button_html") %>
+</div>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -174,6 +174,15 @@ en:
     error_invalid_token: The invitation link used is not valid. Double check the link and try again. If you continue experiencing issues, contact your caseworker.
     error_missing_token_html: "<strong>Your session has timed out due to inactivity.</strong> To continue where you left off, please click the link you received from your benefits agency in your email. If you encounter any issues, contact your benefits agency for assistance."
     error_no_access: We weren't able to load payroll data for this account. Please click the link you received from your benefits agency to try again.
+    expired_invitations:
+      show:
+        body_1: You've either successfully completed your verification process, or are trying to access this invitation after it has expired.
+        body_2: If you still need to verify your income, please reach out to your agency to get a new invitation.
+        cta_button_html:
+          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Visit DTA website</a>
+          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page" class="usa-button">Visit HRA website</a>
+          sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Learn more at CBV Test Agency</a>
+        title: Your invitation to verify income has expired
     missing_results:
       show:
         back_button: Go back to employer search

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Cbv::EntriesController do
             expect { get :show, params: { token: invitation.auth_token } }
               .not_to change { session[:cbv_flow_id] }
 
-            expect(response).to redirect_to(cbv_flow_expired_invitation_path)
+            expect(response).to redirect_to(cbv_flow_expired_invitation_path(site_id: invitation.site_id))
           end
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe Cbv::EntriesController do
           expect { get :show, params: { token: invitation.auth_token } }
             .not_to change { session[:cbv_flow_id] }
 
-          expect(response).to redirect_to(cbv_flow_expired_invitation_path)
+          expect(response).to redirect_to(cbv_flow_expired_invitation_path(site_id: invitation.site_id))
         end
       end
     end


### PR DESCRIPTION

## Ticket

Resolves FFS-1437.

## Changes

The designs weren't ready when I initially implemented link expiry.
Let's implement them now.

Since the `@cbv_flow` is not available, we pass the site_id as a param
to the expiration controller.

## Context for reviewers

N/A

## Testing

Tested locally that an expired link takes us to the right version of the page.
