### PR TITLE
Track when agreement page is loaded

### DIFF
--- a/app/app/controllers/cbv/agreements_controller.rb
+++ b/app/app/controllers/cbv/agreements_controller.rb
@@ -1,5 +1,10 @@
 class Cbv::AgreementsController < Cbv::BaseController
   def show
+    NewRelicEventTracker.track("ApplicantViewedAgreement", {
+      timestamp: Time.now.to_i,
+      site_id: @cbv_flow.site_id,
+      cbv_flow_id: @cbv_flow.id
+    })
   end
 
   def create


### PR DESCRIPTION
## Changes

Tracks when applicant views the agreement page

## Context for reviewers

We don't know when people are proceeding from the entry page. This will let use infer whether users are moving into the next view.
