### PR TITLE
Add NewRelic tracking for caseworker emails

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -182,6 +182,7 @@ class Cbv::SummariesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       site_id: cbv_flow.site_id,
       cbv_flow_id: cbv_flow.id,
+      invitation_id: cbv_flow.cbv_flow_invitation_id,
       account_count: payments.map { |p| p[:account_id] }.uniq.count,
       paystub_count: payments.count,
       account_count_with_additional_information:

--- a/app/app/services/cbv_invitation_service.rb
+++ b/app/app/services/cbv_invitation_service.rb
@@ -19,6 +19,7 @@ class CbvInvitationService
     NewRelicEventTracker.track("ApplicantInvitedToFlow", {
       timestamp: Time.now.to_i,
       user_id: current_user.id,
+      caseworker_email_address: current_user.email,
       site_id: cbv_flow_invitation.site_id,
       invitation_id: cbv_flow_invitation.id
     })

--- a/app/spec/controllers/caseworker/cbv_flow_invitations_controller/nyc_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations_controller/nyc_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
       expect(NewRelicEventTracker).to have_received(:track).with("ApplicantInvitedToFlow", {
         timestamp: be_a(Integer),
         user_id: user.id,
+        caseworker_email_address: user.email,
         site_id: "nyc",
         invitation_id: invitation.id
       })


### PR DESCRIPTION
## Ticket

N/A

## Changes

* Track `invitation_id` as an attribute of the sent-to-caseworker event
* Track the caseworker's email address as an attribute of the invited event.

## Context for reviewers

This will allow us to track the caseworker emails of who is sending
invitations and who is supposed to be receiving the completed CSVs. We
can send caseworker email to NewRelic as it is not client PII.


## Testing

Unit tests included.
