### PR TITLE
1577: Fix error that happens during PDF rendering

### DIFF
--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -34,8 +34,8 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.asset_host = "https://#{ENV["DOMAIN_NAME"]}"
+  # Configure mailers to pull assets from the deployed environment by default.
+  config.action_mailer.asset_host = "https://#{ENV["DOMAIN_NAME"]}"
 
   routes.default_url_options[:host] = ENV["DOMAIN_NAME"]
   config.hosts << ENV["DOMAIN_NAME"]


### PR DESCRIPTION
## Ticket

Resolves FFS-1577.

## Changes

* Set `config.action_mailer.action_host` instead of `config.asset_host`.

## Context for reviewers

The fix in `e5b33456` for logos in emails accidentally broke PDF rendering.

The issue was that, when precompiling assets during the Docker build,
the DOMAIN_NAME environment variable is not set, leading to incomplete
URLs being referenced by the stylesheets built by the asset pipeline,
for example:

    background-image: url(https:/assets/@uswds/uswds/dist/img/file[...].svg)

Since the same asset build is used for both demo and production, we
can't have a domain name in there. So, let's unset the
`config.asset_host`, so that no domain name is included during
compilation, and instead set the fine-grained
`config.action_mailer.action_host`, which is only used in the mailers.

## Testing

Tested locally. Will have to test in demo as well.
