### PR TITLE
1773: Include overtime hours in "Number of hours worked" PDF field

### DIFF
--- a/app/spec/controllers/concerns/cbv/reports_helper_spec.rb
+++ b/app/spec/controllers/concerns/cbv/reports_helper_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe Cbv::ReportsHelper, type: :helper do
               gross_pay_amount: 480720,
               hours: 80,
               pay_date: "2020-12-31",
-              rate: 4759,
               start: "2020-12-10",
               gross_pay_ytd: 6971151,
               gross_pay_amount: 480720,

--- a/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_multiple_hourly_rates_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_multiple_hourly_rates_response.json
@@ -1,0 +1,117 @@
+{
+  "data": [
+    {
+      "account_id": "03e29160-f7e7-4a28-b2d8-813640e030d3",
+      "check_amount": 328609,
+      "created_at": "2021-01-10T19:54:45.745660+00:00",
+      "currency": "USD",
+      "deductions": [
+        {
+          "amount": 7012,
+          "category": "retirement",
+          "name": "401k",
+          "type": "pre_tax"
+        },
+        {
+          "amount": 57692,
+          "category": "commuter",
+          "name": "MTA",
+          "type": "post_tax"
+        },
+        {
+          "amount": 0,
+          "category": "empty_deduction",
+          "name": "empty_deduction",
+          "type": "empty_deduction"
+        }
+      ],
+      "document": {
+        "download_url": "https://s3.us-east-1.amazonaws.com/paystub_document",
+        "download_url_expiration": "2022-04-04T18:13:55.123450+00:00",
+        "id": "aea8cc55-93fa-452d-8eac-b83c80b19a41"
+      },
+      "earnings": [
+        {
+          "name": "Regular",
+          "category": "hourly",
+          "amount": 6650,
+          "rate": 1900,
+          "hours": 3.5
+        },
+        {
+          "name": "Premium $1.5",
+          "category": "premium",
+          "amount": 375,
+          "rate": 150,
+          "hours": 2.5
+        },
+        {
+          "name": "Personal Time",
+          "category": "pto",
+          "amount": 0,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Premium $2.0",
+          "category": "premium",
+          "amount": 0,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Premium $3.0",
+          "category": "premium",
+          "amount": 0,
+          "rate": null,
+          "hours": null
+        }
+      ],
+      "employer_name": "Acme Corp",
+      "gross_pay_amount": 480720,
+      "gross_pay_ytd": 6971151,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "net_pay_amount": 321609,
+      "net_pay_ytd": 4357992,
+      "pay_date": "2020-12-31",
+      "pay_period_end": "2020-12-24",
+      "pay_period_start": "2020-12-10",
+      "taxes": [
+        {
+          "amount": 65158,
+          "category": "federal_income",
+          "name": "Federal Income"
+        },
+        {
+          "amount": 29249,
+          "category": "state_income",
+          "name": "State Income"
+        }
+      ],
+      "time_off": [
+        {
+          "available_hours": 41.5,
+          "category": "pto",
+          "earned_hours": 0,
+          "name": "Vacation",
+          "used_hours": 38.5
+        },
+        {
+          "available_hours": 41.5,
+          "category": "sick",
+          "earned_hours": 0,
+          "name": "Sick Leave",
+          "used_hours": 38.5
+        }
+      ],
+      "total_deductions": 64704,
+      "total_reimbursements": 7000,
+      "total_taxes": 94407
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "next_cursor": "eyJlbXBsb3llciI6ICJVbml0ZWQgUGFyY2VsIFNlcnZpY2UifQ==",
+    "refreshed_at": "2021-01-10T19:54:45.745660+00:00"
+  }
+}

--- a/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_no_hours_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_no_hours_response.json
@@ -1,0 +1,88 @@
+{
+  "data": [
+    {
+      "account_id": "03e29160-f7e7-4a28-b2d8-813640e030d3",
+      "check_amount": 328609,
+      "created_at": "2021-01-10T19:54:45.745660+00:00",
+      "currency": "USD",
+      "deductions": [],
+      "document": {
+        "download_url": "https://s3.us-east-1.amazonaws.com/paystub_document",
+        "download_url_expiration": "2022-04-04T18:13:55.123450+00:00",
+        "id": "aea8cc55-93fa-452d-8eac-b83c80b19a41"
+      },
+      "earnings": [
+        {
+          "name": "Ride Earnings",
+          "category": "fare",
+          "amount": 64095,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Tips",
+          "category": "tips",
+          "amount": 1797,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Bonuses",
+          "category": "bonus",
+          "amount": 2525,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Tolls",
+          "category": "other",
+          "amount": 1388,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "TLC Rate Adjustments",
+          "category": "other",
+          "amount": 86,
+          "rate": null,
+          "hours": null
+        }
+      ],
+      "employer_name": "Acme Corp",
+      "gross_pay_amount": 69891,
+      "gross_pay_ytd": null,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "net_pay_amount": 69891,
+      "net_pay_ytd": null,
+      "pay_date": "2020-12-31",
+      "pay_period_end": "2020-12-24",
+      "pay_period_start": "2020-12-10",
+      "taxes": [
+      ],
+      "time_off": [
+        {
+          "available_hours": 41.5,
+          "category": "pto",
+          "earned_hours": 0,
+          "name": "Vacation",
+          "used_hours": 38.5
+        },
+        {
+          "available_hours": 41.5,
+          "category": "sick",
+          "earned_hours": 0,
+          "name": "Sick Leave",
+          "used_hours": 38.5
+        }
+      ],
+      "total_deductions": 64704,
+      "total_reimbursements": 7000,
+      "total_taxes": 94407
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "next_cursor": "eyJlbXBsb3llciI6ICJVbml0ZWQgUGFyY2VsIFNlcnZpY2UifQ==",
+    "refreshed_at": "2021-01-10T19:54:45.745660+00:00"
+  }
+}

--- a/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_overtime_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_overtime_response.json
@@ -1,0 +1,110 @@
+{
+  "data": [
+    {
+      "account_id": "03e29160-f7e7-4a28-b2d8-813640e030d3",
+      "check_amount": 328609,
+      "created_at": "2021-01-10T19:54:45.745660+00:00",
+      "currency": "USD",
+      "deductions": [
+        {
+          "amount": 7012,
+          "category": "retirement",
+          "name": "401k",
+          "type": "pre_tax"
+        },
+        {
+          "amount": 57692,
+          "category": "commuter",
+          "name": "MTA",
+          "type": "post_tax"
+        },
+        {
+          "amount": 0,
+          "category": "empty_deduction",
+          "name": "empty_deduction",
+          "type": "empty_deduction"
+        }
+      ],
+      "document": {
+        "download_url": "https://s3.us-east-1.amazonaws.com/paystub_document",
+        "download_url_expiration": "2022-04-04T18:13:55.123450+00:00",
+        "id": "aea8cc55-93fa-452d-8eac-b83c80b19a41"
+      },
+      "earnings": [
+        {
+          "name": "Retro Time Entry",
+          "category": "retro_pay",
+          "amount": 0,
+          "rate": 0,
+          "hours": 0.0
+        },
+        {
+          "name": "Sick Pay",
+          "category": "sick",
+          "amount": 0,
+          "rate": 0,
+          "hours": 0.0
+        },
+        {
+          "name": "Time Entry",
+          "category": "hourly",
+          "amount": 19500,
+          "rate": 1500,
+          "hours": 13.00
+        },
+        {
+          "name": "Holiday\nWorked",
+          "category": "overtime",
+          "amount": 11250,
+          "rate": 2250,
+          "hours": 5.00
+        }
+      ],
+      "employer_name": "Acme Corp",
+      "gross_pay_amount": 480720,
+      "gross_pay_ytd": 6971151,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "net_pay_amount": 321609,
+      "net_pay_ytd": 4357992,
+      "pay_date": "2020-12-31",
+      "pay_period_end": "2020-12-24",
+      "pay_period_start": "2020-12-10",
+      "taxes": [
+        {
+          "amount": 65158,
+          "category": "federal_income",
+          "name": "Federal Income"
+        },
+        {
+          "amount": 29249,
+          "category": "state_income",
+          "name": "State Income"
+        }
+      ],
+      "time_off": [
+        {
+          "available_hours": 41.5,
+          "category": "pto",
+          "earned_hours": 0,
+          "name": "Vacation",
+          "used_hours": 38.5
+        },
+        {
+          "available_hours": 41.5,
+          "category": "sick",
+          "earned_hours": 0,
+          "name": "Sick Leave",
+          "used_hours": 38.5
+        }
+      ],
+      "total_deductions": 64704,
+      "total_reimbursements": 7000,
+      "total_taxes": 94407
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "next_cursor": "eyJlbXBsb3llciI6ICJVbml0ZWQgUGFyY2VsIFNlcnZpY2UifQ==",
+    "refreshed_at": "2021-01-10T19:54:45.745660+00:00"
+  }
+}

--- a/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_sick_time_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_sick_time_response.json
@@ -1,0 +1,110 @@
+{
+  "data": [
+    {
+      "account_id": "03e29160-f7e7-4a28-b2d8-813640e030d3",
+      "check_amount": 328609,
+      "created_at": "2021-01-10T19:54:45.745660+00:00",
+      "currency": "USD",
+      "deductions": [
+        {
+          "amount": 7012,
+          "category": "retirement",
+          "name": "401k",
+          "type": "pre_tax"
+        },
+        {
+          "amount": 57692,
+          "category": "commuter",
+          "name": "MTA",
+          "type": "post_tax"
+        },
+        {
+          "amount": 0,
+          "category": "empty_deduction",
+          "name": "empty_deduction",
+          "type": "empty_deduction"
+        }
+      ],
+      "document": {
+        "download_url": "https://s3.us-east-1.amazonaws.com/paystub_document",
+        "download_url_expiration": "2022-04-04T18:13:55.123450+00:00",
+        "id": "aea8cc55-93fa-452d-8eac-b83c80b19a41"
+      },
+      "earnings": [
+        {
+          "name": "Retro Time Entry",
+          "category": "retro_pay",
+          "amount": 0,
+          "rate": 0,
+          "hours": 0.0
+        },
+        {
+          "name": "Sick Pay",
+          "category": "sick",
+          "amount": 4500,
+          "rate": 1500,
+          "hours": 3.0
+        },
+        {
+          "name": "Time Entry",
+          "category": "hourly",
+          "amount": 6000,
+          "rate": 1500,
+          "hours": 4.00
+        },
+        {
+          "name": "Holiday\nWorked",
+          "category": "premium",
+          "amount": 0,
+          "rate": 0,
+          "hours": 0.0
+        }
+      ],
+      "employer_name": "Acme Corp",
+      "gross_pay_amount": 480720,
+      "gross_pay_ytd": 6971151,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "net_pay_amount": 321609,
+      "net_pay_ytd": 4357992,
+      "pay_date": "2020-12-31",
+      "pay_period_end": "2020-12-24",
+      "pay_period_start": "2020-12-10",
+      "taxes": [
+        {
+          "amount": 65158,
+          "category": "federal_income",
+          "name": "Federal Income"
+        },
+        {
+          "amount": 29249,
+          "category": "state_income",
+          "name": "State Income"
+        }
+      ],
+      "time_off": [
+        {
+          "available_hours": 41.5,
+          "category": "pto",
+          "earned_hours": 0,
+          "name": "Vacation",
+          "used_hours": 38.5
+        },
+        {
+          "available_hours": 41.5,
+          "category": "sick",
+          "earned_hours": 0,
+          "name": "Sick Leave",
+          "used_hours": 38.5
+        }
+      ],
+      "total_deductions": 64704,
+      "total_reimbursements": 7000,
+      "total_taxes": 94407
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "next_cursor": "eyJlbXBsb3llciI6ICJVbml0ZWQgUGFyY2VsIFNlcnZpY2UifQ==",
+    "refreshed_at": "2021-01-10T19:54:45.745660+00:00"
+  }
+}

--- a/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_start_bonus_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_paystubs_with_start_bonus_response.json
@@ -1,0 +1,58 @@
+{
+  "data": [
+    {
+      "account_id": "03e29160-f7e7-4a28-b2d8-813640e030d3",
+      "check_amount": 328609,
+      "created_at": "2021-01-10T19:54:45.745660+00:00",
+      "currency": "USD",
+      "deductions": [],
+      "document": {
+        "download_url": "https://s3.us-east-1.amazonaws.com/paystub_document",
+        "download_url_expiration": "2022-04-04T18:13:55.123450+00:00",
+        "id": "aea8cc55-93fa-452d-8eac-b83c80b19a41"
+      },
+      "earnings": [
+        {
+          "name": "Regular",
+          "category": "hourly",
+          "amount": 18000,
+          "rate": 1800,
+          "hours": 10.00
+        },
+        {
+          "name": "New Hire Bnus",
+          "category": "other",
+          "amount": 50000,
+          "rate": null,
+          "hours": null
+        },
+        {
+          "name": "Shift Pay",
+          "category": "premium",
+          "amount": 1000,
+          "rate": 100,
+          "hours": 10.00
+        }
+      ],
+      "employer_name": "Acme Corp",
+      "gross_pay_amount": 65903,
+      "gross_pay_ytd": 65903,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "net_pay_amount": 41444,
+      "net_pay_ytd": 41444,
+      "pay_date": "2020-12-31",
+      "pay_period_end": "2020-12-24",
+      "pay_period_start": "2020-12-10",
+      "taxes": [],
+      "time_off": [],
+      "total_deductions": 64704,
+      "total_reimbursements": 7000,
+      "total_taxes": 94407
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "next_cursor": "eyJlbXBsb3llciI6ICJVbml0ZWQgUGFyY2VsIFNlcnZpY2UifQ==",
+    "refreshed_at": "2021-01-10T19:54:45.745660+00:00"
+  }
+}


### PR DESCRIPTION
## Ticket

Resolves FFS-1773.

## Changes

* Add `earnings` entries with category="overtime" into the hours calculation.

## Context for reviewers

See the comment in https://jiraent.cms.gov/browse/FFS-1773 for a
longwinded explanation of why this seems like the best way to make the
"Number of hours worked" field align better with reality.

## Testing

Unit tests included for a number of cases I copied from real data. Only the
"earnings" hash is copied from real data, and I anonomyzied it somewhat by
rounding the numbers.
