### PR TITLE
Bug fix: Include current_site as part of the locals

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -103,6 +103,7 @@ class Cbv::SummariesController < Cbv::BaseController
       # Generate PDF
       pdf_service = PdfService.new
       @pdf_output = pdf_service.generate(
+        renderer: self,
         template: "cbv/summaries/show",
         variables: {
           is_caseworker: true,
@@ -112,8 +113,7 @@ class Cbv::SummariesController < Cbv::BaseController
           incomes: @incomes,
           identities: @identities,
           payments_grouped_by_employer: summarize_by_employer(@payments, @employments, @incomes, @identities, @cbv_flow.pinwheel_accounts),
-          has_consent: has_consent,
-          current_site: current_site
+          has_consent: has_consent
         }
       )
 

--- a/app/app/services/pdf_service.rb
+++ b/app/app/services/pdf_service.rb
@@ -1,7 +1,6 @@
 require "pdf-reader"
 
 class PdfService
-  include ApplicationHelper
   # Represents the result of PDF generation
   class PdfGenerationResult
     attr_reader :content, :html, :page_count, :file_size
@@ -14,8 +13,8 @@ class PdfService
     end
   end
 
-  def generate(template:, variables: {})
-    html_content = ApplicationController.renderer.render_to_string(
+  def generate(renderer:, template:, variables: {})
+    html_content = renderer.render_to_string(
       template: template,
       formats: [ :pdf ],
       layout: "layouts/pdf",

--- a/app/spec/services/pdf_service_spec.rb
+++ b/app/spec/services/pdf_service_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe PdfService, type: :service do
     it 'generates a PDF file' do
       pdf_service = PdfService.new
       @pdf_results = pdf_service.generate(
+        renderer: ApplicationController.renderer,
         template: 'cbv/summaries/show',
         variables: variables
       )


### PR DESCRIPTION
## Ticket

https://nava.slack.com/archives/C074ZV2SP0X/p1727375841786299?thread_ts=1727359349.342059&cid=C074ZV2SP0X

`current_site` is a value used by ApplicationHelper. During transmission to MA, ApplicationHelper is included in the PdfGenerator. However, a value that depends on it, `current_site`, was not included.

It seems like ApplicationHelper worked because it prevented execution of any of the methods if `current_site` were ever falsey or unavailable.



## Changes

Includes `current_site` as part of the PdfGenerator call.


## Testing

I don't know how to manually test this! 