### PR TITLE
Menu toggle button was previously only visible to authenticated casew…

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   helper :view
-  helper_method :current_site, :show_translate_button?
+  helper_method :current_site, :show_translate_button?, :show_menu?
   around_action :switch_locale
   before_action :add_newrelic_metadata
   before_action :redirect_if_maintenance_mode
@@ -29,6 +29,16 @@ class ApplicationController < ActionController::Base
   private
   def show_translate_button?
     false
+  end
+
+  def show_menu?
+    # show the menu if we're in the cbv flow
+    return true if controller_path.start_with?("cbv/")
+    user_signed_in? && !home_page?
+  end
+
+  def home_page?
+    request.path == root_path
   end
 
   def current_site

--- a/app/app/views/application/_header.html.erb
+++ b/app/app/views/application/_header.html.erb
@@ -33,7 +33,7 @@
         </em>
       </div>
 
-      <% if user_signed_in? %>
+      <% if show_menu? %>
         <button class="usa-menu-btn"><%= t("shared.header.menu") %></button>
       <% end %>
     </div>


### PR DESCRIPTION
## Ticket
FFS-1802

## Changes

The menu toggle button is now visible to applicants within the CBV flow and all authenticated state agency caseworkers. The menu is not visible on the homepage.

## Context for reviewers

During our Spanish Translation smoke test we discovered a [bug](https://nava.slack.com/archives/C07L67ECPM0/p1727900071102739) that prevented applicants on mobile devices from accessing the language selector.


## Testing

![Screen Shot 2024-10-03 at 08 56 52](https://github.com/user-attachments/assets/2456ca00-07b1-45aa-81fe-e74727d4f4c9)
![Screen Shot 2024-10-03 at 08 56 47](https://github.com/user-attachments/assets/c29adc0d-0e14-466a-901c-350fa9f68ed7)
![Screen Shot 2024-10-03 at 08 56 27](https://github.com/user-attachments/assets/4fe62c1e-4693-4b6a-901a-a8fa6286555e)
![Screen Shot 2024-10-03 at 08 54 58](https://github.com/user-attachments/assets/021dbfcc-9c64-49de-89e1-d532643839db)
![Screenshot 2024-10-03 at 08-54-38 DTA is piloting a new way to quickly verify clients' income SNAP Income Pilot](https://github.com/user-attachments/assets/6139aba7-2d4a-4c66-9856-a897e2417062)
