### PR TITLE
1865: [bugfix] NYC applicant success page shows incorrect agency name.

### DIFF
--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -298,8 +298,8 @@ en:
         back_to_agency: Go to %{agency_short_name} website
         caseworker_received: We have delivered your payment information to %{agency_acronym}. They will contact you if any additional information is needed.
         check_status:
-          nyc: To check the status of your SNAP application or recertification you can visit HRA's website.
           ma: To check the status of your SNAP recertification you can visit DTA's website.
+          nyc: To check the status of your SNAP application or recertification you can visit HRA's website.
         confirmation_code_html: "<strong>Confirmation code</strong>: %{confirmation_code}"
         download: Download a copy of the report
         header: Your income report has been successfully shared with %{agency_acronym}

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -298,7 +298,7 @@ en:
         back_to_agency: Go to %{agency_short_name} website
         caseworker_received: We have delivered your payment information to %{agency_acronym}. They will contact you if any additional information is needed.
         check_status:
-          default: To check the status of your SNAP application or recertification you can visit DTA's website.
+          nyc: To check the status of your SNAP application or recertification you can visit HRA's website.
           ma: To check the status of your SNAP recertification you can visit DTA's website.
         confirmation_code_html: "<strong>Confirmation code</strong>: %{confirmation_code}"
         download: Download a copy of the report

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -193,8 +193,8 @@ es:
         back_to_agency: Vaya al sitio web de %{agency_short_name}
         caseworker_received: Hemos enviado su información de pago a %{agency_acronym}. Ellos lo contactarán si se necesita alguna información adicional.
         check_status:
-          nyc: Para comprobar el estado de su solicitud o recertificación de SNAP puede visitar el sitio web del HRA.
           ma: Para comprobar el estado de su recertificación de SNAP puede visitar el sitio web del DTA.
+          nyc: Para comprobar el estado de su solicitud o recertificación de SNAP puede visitar el sitio web del HRA.
         confirmation_code_html: "<strong>Código de confirmación </strong>: %{confirmation_code}"
         download: Descargue una copia del informe
         header: Su informe de ingresos ha sido compartido de forma exitosa con %{agency_acronym}

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -193,7 +193,7 @@ es:
         back_to_agency: Vaya al sitio web de %{agency_short_name}
         caseworker_received: Hemos enviado su información de pago a %{agency_acronym}. Ellos lo contactarán si se necesita alguna información adicional.
         check_status:
-          default: Para comprobar el estado de su solicitud o recertificación de SNAP puede visitar el sitio web del DTA.
+          nyc: Para comprobar el estado de su solicitud o recertificación de SNAP puede visitar el sitio web del HRA.
           ma: Para comprobar el estado de su recertificación de SNAP puede visitar el sitio web del DTA.
         confirmation_code_html: "<strong>Código de confirmación </strong>: %{confirmation_code}"
         download: Descargue una copia del informe


### PR DESCRIPTION
[FFS-1865
](https://jiraent.cms.gov/browse/FFS-1865)


## Changes

Replaced the `default` entry with `nyc` for the success page

### English
![Screenshot 2024-10-10 at 3 57 48 PM](https://github.com/user-attachments/assets/4b00d24e-6957-4085-80eb-c2b895c59b8a)

### Spanish
![Screenshot 2024-10-10 at 3 57 41 PM](https://github.com/user-attachments/assets/787a539b-de3e-42c5-84f5-cd664cb76e70)
