### PR TITLE
Fix permissions on Github Actions token

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   deploy:
     permissions:
-      contents: read
+      contents: write
       id-token: write
     name: Deploy
     uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
We need to give the deploy workflow `write` permission so it can post a
tag after the deploy finishes. I had forgotten to do it in my last commit:
https://github.com/DSACMS/iv-cbv-payroll/pull/315
