### PR TITLE
Fix employer search "no results" message for non-first jobs

### DIFF
--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -42,18 +42,29 @@
   <% if @query.present? && @employers.count == 0 %>
     <h3 class="margin-bottom-5"><%= t("cbv.employer_searches.show.no_results_title") %></h3>
     <h4><%= t("cbv.employer_searches.show.no_results_steps_title") %></h4>
-    <ol class="line-height-sans-5">
-      <li><%= t("cbv.employer_searches.show.no_results_steps1") %></li>
-      <li><%= t("cbv.employer_searches.show.no_results_steps2") %></li>
-    </ol>
+    <div class="usa-prose">
+      <ol class="line-height-sans-5">
+        <li><%= t("cbv.employer_searches.show.no_results_steps1") %></li>
+        <li><%= t("cbv.employer_searches.show.no_results_steps2") %></li>
+      </ol>
+    </div>
     <h4><%= t("cbv.employer_searches.show.to_continue") %></h4>
-    <ul class="line-height-sans-5">
-      <li><%= t("cbv.employer_searches.show.to_continue_li_1") %> <%= site_translation("cbv.employer_searches.show.to_continue_li_1_html") %></li>
-      <li><%= t("cbv.employer_searches.show.to_continue_li_2") %></li>
-      <li><%= t("cbv.employer_searches.show.to_continue_li_3") %></li>
-    </ul>
-    <%= link_to (@has_pinwheel_account ? cbv_flow_summary_path : current_site.agency_contact_website), class: "usa-button margin-top-5", data: { turbo_frame: "_top" } do %>
-      <%= @has_pinwheel_account ? t("cbv.employer_searches.show.review_button_text") : t("cbv.employer_searches.show.exit_button_text", agency_short_name: current_site.agency_short_name) %>
+    <div class="usa-prose">
+      <ul class="line-height-sans-5">
+        <li><%= t("cbv.employer_searches.show.to_continue_li_1") %> <%= site_translation("cbv.employer_searches.show.to_continue_li_1_html") %></li>
+        <li><%= t("cbv.employer_searches.show.to_continue_li_2") %></li>
+        <% if @has_pinwheel_account %>
+          <li><%= t("cbv.employer_searches.show.to_continue_li_3_continue") %></li>
+        <% else %>
+          <li><%= t("cbv.employer_searches.show.to_continue_li_3") %></li>
+        <% end %>
+      </ul>
+    </div>
+
+    <% if @has_pinwheel_account %>
+      <%= link_to t("cbv.employer_searches.show.review_button_text"), cbv_flow_summary_path, class: "usa-button margin-top-5", data: { turbo_frame: "_top" } %>
+    <% else %>
+      <%= link_to t("cbv.employer_searches.show.exit_button_text", agency_short_name: current_site.agency_short_name), current_site.agency_contact_website, class: "usa-button margin-top-5", data: { turbo_frame: "_top" } %>
     <% end %>
   <% elsif @employers.count > 0 %>
     <h2><%= t("cbv.employer_searches.show.employer_not_listed") %></h2>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
           sandbox: Go to <a href="https://example.com/contact">CBV's website</a> to learn about other ways to report your income.
         to_continue_li_2: If you have other jobs to add, search for them.
         to_continue_li_3: If you have no other jobs to add, you can exit this site.
+        to_continue_li_3_continue: If you have no other jobs to add, continue to review your income report.
         what_is_html: "<strong>What is a payroll provider?</strong> A payroll provider is a system that some employers or companies use to handle payroll, pay processing, and distribute paychecks and direct deposit. Examples of popular payroll providers are ADP, Paychex, Gusto, etc."
         you_ll_go: You’ll go to their login portal and sign-in to see your payment history.
     entries:

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Cbv::EmployerSearchesController do
           create(:pinwheel_account, cbv_flow_id: cbv_flow.id)
           get :show, params: { query: "no_results" }
           expect(response).to be_successful
+          expect(response.body).to include("continue to review your income report")
           expect(response.body).to include("Review my income report")
         end
       end
@@ -43,6 +44,7 @@ RSpec.describe Cbv::EmployerSearchesController do
         it "renders the view with a link to exit income verification" do
           get :show, params: { query: "no_results" }
           expect(response).to be_successful
+          expect(response.body).to include("you can exit this site")
           expect(response.body).to include("Exit and go to CBV")
         end
       end


### PR DESCRIPTION
## Ticket

Resolves FFS-1479.

## Changes

The message had been informing users to exit the flow (assuming they had
previously linked an employer). We want to tell them to continue through
to review their report.

## Context for reviewers

N/A

## Testing

Screenshots below.
