### PR TITLE
1488: Explicitly set margin to something slightly higher than the default

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -30,7 +30,13 @@ class Cbv::SummariesController < Cbv::BaseController
         render pdf: "#{@cbv_flow.id}",
           layout: "pdf",
           locals: { is_caseworker: Rails.env.development? && params[:is_caseworker] },
-          footer: { right: "Income Verification Report | Page [page] of [topage]", font_size: 10 }
+          footer: { right: "Income Verification Report | Page [page] of [topage]", font_size: 10 },
+          margin:  {
+            top:               12,
+            bottom:            12,
+            left:              12,
+            right:             12
+          }
       end
     end
   end


### PR DESCRIPTION
## Ticket

https://jiraent.cms.gov/browse/FFS-1488

## Changes

Explicitly sets margins during PDF generation

## Context for reviewers

See discussion here: https://nava.slack.com/archives/C06FC5TPAR3/p1728411846834959?thread_ts=1724784739.697159&cid=C06FC5TPAR3

When margins are not set (or set to 0), the margin page numbers are not included. This is just an experiment to see. 
