### PR TITLE
Fix OWASP "Secondary Rate Limit" error in CI runs

### DIFF
--- a/.github/workflows/owasp-scan.yml
+++ b/.github/workflows/owasp-scan.yml
@@ -41,7 +41,7 @@ jobs:
           database_url: ${{ steps.setup.outputs.database_url }}
 
       - name: Run OWASP Full Scan
-        uses: zaproxy/action-full-scan@v0.10.0
+        uses: zaproxy/action-full-scan@v0.11.0
         with:
           target: 'http://localhost:3000/'
           fail_action: true


### PR DESCRIPTION
## Ticket

N/A

## Changes

Upgrade OWASP Scan from v0.10.0 -> v0.11.0 which includes a
rate-limit/throttling fix that should get rid of the failures for
hitting the "secondary rate limit".

See: https://github.com/zaproxy/action-full-scan/pull/93

## Context for reviewers

N/A

## Testing

N/A
