### PR TITLE
Fix "submitted date" on caseworker email

### DIFF
--- a/app/app/views/caseworker_mailer/summary_email.html.erb
+++ b/app/app/views/caseworker_mailer/summary_email.html.erb
@@ -12,7 +12,7 @@
   CIN <%= @cbv_flow_invitation.client_id_number %>.
   It was requested by <%= @cbv_flow_invitation.user.email %>
   on <%= format_parsed_date(@cbv_flow_invitation.created_at) %>, and submitted by the client
-  on <%= format_parsed_date(@cbv_flow.transmitted_at) %>.
+  on <%= format_parsed_date(@cbv_flow.consented_to_authorized_use_at) %>.
 </p>
 
   NYC document indexers please follow these steps:

--- a/app/spec/factories/cbv_flow.rb
+++ b/app/spec/factories/cbv_flow.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
 
     cbv_flow_invitation
 
-    trait :transmitted do
-      transmitted_at { 10.minutes.ago }
+    trait :completed do
+      consented_to_authorized_use_at { 10.minutes.ago }
       confirmation_code { "SANDBOX0010002" }
     end
 

--- a/app/spec/mailers/caseworker_mailer_spec.rb
+++ b/app/spec/mailers/caseworker_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CaseworkerMailer, type: :mailer do
     case_number: "ABC1234",
     confirmation_code: "00001",
     site_id: "nyc",
-    transmitted_at:  Date.today
+    consented_to_authorized_use_at: Time.now
   )}
   let(:caseworker_email) { cbv_flow.cbv_flow_invitation.user.email }
   let(:account_id) { cbv_flow.pinwheel_accounts.first.pinwheel_account_id }

--- a/app/spec/mailers/previews/caseworker_mailer_preview.rb
+++ b/app/spec/mailers/previews/caseworker_mailer_preview.rb
@@ -10,7 +10,7 @@ class CaseworkerMailerPreview < BaseMailerPreview
     cbv_flow = FactoryBot.create(
       :cbv_flow,
       :with_pinwheel_account,
-      :transmitted,
+      :completed,
       cbv_flow_invitation: invitation
     )
     payments = stub_post_processed_payments(cbv_flow.pinwheel_accounts.first.pinwheel_account_id)


### PR DESCRIPTION
## Ticket

N/A - Bug report in slack

## Changes

We used `transmitted_at` by accident, but that won't be set until the
email succeeds at sending. Let's use `consented_to_authorized_use_at`
instead, which represents the time we should initially consider the CBV
flow "complete" and that it is ready to transmit.

## Context for reviewers

N/A

## Testing

Screenshot of the mailer preview below.
