### PR TITLE
Update method to more accurately reflect its meaning

### DIFF
--- a/app/app/models/pinwheel_account.rb
+++ b/app/app/models/pinwheel_account.rb
@@ -24,8 +24,9 @@ class PinwheelAccount < ApplicationRecord
 
   def job_succeeded?(job)
     error_column = EVENTS_ERRORS_MAP.select { |key| key.start_with? job }&.values.last
+    sync_column = EVENTS_MAP.select { |key| key.start_with? job }&.values.last
     return nil unless error_column.present?
 
-    supported_jobs.include?(job) && send(error_column).blank?
+    supported_jobs.include?(job) && send(sync_column).present? && send(error_column).blank?
   end
 end

--- a/app/spec/models/pinwheel_account_spec.rb
+++ b/app/spec/models/pinwheel_account_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe PinwheelAccount, type: :model do
 
   describe "#job_succeeded?" do
     context "when job is supported" do
+      it "returns false when income is supported but not yet synced" do
+        pinwheel_account.update!(income_synced_at: nil)
+        expect(pinwheel_account.job_succeeded?('income')).to be_falsey
+      end
+
       it "returns true when income is supported and it succeeded" do
         pinwheel_account.update!(income_synced_at: Time.current)
         expect(pinwheel_account.job_succeeded?('income')).to be_truthy


### PR DESCRIPTION
## Changes

Minor fix that updates the `#job_succeeded?` method to more accurately reflect its meaning.

## Context for reviewers

Before, if using this method, it would return "true" for a job that was supported but not yet synced. This is misleading.

Now, it returns "false" if the job is supported but not yet synchronized.

## Testing

Added a test case
