### PR TITLE
Fix deploy tagging to use dashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
           # on every commit.
           if [ "${{ inputs.environment }}" != "dev" ]; then
             export TZ="America/New_York"
-            TAG_NAME="deploy/${{ inputs.environment }}/$(date +'%Y-%m-%d-%H:%M:%S')"
+            TAG_NAME="deploy/${{ inputs.environment }}/$(date +'%Y-%m-%d-%H-%M-%S')"
             git config --local user.name "github-actions"
             git config --local user.email "github-actions@github.com"
             git tag "$TAG_NAME"


### PR DESCRIPTION
## Ticket

N/A

## Changes

Oops - git tags cannot contain colons.

## Context for reviewers

N/A

## Testing

Tested this locally and pushed the tag to Github here:
https://github.com/DSACMS/iv-cbv-payroll/releases/tag/deploy/prod/2024-10-17-15-15-39
