### PR TITLE
Fix data redaction to only redact records once

### DIFF
--- a/app/app/models/concerns/redactable.rb
+++ b/app/app/models/concerns/redactable.rb
@@ -24,6 +24,11 @@ module Redactable
     uuid: "00000000-0000-0000-0000-000000000000"
   }
 
+  included do
+    scope :redacted, -> { where.not(REDACTED_TIMESTAMP_COLUMN => nil) }
+    scope :unredacted, -> { where(REDACTED_TIMESTAMP_COLUMN => nil) }
+  end
+
   class_methods do
     attr_accessor :fields_to_redact
 

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -16,6 +16,7 @@ class DataRetentionService
   def redact_invitations
     CbvFlowInvitation
       .unstarted
+      .unredacted
       .find_each do |cbv_flow_invitation|
         cbv_flow_invitation.redact! if Time.now.after?(cbv_flow_invitation.expires_at + REDACT_UNUSED_INVITATIONS_AFTER)
       end
@@ -24,6 +25,7 @@ class DataRetentionService
   def redact_incomplete_cbv_flows
     CbvFlow
       .incomplete
+      .unredacted
       .includes(:cbv_flow_invitation)
       .find_each do |cbv_flow|
         invitation_redact_at = cbv_flow.cbv_flow_invitation.expires_at + REDACT_UNUSED_INVITATIONS_AFTER
@@ -36,6 +38,7 @@ class DataRetentionService
 
   def redact_complete_cbv_flows
     CbvFlow
+      .unredacted
       .where("transmitted_at < ?", REDACT_TRANSMITTED_CBV_FLOWS_AFTER.ago)
       .includes(:cbv_flow_invitation)
       .find_each do |cbv_flow|

--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -45,6 +45,10 @@ common: &default_settings
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  # Instrument CBV custom rake tasks:
+  rake:
+    tasks: ["data_deletion:.+", "weekly_reports:.+"]
+
   error_collector:
     # Ignore errors that aren't likely related to user-facing issues (e.g.
     # triggered by automated scanners)

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe DataRetentionService do
             redacted_at: within(1.second).of(Time.now)
           )
         end
+
+        it "skips the invitation if it has already been redacted" do
+          cbv_flow_invitation.redact!
+
+          expect_any_instance_of(CbvFlowInvitation)
+            .not_to receive(:redact!)
+          service.redact_invitations
+        end
       end
     end
   end
@@ -89,6 +97,13 @@ RSpec.describe DataRetentionService do
         expect(cbv_flow_invitation.reload).to have_attributes(
           case_number: "REDACTED"
         )
+      end
+
+      it "skips redacting already-redacted CbvFlows" do
+        service.redact_incomplete_cbv_flows
+
+        expect_any_instance_of(CbvFlow).not_to receive(:redact!)
+        service.redact_incomplete_cbv_flows
       end
 
       context "for a complete CbvFlow" do
@@ -164,6 +179,13 @@ RSpec.describe DataRetentionService do
         expect(cbv_flow_invitation.reload).to have_attributes(
           case_number: "REDACTED"
         )
+      end
+
+      it "skips redacting already-redacted CbvFlows" do
+        service.redact_complete_cbv_flows
+
+        expect_any_instance_of(CbvFlow).not_to receive(:redact!)
+        service.redact_complete_cbv_flows
       end
     end
   end


### PR DESCRIPTION
## Ticket

N/A - Bugfix.

## Changes

While running data redaction, I noticed that it was redacting every record
every time. To avoid wasting time on this every time redaction is run, let's
skip redacting any records that have previously been redacted.

## Context for reviewers

Also, I noticed the error wasn't reported to NewRelic. I've added rake task
monitoring in an attempt to fix that.

## Testing

Unit tests included. Will test manually in demo.
