### PR TITLE
Update link to agency website

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -71,7 +71,7 @@ class Cbv::BaseController < ApplicationController
   end
 
   def agency_url
-    site_config[@cbv_flow.site_id].agency_contact_website
+    current_site&.agency_contact_website
   end
 
   def get_comment_by_account_id(account_id)

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -71,7 +71,7 @@ class Cbv::BaseController < ApplicationController
   end
 
   def agency_url
-    "https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page"
+    site_config[@cbv_flow.site_id].agency_contact_website
   end
 
   def get_comment_by_account_id(account_id)


### PR DESCRIPTION
## Ticket

From bug bash

## Changes

The agency url website was hard-coded to the NYC url.

