### PR TITLE
Filter more parameters from logs

### DIFF
--- a/app/config/initializers/filter_parameter_logging.rb
+++ b/app/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,10 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  # CBV flow invitation
+  :email_address, :case_number, :first_name, :middle_name, :last_name,
+  :snap_application_date, :agency_id_number, :client_id_number, :beacon_id,
+  # CBV flow
+  :additional_information
 ]


### PR DESCRIPTION
## Ticket

N/A - Came up as I was looking at logs.

## Changes

Let's get Rails to remove these parameters from the logs, to minimize
the risk that logs will inadvertently contain PII.

## Context for reviewers

N/A

## Testing

Tested locally:
<img width="1291" alt="image" src="https://github.com/user-attachments/assets/e2d05d33-1ffe-43e4-8a5b-42b1057db1b8">
