### PR TITLE
Only conditionally set the asset host

### DIFF
--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -35,7 +35,9 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.asset_host = "https://#{ENV["DOMAIN_NAME"]}"
+  if ENV["DOMAIN_NAME"]
+    config.asset_host = "https://#{ENV["DOMAIN_NAME"]}"
+  end
 
   routes.default_url_options[:host] = ENV["DOMAIN_NAME"]
   config.hosts << ENV["DOMAIN_NAME"]


### PR DESCRIPTION
## Ticket

N/A

## Changes

In production it seems like this value isn't set in some contexts, leading to an improper URL. This conditionally sets it.

## Context for reviewers

https://nava.slack.com/archives/C0700F01KKP/p1726011283462929?thread_ts=1726003282.315599&cid=C0700F01KKP
