### PR TITLE
Add `bin/will-deploy` script to help communicate about deploys

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Use this script when preparing for a deploy:
+#
+#   bin/will-deploy | pbcopy
+#
+# Then paste the message into Slack, applying formatting by pressing
+# Cmd+Shift+F.
+set -euo pipefail
+
+if [ -t 1 ]; then
+  echo "Copy-paste this output into Slack (on macOS, pipe this script to 'pbcopy'):" >&2
+  echo "=================================================================" >&2
+else
+  echo "Copying commit list... (use Cmd+Shift+F to apply formatting after pasting it into Slack)" >&2
+fi
+
+git fetch
+prod=$(curl --silent https://snap-income-pilot.com/health | jq -r .version)
+current_sha=$(git rev-parse origin/main)
+echo '🚀 Will deploy `'${current_sha:0:7}'` to production: 🚀 (cc @cbv-product-team)'
+git log --no-decorate --pretty="format:• *%s* - %an" ${prod}..${current_sha} | \
+  sed -E 's/(FFS-)?([0-9]{3,4}): (.*)/\3 \[[FFS-\2](https:\/\/jiraent.cms.gov\/browse\/FFS-\2)\]/g'
+
+echo
+echo
+echo "See the [full diff on Github](https://github.com/DSACMS/iv-cbv-payroll/compare/${prod:0:7}..${current_sha:0:7})."


### PR DESCRIPTION
## Ticket

N/A

## Changes

This script does a few things:
1. Fetches the latest code
2. Determines which commits have landed on `main` but haven't yet been
   deployed to production (according to the production /health
   endpoint.)
3. Formats a list of those commits suitable for pasting into slack.

It will recognize any 4-digit number followed by a colon in the commit
message title, and auto-link the Jira ticket (e.g. "FFS-1234:" or
"1234:")

In Terminal:
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/bcbe9777-2283-4cfb-8487-a7d65fdda55c">

In Slack:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/c2e015b5-f8a4-46c1-9ff6-77488174dce7">


## Context for reviewers

Hopefully when we automate deploys a bit better, we can call this script in CI
or something, but until then, this may be helpful for standardizing the format
of these messages.

## Testing

Tested locally.
