### PR TITLE
Fix /:site/invitations to be a 404 instead of 500

### DIFF
--- a/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
+++ b/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
@@ -18,7 +18,7 @@ class Caseworker::CbvFlowInvitationsController < Caseworker::BaseController
                         error_message: ex.message
                        )
       Rails.logger.error("Error sending CBV invitation: #{ex.class} - #{ex.message}")
-      return redirect_to new_invitation_path(secret: params[:secret])
+      return redirect_to new_invitation_path(site_id: params[:site_id])
     end
 
     flash[:slim_alert] = {

--- a/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
@@ -6,7 +6,6 @@
 </div>
 
 <%= form_with(model: @cbv_flow_invitation, url: invitations_path, builder: UswdsFormBuilder) do |f| %>
-  <%= hidden_field_tag :secret, params[:secret] %>
   <%= render partial: "#{@site_id}", locals: { f: f } %>
   <%= f.submit t(".form.submit") %>
 <% end %>

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
       root to: "entries#index", as: :new_user_session
 
       resource :dashboard, only: %i[show], as: :caseworker_dashboard
-      resources :cbv_flow_invitations, as: :invitations, path: :invitations
+      resources :cbv_flow_invitations, only: %i[new create], as: :invitations, path: :invitations
     end
   end
 

--- a/app/spec/controllers/caseworker/cbv_flow_invitations_controller/auth_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations_controller/auth_spec.rb
@@ -3,16 +3,15 @@ require "rails_helper"
 RSpec.describe Caseworker::CbvFlowInvitationsController do
   let(:nyc_user) { create(:user, email: "test@test.com", site_id: 'nyc') }
   let(:ma_user) { create(:user, email: "test@test.com", site_id: 'ma') }
-  let(:invite_secret) { "FAKE_INVITE_SECRET" }
-  let(:ma_params) { { site_id: "ma", secret: invite_secret } }
-  let(:nyc_params) { { site_id: "nyc", secret: invite_secret } }
+  let(:ma_params) { { site_id: "ma" } }
+  let(:nyc_params) { { site_id: "nyc" } }
 
   describe "#new" do
     let(:valid_params) { nyc_params }
 
     context "without authentication" do
       it "redirects to the sso login page" do
-        get :new, params: valid_params.except(:secret)
+        get :new, params: valid_params
         expect(response).to redirect_to(new_user_session_url)
       end
     end
@@ -81,7 +80,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
     end
     let(:valid_params) do
       {
-        secret: invite_secret,
         site_id: site_id,
         cbv_flow_invitation: cbv_flow_invitation_params
       }
@@ -93,10 +91,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
     end
 
     context "without authentication" do
-      before do
-        valid_params[:secret] = nil
-      end
-
       it "redirects to the homepage without creating any invitation" do
         expect_any_instance_of(CbvInvitationService).not_to receive(:invite)
 
@@ -142,7 +136,7 @@ RSpec.describe Caseworker::CbvFlowInvitationsController do
 
           post :create, params: broken_params
 
-          expect(response).to redirect_to(new_invitation_path(secret: broken_params[:secret]))
+          expect(response).to redirect_to(new_invitation_path(site_id: broken_params[:site_id]))
           expect(controller.flash.alert).to include("Some random error")
         end
       end

--- a/app/spec/controllers/caseworker/cbv_flow_invitations_controller/ma_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations_controller/ma_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
-  let(:invite_secret) { "FAKE_INVITE_SECRET" }
   let(:user) { create(:user, email: "test@test.com", site_id: 'ma') }
-  let(:ma_params) { { site_id: "ma", secret: invite_secret } }
+  let(:ma_params) { { site_id: "ma" } }
 
   before do
     sign_in user
@@ -45,7 +44,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "creates a CbvFlowInvitation record with the ma fields" do
       post :create, params: {
-        secret: invite_secret,
         site_id: ma_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params
       }
@@ -62,7 +60,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "requires the ma fields" do
       post :create, params: {
-        secret: invite_secret,
         site_id: "ma",
         cbv_flow_invitation: cbv_flow_invitation_params.except(:beacon_id, :agency_id_number)
       }
@@ -71,7 +68,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "redirects back to the caseworker dashboard" do
       post :create, params: {
-        secret: invite_secret,
         site_id: ma_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params
       }

--- a/app/spec/controllers/caseworker/cbv_flow_invitations_controller/nyc_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations_controller/nyc_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
   let(:user) { create(:user, email: "test@test.com", site_id: 'nyc') }
-  let(:invite_secret) { "FAKE_INVITE_SECRET" }
-  let(:nyc_params) { { site_id: "nyc", secret: invite_secret } }
+  let(:nyc_params) { { site_id: "nyc" } }
 
   before do
     sign_in user
@@ -35,7 +34,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "creates a CbvFlowInvitation record with the nyc fields" do
       post :create, params: {
-        secret: invite_secret,
         site_id: nyc_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params
       }
@@ -51,7 +49,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "creates a CbvFlowInvitation record without optional fields" do
       post :create, params: {
-        secret: invite_secret,
         site_id: nyc_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params.except(:middle_name, :client_id_number)
       }
@@ -61,7 +58,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
 
     it "redirects back to the caseworker dashboard" do
       post :create, params: {
-        secret: invite_secret,
         site_id: nyc_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params
       }
@@ -73,7 +69,6 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
       allow(NewRelicEventTracker).to receive(:track)
 
       post :create, params: {
-        secret: invite_secret,
         site_id: nyc_params[:site_id],
         cbv_flow_invitation: cbv_flow_invitation_params
       }


### PR DESCRIPTION
## Ticket

Resolves FFS-1350.

## Changes

This error has happened a couple times. I couldn't reproduce why, so I'm
assuming that NYC staff just forgot the "/new" at the end of the link
and typed it in manually. To handle this, let's make it be a 404 rather
than 500 error.

While testing, I also cleaned up the parameters used on these redirects -
we don't have an invite secret anymore.

## Context for reviewers

N/A

## Testing

Tested invitation sending locally - still works.
