### PR TITLE
1473: Create a git tag after deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [database-migrations]
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -48,3 +48,19 @@ jobs:
       - name: Deploy release
         working-directory: .
         run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }}
+
+      - name: Push git tag with timestamp
+        if: success()
+        run: |
+          # Create a tag like "deploy/prod/2024-10-09-11:00:00".
+          #
+          # Skip tagging in "dev" environment (our demo site) since we deploy
+          # on every commit.
+          if [ "${{ inputs.environment }}" != "dev" ]; then
+            export TZ="America/New_York"
+            TAG_NAME="deploy/${{ inputs.environment }}/$(date +'%Y-%m-%d-%H:%M:%S')"
+            git config --local user.name "github-actions"
+            git config --local user.email "github-actions@github.com"
+            git tag "$TAG_NAME"
+            git push origin "$TAG_NAME"
+          fi


### PR DESCRIPTION
## Ticket

Resolves FFS-1473.

## Changes

This is an attempt to create a tag after each deploy so we can get
Github to help us see when any commit was deployed.
## Context for reviewers

N/A

## Testing

I don't have a good way to test this, so we'll have to see how it works
on our next production deploy.
