### PR TITLE
FFS-1750: Update SNAP strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ guide for an introduction to the framework.
 1. Start postgres & redis:
    * `brew services start postgresql@12`
    * `brew services start redis`
-1. Get development credentials from 1Password: search for "CBV Rails Secrets" and copy its ".env.development.local" section into a file called that in the app directory.
+1. Get development credentials from 1Password: search for "CBV .env.local secrets" and copy its ".env.local" section into a file called that in the app directory.
 1. Create database: `bin/rails db:create`
 1. Run migrations: `bin/rails db:migrate`
 1. Run the development server: `bin/dev`

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -310,8 +310,8 @@ en:
         additional_information_title: Is there anything else you'd like your caseworker to know about your income?
         application_or_recertification_date:
           ma: Date client was contacted
-          nyc: Application or recertification date
-          sandbox: Application or recertification date
+          nyc: SNAP application or recertification interview date
+          sandbox: SNAP application or recertification interview date
         consent_to_authorize_use_html:
           ma: Check this box to confirm that the information provided by you is true and complete to the best of your knowledge. You agree to inform DTA of any income not reflected in this report or any discrepancies found in the information gathered with this tool. You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences. For more information on your rights and responsibilities regarding private information you share with DTA, please refer to the Rights and Responsibilities you signed at application, found on <a href="https://www.mass.gov/lists/department-of-transitional-assistance-rights-responsibilities-and-penalties">Mass.gov</a>.<br/><br/>By sending this report, you authorize its use for income verification by authorized DTA personnel.
           nyc: Check this box to confirm that the information provided by you is true and complete to the best of your knowledge. You agree to inform NYC Human Resources Administration (HRA) of any income not reflected in this report or any discrepancies found in the information gathered with this tool. You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.<br/><br/>By sending this report, you authorize its use for income verification by authorized HRA personnel.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
               blank: Enter the client's last name.
             snap_application_date:
               ma_invalid_date: Enter today's date or the date you contacted the client. This date must be today or in the past year.
-              nyc_invalid_date: SNAP application/recertification date must be today or in the past 30 days.
+              nyc_invalid_date: SNAP interview date must be today or in the past 30 days.
   applicant_mailer:
     invitation_email:
       body_1:
@@ -78,7 +78,7 @@ en:
           language_label: In what language should we send the invitation?
           last_name: Client's last name
           middle_name: Client's middle name
-          snap_application_date: SNAP application or recertification date
+          snap_application_date: SNAP application or recertification interview date
       sandbox:
         invite:
           agency_id_number: Client's agency ID number
@@ -89,7 +89,7 @@ en:
           language_label: In what language should we send the invitation?
           last_name: Client's last name
           middle_name: Client's middle name
-          snap_application_date: SNAP application or recertification date
+          snap_application_date: SNAP application or recertification interview date
     dashboards:
       show:
         create_invitation: Create a new invitation


### PR DESCRIPTION
## Ticket

Resolves [#FFS-1750](https://jiraent.cms.gov/browse/FFS-1750)

## Changes
1. On the /nyc/invitations page, observe that the date field's header has been updated and looks like this:
![image](https://github.com/user-attachments/assets/041c5e01-244f-4ccc-bd62-6a66ae824cde)

2. Then enter a date that is more than 30 days ago and submit the form. The error text should be updated and look like this:
![image](https://github.com/user-attachments/assets/a86847ef-3545-466d-8a89-3cedaee1230a)

3. Proceed through the workflow until you can download the PDF as an applicant. Verify that the prompt for "Application or recertification date" has changed to "SNAP application or recertification interview date"
![image](https://github.com/user-attachments/assets/ab229ba4-83b6-4f34-bd85-24de483726f1)

4. Append `?is_caseworker=true` to the URL you used to download the PDF in step 3 to download the caseworker version of the same PDF. Verify the same change in step 3 was made in this PDF.

## Testing
Use the Changes section when going through the NYC workflow. Observe the changes were made. No other testing is required.
