### PR TITLE
Improve docs for running local Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,18 @@ To enable automatic ruby linting and terraform formatting on every `git commit` 
 
 ## CI/CD
 
-GitHub actions are used to run all tests and scans as part of pull requests.
+GitHub Actions are used to run all tests and scans as part of pull requests.
 
-Security scans are also run on a scheduled basis. Weekly for static code scans, and daily for dependency scans.
+## Vulnerability Scanning
+
+We also run vulnerability scanners on every pull request. See [Vulnerability Management](/docs/infra/vulnerability-management.md) documentation for more details.
+
+## Running a production image locally
+
+To debug locally an image built for deployment, see [the Running Built Images Locally runbook](/docs/app/runbooks/running-built-images-locally.md).
 
 
 # Deployment
-
-TK
 
 ## Demo
 

--- a/docs/app/runbooks/running-built-images-locally.md
+++ b/docs/app/runbooks/running-built-images-locally.md
@@ -1,0 +1,33 @@
+# Running Built Images Locally
+
+When debugging problems that are hard to reproduce locally, you may find it useful to run a production image locally.
+
+Follow these steps to run an image that was built to deploy to demo/production:
+
+```
+# 1. Authenticate to AWS Elastic Container Repository:
+AWS_PROFILE=prod aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin 730335532059.dkr.ecr.us-east-1.amazonaws.com
+
+# 2. Get the latest Production image name
+image_tag=$(curl https://snap-income-pilot.com/health | jq -r .version)
+image_name="730335532059.dkr.ecr.us-east-1.amazonaws.com/iv-cbv-payroll-app:$image_tag"
+
+# 3. Run the docker image
+# (in the "app" subdirectory)
+docker run --read-only --mount type=bind,source=$(pwd)/tmp,target=/rails/tmp --publish 3001:3000 --env-file .env --env-file .env.development.local -e GNUPGHOME=/rails/tmp -e SECRET_KEY_BASE=$(openssl rand -hex 64) -e DOMAIN_NAME="localhost:3000" -e RAILS_SERVE_STATIC_FILES=true -ti "$image_name" bash
+
+# 4. In the docker image, start the server:
+bin/rails server
+
+# 5. Since we require TLS in production, you will need to run a local proxy (outside docker):
+npx local-ssl-proxy --source 3000 --target 3001
+
+# 6. Access it in your browser at https://localhost:3000. (Disregard the security warning.)
+#
+# Note that most functionality will not work - as this will not connect to the
+# database properly. (You will need to pass more environment variables for that
+to work.)
+```
+
+:warning: **Warning:** The docker image repository is hosted in our production account. You should not push to the production image repository under any normal circumstance - let's make sure all our images are built via Github Actions!

--- a/docs/infra/vulnerability-management.md
+++ b/docs/infra/vulnerability-management.md
@@ -32,8 +32,17 @@ The hadolint scanner allows you to ignore or safelist certain findings, which ca
 ### Trivy
 The trivy scanner allows you to ignore or safelist certain findings, which can be specified in the [.trivyignore](../../.trivyignore) file. There is a template file here that you can use in your repo.
 
-### Anchore
-The anchore scanner allows you to ignore or safelist certain findings, which can be specified in the [.grype.yml](../../.grype.yml) file. There is a template file here that you can use in your repo. There are flags set to ignore findings that are in the state `not-fixed`, `wont-fix`, and `unknown`.
+### Anchore (Grype)
+The Grype scanner is a Docker image scanner made by the company Anchore. It allows you to ignore or safelist certain findings, which can be specified in the [.grype.yml](../../.grype.yml) file. There are flags set to ignore findings that are in the state `not-fixed`, `wont-fix`, and `unknown`.
+
+To debug a vulnerable system-level dependency of unknown origin, [download the CI-built image](/docs/app/runbooks/running-built-images-locally.md) and run:
+
+```bash
+image_name=730335532059.dkr.ecr.us-east-1.amazonaws.com/iv-cbv-payroll-app:[image_tag]
+
+grype --config .grype.yml -o json --fail-on medium "$image_name" |
+  jq '.matches | map(.artifact | { name, version, "location": .locations[0].path })'
+```
 
 ### Dockle
 The dockle scanner action does not have the ability to use an ignore or safelist findings file, but is able to by specifying an allow file, or `DOCKLE_ACCEPT_FILES`, environmental variable. To get around this, before the dockle scan runs, a prior step checks for a file named [.dockleconfig](../../.dockleconfig) and pipes it to the environmental variable if it exists. Note that this will not ignore finding types like the other scanner's ignore file, but ignore the file specified in the list.


### PR DESCRIPTION
## Ticket

N/A

## Changes

This adds documentation for a couple things I just needed to do:

1. Download and run the docker container locally
2. Investigate a `grype` failure that didn't explain what files were
   triggering the alert.

## Context for reviewers

N/A

## Testing

N/A
