### PR TITLE
1488: Reset PDF margins back to 10

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -33,10 +33,10 @@ class Cbv::SummariesController < Cbv::BaseController
           locals: { is_caseworker: Rails.env.development? && params[:is_caseworker] },
           footer: { right: "Income Verification Report | Page [page] of [topage]", font_size: 10 },
           margin:  {
-            top:               12,
-            bottom:            12,
-            left:              12,
-            right:             12
+            top:               10,
+            bottom:            10,
+            left:              10,
+            right:             10
           }
       end
     end


### PR DESCRIPTION
## Ticket

Addresses 1488

## Changes

Sets back to the default. The previous size was too large. 

This _did_ fix a minor issue where defaults were apparently ignored in production.

## Context for reviewers

It doesn't address any of the substance of 1488, unfortunately. 
