### PR TITLE
1549: Fix logos in MA/NYC emails

### DIFF
--- a/app/config/environments/ci.rb
+++ b/app/config/environments/ci.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   config.public_file_server.enabled = true
   config.force_ssl = false
   config.hosts << "localhost"
+  config.asset_host = "http://localhost"
 
   logger = ActiveSupport::Logger.new($stdout)
   logger.formatter = config.log_formatter

--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
+  config.asset_host = "https://#{ENV["DOMAIN_NAME"]}"
 
   routes.default_url_options[:host] = ENV["DOMAIN_NAME"]
   config.hosts << ENV["DOMAIN_NAME"]


### PR DESCRIPTION
## Ticket

Resolves FFS-1549.

## Changes

These logos weren't loading because there was no `asset_host` specified.
Let's re-use the `DOMAIN_NAME` env var for it.

## Context for reviewers

N/A

## Testing

Tested in development by copying this config into development.rb and
verifying it was used in the Rails mailer.
