### PR TITLE
Ignore scanning-related errors in NewRelic

### DIFF
--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -38,6 +38,14 @@ common: &default_settings
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  error_collector:
+    # Ignore errors that aren't likely related to user-facing issues (e.g.
+    # triggered by automated scanners)
+    ignore_classes:
+      - "ActionController::BadRequest"
+      - "ActionDispatch::Http::MimeNegotiation::InvalidType"
+      - "ActionController::UnknownHttpMethod"
+
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.


### PR DESCRIPTION
## Ticket

N/A

## Changes

A bunch of these errors popped up in NewRelic due to automated scanning.
Since it's unlikely we'll actually have users hitting these errors
naturally, let's not send them to NewRelic.

## Context for reviewers

N/A

## Testing

N/A
