### PR TITLE
1625: Remove step 2 from NYC caseworker email body

### DIFF
--- a/app/app/views/caseworker_mailer/summary_email.html.erb
+++ b/app/app/views/caseworker_mailer/summary_email.html.erb
@@ -18,7 +18,6 @@
   NYC document indexers please follow these steps:
 <ol class="margin-top-1">
   <li>Upload the attached PDF to the relevant case in the case management system.</li>
-  <li>Notify the requesting Test Agency staff member once the PDF has been linked to the case.</li>
 </ol>
 <p>
   This document is for NYC HRA staff only and should not be shared outside the agency.


### PR DESCRIPTION
## Ticket

Closes [1625](https://jiraent.cms.gov/browse/FFS-1625)

## Changes

Removes step 2 from caseworker email body for _all_

## Context for reviewers

There's no site-specific handling, it applies to all pilots!

## Testing

<img width="898" alt="Screenshot 2024-09-13 at 1 32 13 PM" src="https://github.com/user-attachments/assets/2f601ea4-ebf4-4499-9542-9717f2299d2c">
