### PR TITLE
1391: Automate data retention and weekly report jobs

### DIFF
--- a/app/lib/tasks/weekly_reports.rake
+++ b/app/lib/tasks/weekly_reports.rake
@@ -1,0 +1,11 @@
+namespace :weekly_reports do
+  desc "Send weekly reports (NYC and later others?)"
+  task send_all: :environment do
+    report_date = Time.now.in_time_zone("America/New_York").beginning_of_week
+
+    WeeklyReportMailer
+      .with(site_id: "nyc", report_date: report_date.to_date)
+      .report_email
+      .deliver_now
+  end
+end

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -1,14 +1,17 @@
 locals {
-  # The `cron` here is the literal name of the scheduled job. It can be anything you want.
-  # For example "file_upload_jobs" or "daily_report". Whatever makes sense for your use case.
   # The `task_command` is what you want your scheduled job to run, for example: ["poetry", "run", "flask"].
   # Schedule expression defines the frequency at which the job should run.
   # The syntax for `schedule_expression` is explained in the following documentation:
   # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html
   scheduled_jobs = {
-    # cron = {
-    #   task_command        = ["python", "-m", "flask", "--app", "app.py", "cron"]
-    #   schedule_expression = "cron(0 * ? * * *)"
-    # }
+    send_weekly_reports = {
+      task_command        = ["bin/rails", "weekly_reports:send_all"]
+      schedule_expression = "cron(0 12 ? * MON *)" # Every Monday at 12pm UTC (7am EST / 8am EDT)
+    }
+
+    redact_data = {
+      task_command        = ["bin/rails", "data_deletion:redact_all"]
+      schedule_expression = "cron(0 14 ? * * *)" # Every day at 2pm UTC (9am EST / 10am EDT)
+    }
   }
 }


### PR DESCRIPTION
## Ticket

Resolves FFS-1391.

## Changes
The `template-infra` v0.12.2 release contains built-in cron job support
\- just in time, too. Let's give it a shot with our data retention and
weekly report jobs.

## Context for reviewers

These changes will be deployed automatically by the GH Action since
they are part of the app service.

## Testing

Will test in demo and verify that the data retention job is operating
correctly.
