### PR TITLE
1725: Add NewRelic event for PinwheelAccountSyncFinished

### DIFF
--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Webhooks::Pinwheel::EventsController do
+  include PinwheelApiHelper
+
   let(:valid_params) do
     {
       "event" => event_name,
@@ -27,16 +29,14 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
     let(:supported_jobs) { [ "paystubs", "identity", "income", "employment" ] }
 
     before do
-      allow_any_instance_of(PinwheelService).to receive(:fetch_platform)
-        .with(platform_id: "fake-platform-id")
-        .and_return("data" => { "supported_jobs" => supported_jobs })
+      stub_request_platform_response
     end
 
     context "for an 'account.added' event" do
       let(:event_name) { "account.added" }
       let(:payload) do
         {
-          "platform_id" => "fake-platform-id",
+          "platform_id" => "00000000-0000-0000-0000-000000011111",
           "end_user_id" => cbv_flow.pinwheel_end_user_id,
           "account_id" => account_id
         }
@@ -50,7 +50,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
         pinwheel_account = PinwheelAccount.last
         expect(pinwheel_account).to have_attributes(
           cbv_flow_id: cbv_flow.id,
-          supported_jobs: supported_jobs,
+          supported_jobs: include(*supported_jobs),
           pinwheel_account_id: account_id
         )
       end

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe Webhooks::Pinwheel::EventsController do
+  let(:valid_params) do
+    {
+      "event" => event_name,
+      "payload" => payload
+    }
+  end
+  let(:request_headers) do
+    {
+      "X-Pinwheel-Signature" => "v2=test-signature",
+      "X-Timestamp" => "test-timestamp"
+    }
+  end
+  let(:cbv_flow) { create(:cbv_flow, site_id: "sandbox") }
+  let(:account_id) { "00000000-0000-0000-0000-000000000000" }
+
+  before do
+    request.headers.merge!(request_headers)
+    allow_any_instance_of(PinwheelService).to receive(:generate_signature_digest)
+      .with("test-timestamp", anything)
+      .and_return("v2=test-signature")
+  end
+
+  describe "#create" do
+    let(:supported_jobs) { [ "paystubs", "identity", "income", "employment" ] }
+
+    before do
+      allow_any_instance_of(PinwheelService).to receive(:fetch_platform)
+        .with(platform_id: "fake-platform-id")
+        .and_return("data" => { "supported_jobs" => supported_jobs })
+    end
+
+    context "for an 'account.added' event" do
+      let(:event_name) { "account.added" }
+      let(:payload) do
+        {
+          "platform_id" => "fake-platform-id",
+          "end_user_id" => cbv_flow.pinwheel_end_user_id,
+          "account_id" => account_id
+        }
+      end
+
+      it "creates a PinwheelAccount object" do
+        expect do
+          post :create, params: valid_params
+        end.to change(PinwheelAccount, :count).by(1)
+
+        pinwheel_account = PinwheelAccount.last
+        expect(pinwheel_account).to have_attributes(
+          cbv_flow_id: cbv_flow.id,
+          supported_jobs: supported_jobs,
+          pinwheel_account_id: account_id
+        )
+      end
+
+      context "when the webhook signature is incorrect" do
+        before do
+          request.headers["X-Pinwheel-Signature"] = "wrong-signature"
+        end
+
+        it "discards the webhook" do
+          expect do
+            post :create, params: valid_params
+          end.not_to change(PinwheelAccount, :count)
+
+          expect(response).to be_unauthorized
+        end
+      end
+    end
+
+    context "for an 'paystubs.fully_synced' event" do
+      let(:event_name) { "paystubs.fully_synced" }
+      let(:payload) do
+        {
+          "account_id" => account_id,
+          "end_user_id" => cbv_flow.pinwheel_end_user_id,
+          "outcome" => "success"
+        }
+      end
+      let(:pinwheel_account) { PinwheelAccount.create!(cbv_flow: cbv_flow, supported_jobs: supported_jobs, pinwheel_account_id: account_id) }
+
+      it "updates the PinwheelAccount object with the current timestamp" do
+        expect { post :create, params: valid_params }
+          .to change { pinwheel_account.reload.paystubs_synced_at }
+          .from(nil)
+          .to(within(1.second).of(Time.now))
+      end
+    end
+  end
+end

--- a/app/spec/support/fixtures/pinwheel/request_platform_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_platform_response.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": "00000000-0000-0000-0000-000000011111",
+    "name": "Testing Payroll Provider Inc.",
+    "type": "payroll",
+    "fractional_amount_supported": false,
+    "min_amount": null,
+    "max_amount": null,
+    "last_updated": "2023-05-05T15:18:39.312868+00:00",
+    "logo_url": null,
+    "percentage_supported": false,
+    "min_percentage": 1,
+    "max_percentage": 99,
+    "supported_jobs": [
+      "direct_deposit_allocations",
+      "income",
+      "identity",
+      "employment",
+      "tax_forms",
+      "direct_deposit_switch",
+      "paystubs",
+      "shifts"
+    ],
+    "amount_supported": true
+  }
+}

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -112,6 +112,15 @@ module PinwheelApiHelper
       )
   end
 
+  def stub_request_platform_response
+    stub_request(:get, %r{#{PinwheelService::PLATFORMS_ENDPOINT}/[0-9a-fA-F\-]{36}})
+      .to_return(
+        status: 200,
+        body: load_relative_json_file('request_platform_response.json').to_json,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' }
+      )
+  end
+
   def load_relative_file(filename)
     File.read(File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
## Ticket

Resolves FFS-1725.

## Changes

1. Add unit tests for Pinwheel::EventsController
2. Add NewRelic event for PinwheelAccountSyncFinished

## Context for reviewers

This will give us better visibility into Pinwheel failures.

## Testing

Unit tests included.
