### PR TITLE
Add NYC HRA logo to invite email

### DIFF
--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -7,6 +7,8 @@
       <span class="text-primary"><%= t("shared.pilot_name") %> | </span>
       <% if current_site.id == "ma" %>
         <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
+      <% elsif current_site.id == "nyc" %>
+        <%= image_tag "hra_logo.png", class: "text-middle", style: "width: 140px" %>
       <% else %>
         <%= site_translation("shared.header.cbv_flow_title") %>
       <% end %>

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -8,7 +8,7 @@
       <% if current_site.id == "ma" %>
         <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
       <% elsif current_site.id == "nyc" %>
-        <%= image_tag "hra_logo.png", class: "text-middle", style: "width: 140px" %>
+        <%= image_tag "hra_logo.png", class: "text-middle", style: "width: 170px" %>
       <% else %>
         <%= site_translation("shared.header.cbv_flow_title") %>
       <% end %>


### PR DESCRIPTION
## Ticket

Resolves FFS-1355

## Changes

Adds nyc logo.

## Testing

Image of updated email:
![image](https://github.com/user-attachments/assets/4fad153c-5d6a-4244-9ebd-bb33376de54d)

Overlay using [pixel perfect](https://chromewebstore.google.com/detail/perfectpixel-by-welldonec/dkaagdgjmgdmbnecmcefdhjekcoceebi?hl=en) (image is correct size)

![image](https://github.com/user-attachments/assets/9ecec604-e981-4252-852e-031b535eaa9c)
