### PR TITLE
Fix `invalidated_session_ids` system error when logging out twice

### DIFF
--- a/app/app/services/session_invalidation_service.rb
+++ b/app/app/services/session_invalidation_service.rb
@@ -33,6 +33,8 @@ class SessionInvalidationService
   end
 
   def valid?
+    return false unless @user.present?
+
     (@user.invalidated_session_ids || {}).exclude?(@session_id)
   end
 

--- a/app/spec/services/session_invalidation_service_spec.rb
+++ b/app/spec/services/session_invalidation_service_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe SessionInvalidationService do
       end
     end
 
+    context "for a nil User (if they try to log out twice)" do
+      let(:user) { nil }
+
+      it "is false" do
+        expect(service.valid?).to eq(false)
+      end
+    end
+
     context "for a User with invalidated sessions" do
       let(:user) { create(:user, invalidated_session_ids: invalidated_session_ids) }
       let(:invalidated_session_ids) { { "BBBBB" => Time.now } }
@@ -63,6 +71,14 @@ RSpec.describe SessionInvalidationService do
           service.invalidate!
           expect(user.invalidated_session_ids).not_to include("BBBBB")
         end
+      end
+    end
+
+    context "when the user has already logged out" do
+      let(:user) { nil }
+
+      it "does nothing" do
+        expect { service.invalidate! }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Ticket

N/A - Fixes system error in logs.

## Changes

The "before_logout" hook can be called with a `nil` user if the user has
already logged out (or their session timed out, presumably). In this
case, we can't do anything to invalidate the session because Devise
won't tell us which user it was related to. That's fine - we don't need
to invalidate the session, as Devise will already consider the session
timed out.

This commit fixes the error that comes up with `user` is nil in this
case.

## Context for reviewers

N/A

## Testing

N/A
