### PR TITLE
Allow deduping all NewRelic events per invitation

### DIFF
--- a/app/app/controllers/api/pinwheel_controller.rb
+++ b/app/app/controllers/api/pinwheel_controller.rb
@@ -25,6 +25,7 @@ class Api::PinwheelController < ApplicationController
   def track_event
     NewRelicEventTracker.track("ApplicantBeganLinkingEmployer", {
       cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
       response_type: token_params[:response_type]
     })
   rescue => ex

--- a/app/app/controllers/cbv/agreements_controller.rb
+++ b/app/app/controllers/cbv/agreements_controller.rb
@@ -3,7 +3,8 @@ class Cbv::AgreementsController < Cbv::BaseController
     NewRelicEventTracker.track("ApplicantViewedAgreement", {
       timestamp: Time.now.to_i,
       site_id: @cbv_flow.site_id,
-      cbv_flow_id: @cbv_flow.id
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   end
 
@@ -12,7 +13,8 @@ class Cbv::AgreementsController < Cbv::BaseController
       NewRelicEventTracker.track("ApplicantAgreed", {
         timestamp: Time.now.to_i,
         site_id: @cbv_flow.site_id,
-        cbv_flow_id: @cbv_flow.id
+        cbv_flow_id: @cbv_flow.id,
+        invitation_id: @cbv_flow.cbv_flow_invitation_id
       })
       redirect_to next_path
     else

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -29,6 +29,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
 
     NewRelicEventTracker.track("ApplicantSearchedForEmployer", {
       cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
       num_results: @employers.length,
       has_pinwheel_account: @has_pinwheel_account
     })

--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -151,6 +151,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
 
     NewRelicEventTracker.track("ApplicantViewedPaymentDetails", {
       cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
       pinwheel_account_id: @pinwheel_account.id,
       payments_length: @payments.length,
       has_employment_data: has_employment_data?,
@@ -166,6 +167,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
 
     NewRelicEventTracker.track("ApplicantSavedPaymentDetails", {
       cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
       additional_information_length: comment_data ? comment_data["comment"].length : 0
     })
   rescue => ex

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -24,7 +24,8 @@ class Cbv::SummariesController < Cbv::BaseController
         NewRelicEventTracker.track("ApplicantDownloadedIncomePDF", {
           timestamp: Time.now.to_i,
           site_id: @cbv_flow.site_id,
-          cbv_flow_id: @cbv_flow.id
+          cbv_flow_id: @cbv_flow.id,
+          invitation_id: @cbv_flow.cbv_flow_invitation_id
         })
 
         render pdf: "#{@cbv_flow.id}",

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -57,6 +57,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
   def track_account_synced_event(cbv_flow, pinwheel_account)
     NewRelicEventTracker.track("PinwheelAccountSyncFinished", {
       cbv_flow_id: cbv_flow.id,
+      invitation_id: cbv_flow.cbv_flow_invitation_id,
       identity_success: pinwheel_account.job_succeeded?("identity"),
       identity_supported: pinwheel_account.supported_jobs.include?("identity"),
       income_success: pinwheel_account.job_succeeded?("income"),
@@ -74,6 +75,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
   def track_account_created_event(cbv_flow, platform_name)
     NewRelicEventTracker.track("PinwheelAccountCreated", {
       cbv_flow_id: cbv_flow.id,
+      invitation_id: cbv_flow.cbv_flow_invitation_id,
       platform_name: platform_name
     })
   end

--- a/app/app/mailers/application_mailer.rb
+++ b/app/app/mailers/application_mailer.rb
@@ -1,8 +1,24 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "noreply@mail.#{ENV["DOMAIN_NAME"]}"
   layout "mailer"
+  after_deliver :track_delivery
 
   def site_config
     Rails.application.config.sites
+  end
+
+  private
+
+  def track_delivery
+    NewRelicEventTracker.track("EmailSent", {
+      mailer: self.class.name,
+      action: action_name,
+      message_id: mail.message_id,
+
+      # Include a couple attributes that are passed in as params to subclasses,
+      # to help with linking metadata without including any PII.
+      cbv_flow_id: params[:cbv_flow]&.id,
+      invitation_id: params[:cbv_flow_invitation]&.id
+    })
   end
 end

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Api::PinwheelController do
         .to receive(:track)
         .with("ApplicantBeganLinkingEmployer", hash_including(
           cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
           response_type: "employer",
         ))
       post :create_token, params: valid_params

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Cbv::EmployerSearchesController do
           .to receive(:track)
           .with("ApplicantSearchedForEmployer", hash_including(
             cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
             num_results: 1,
             has_pinwheel_account: false
           ))

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Cbv::PaymentDetailsController do
           .to receive(:track)
           .with("ApplicantViewedPaymentDetails", hash_including(
             cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
             pinwheel_account_id: pinwheel_account.id,
             payments_length: 1,
             has_employment_data: true,
@@ -221,6 +222,7 @@ RSpec.describe Cbv::PaymentDetailsController do
         .to receive(:track)
         .with("ApplicantSavedPaymentDetails", hash_including(
           cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
           additional_information_length: comment.length
         ))
 

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
         expect(NewRelicEventTracker).to receive(:track)
           .with("PinwheelAccountCreated", {
             cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
             platform_name: "acme"
           })
 
@@ -106,6 +107,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
         expect(NewRelicEventTracker).to receive(:track)
           .with("PinwheelAccountSyncFinished", {
             cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
             identity_success: false,
             identity_supported: true,
             income_success: true,

--- a/app/spec/mailers/weekly_report_mailer_spec.rb
+++ b/app/spec/mailers/weekly_report_mailer_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe WeeklyReportMailer, type: :mailer do
     expect(mail.body.encoded).to include("Attached is a report from")
   end
 
+  it "tracks newrelic" do
+    expect(NewRelicEventTracker).to receive(:track)
+      .with("EmailSent", hash_including(
+        mailer: "WeeklyReportMailer",
+        action: "report_email",
+        message_id: be_a(String)
+      ))
+
+    mail.deliver_now
+  end
+
   it "renders the csv data from the week before the report_date" do
     expect(mail.attachments.first.filename).to eq("weekly_report_20240902-20240908.csv")
     expect(mail.attachments.first.content_type).to start_with('text/csv')


### PR DESCRIPTION
## Ticket

N/A - Came up when chatting with NYC.

## Changes

Two changes, related to NewRelic. The second is unrelated, but also will be
helpful:

- **Track `invitation_id` attribute on all pageview events**
- **Add NewRelic event for `EmailSent`**

## Context for reviewers

This came up when chatting with NYC, as we noticed that it's been hard to
deduplicate the funnel per-invitation.

## Testing

Unit tests updated.
