### PR TITLE
Don't send 404 errors to NewRelic

### DIFF
--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -43,8 +43,9 @@ common: &default_settings
     # triggered by automated scanners)
     ignore_classes:
       - "ActionController::BadRequest"
-      - "ActionDispatch::Http::MimeNegotiation::InvalidType"
+      - "ActionController::RoutingError"
       - "ActionController::UnknownHttpMethod"
+      - "ActionDispatch::Http::MimeNegotiation::InvalidType"
 
 
 # Environment-specific settings are in this section.


### PR DESCRIPTION
## Ticket

N/A

## Changes

The errors that become 404's (ActionController::RoutingError) are not
useful for us to receive as alerts, so let's skip sending them to
NewRelic.

## Context for reviewers

N/A

## Testing

N/A
