### PR TITLE
Fix MA GPG encryption in production

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -102,6 +102,7 @@ FROM base AS release
 
 # Set the tmp dir to the writeable tmp volume
 ENV TMPDIR="/rails/tmp"
+ENV GNUPGHOME="/rails/tmp"
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \


### PR DESCRIPTION
## Ticket

N/A - Discovered during E2E testing

## Changes

In production (only), our docker containers are read-only, which prevents the
GPG key from being added to the local keyring.

We should probably redo this to happen during build-time, but until then, let's
tell GPG to create our keyring in the writable directory.

## Context for reviewers
N/A

## Testing

Tested locally with an incantation of `docker run --read-only` and bind
mounting.
