### PR TITLE
Fix documentation test failure by excluding HHS.gov

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -11,6 +11,9 @@
         },
         {
           "pattern": "^https://confluenceent.cms.gov"
+        },
+        {
+          "pattern": "^https://www.hhs.gov"
         }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
## Ticket

N/A

## Changes
It looks like HHS.gov is blocking automated tools from accessing its
pages. Let's ignore it when validating link destinations.

## Context for reviewers

N/A

## Testing

N/A
