### PR TITLE
1553: Set org name as “search”

### DIFF
--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -89,7 +89,7 @@ class PinwheelService
 
   def create_link_token(end_user_id:, response_type:, id:)
     params = {
-      org_name: "search",
+      org_name: I18n.t("shared.pilot_name"),
       required_jobs: [ "paystubs" ],
       end_user_id: end_user_id,
       skip_intro_screen: true


### PR DESCRIPTION
## Ticket

Resolves [1553](https://jiraent.cms.gov/browse/FFS-1553)

## Changes

Sets the "org name" for the create token process to "search"

## Context for reviewers

We can't really opt out of this field and apparently can't hide it for the buton

## Testing

<img width="451" alt="image" src="https://github.com/user-attachments/assets/d0c73f88-8c3b-4f8d-a239-cbfce9b5260e">
