### PR TITLE
Fix logic bug in DataRetentionService

### DIFF
--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -27,8 +27,9 @@ class DataRetentionService
       .includes(:cbv_flow_invitation)
       .find_each do |cbv_flow|
         invitation_redact_at = cbv_flow.cbv_flow_invitation.expires_at + REDACT_UNUSED_INVITATIONS_AFTER
+        next unless Time.now.after?(invitation_redact_at)
 
-        cbv_flow.redact! if Time.now.after?(invitation_redact_at)
+        cbv_flow.redact!
         cbv_flow.cbv_flow_invitation.redact! if cbv_flow.cbv_flow_invitation.present?
       end
   end

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe DataRetentionService do
         expect { service.redact_incomplete_cbv_flows }
           .not_to change { cbv_flow.reload.attributes }
       end
+
+      it "does not redact the CbvFlowInvitation" do
+        expect { service.redact_incomplete_cbv_flows }
+          .not_to change { cbv_flow_invitation.reload.attributes }
+      end
     end
 
     context "after the deletion threshold" do
@@ -89,6 +94,11 @@ RSpec.describe DataRetentionService do
       context "for a complete CbvFlow" do
         before do
           cbv_flow.update(confirmation_code: "SANDBOX001")
+        end
+
+        it "does not redact the CbvFlow" do
+          expect { service.redact_invitations }
+            .not_to change { cbv_flow.reload.attributes }
         end
 
         it "does not redact the invitation" do
@@ -129,6 +139,11 @@ RSpec.describe DataRetentionService do
       it "does not redact the CbvFlow" do
         expect { service.redact_complete_cbv_flows }
           .not_to change { cbv_flow.reload.attributes }
+      end
+
+      it "does not redact the CbvFlowInvitation" do
+        expect { service.redact_complete_cbv_flows }
+          .not_to change { cbv_flow_invitation.reload.attributes }
       end
     end
 


### PR DESCRIPTION
## Ticket

N/A

## Changes

I was re-reading this code this morning, and discovered that we would
inadvertently redact incomplete CbvFlowInvitation's regardless of
whether they had expired or not.

This fixes the logic error and beefs up the tests.

## Context for reviewers

N/A

## Testing

N/A
