### PR TITLE
987: PDF header and show pagination for caseworker email

### DIFF
--- a/app/app/views/cbv/summaries/show.pdf.erb
+++ b/app/app/views/cbv/summaries/show.pdf.erb
@@ -1,3 +1,13 @@
+<div>
+  <span class="cbv-header__pilot-name">
+    <%= t("shared.pilot_name") %>
+  </span>
+  <% if current_site %>
+    <span class="cbv-header__separator">|</span>
+  <% end %>
+  <%= site_translation("shared.header.cbv_flow_title") %>
+</div>
+
 <h1><%= t(".pdf.client.header") %></h1>
 
 <% if is_caseworker %>

--- a/app/app/views/layouts/pdf.pdf.erb
+++ b/app/app/views/layouts/pdf.pdf.erb
@@ -11,16 +11,6 @@
 
   <body>
     <div id="root">
-      <div>
-        <span class="cbv-header__pilot-name">
-          <%= t("shared.pilot_name") %>
-        </span>
-        <% if current_site %>
-          <span class="cbv-header__separator">|</span>
-        <% end %>
-        <%= site_translation("shared.header.cbv_flow_title") %>
-      </div>
-
       <main id="main-content">
         <section class="grid-container usa-section">
           <%= yield %>


### PR DESCRIPTION
## Changes

Displays header for PDF; Shows pagination for mailer as well

<img width="873" alt="image" src="https://github.com/user-attachments/assets/b596e1c2-65d3-4291-afed-ad2356795b8a">

