### PR TITLE
FFS-1839: Add more events to NewRelic tracking

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -91,12 +91,9 @@ class Cbv::BaseController < ApplicationController
     response.headers["Expires"] = "#{1.year.ago}"
   end
 
-  def track_timeout_event
+  def track_timeout_event()
     NewRelicEventTracker.track("ApplicantTimedOut", {
-      timestamp: Time.now.to_i,
-      cbv_flow_id: @cbv_flow.id,
-      invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      has_pinwheel_account: @has_pinwheel_account
+      timestamp: Time.now.to_i
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantTimedOut): #{ex}"

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -91,7 +91,7 @@ class Cbv::BaseController < ApplicationController
     response.headers["Expires"] = "#{1.year.ago}"
   end
 
-  def track_timeout_event()
+  def track_timeout_event
     NewRelicEventTracker.track("ApplicantTimedOut", {
       timestamp: Time.now.to_i
     })

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -37,7 +37,7 @@ class Cbv::BaseController < ApplicationController
         redirect_to root_url
       end
     else
-      track_timeout_event()
+      track_timeout_event
       redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
     end
   end

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -29,8 +29,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
     NewRelicEventTracker.track("ApplicantAccessedSearchPage", {
       timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
-      invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      has_pinwheel_account: @has_pinwheel_account
+      invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantAccessedSearchPage): #{ex}"

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -1,7 +1,7 @@
 class Cbv::EmployerSearchesController < Cbv::BaseController
   # Disable CSP since Pinwheel relies on inline styles
   content_security_policy false, only: :show
-  before_action :track_accessed_search_event, only: :show
+  after_action :track_accessed_search_event, only: :show
   after_action :track_applicant_searched_event, only: :show
 
   def show
@@ -26,6 +26,8 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
   end
 
   def track_accessed_search_event
+    return if @query.present?
+
     NewRelicEventTracker.track("ApplicantAccessedSearchPage", {
       timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -27,6 +27,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
 
   def track_accessed_search_event
     NewRelicEventTracker.track("ApplicantAccessedSearchPage", {
+      timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       has_pinwheel_account: @has_pinwheel_account
@@ -39,10 +40,12 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
     return if @query.blank?
 
     NewRelicEventTracker.track("ApplicantSearchedForEmployer", {
+      timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       num_results: @employers.length,
-      has_pinwheel_account: @has_pinwheel_account
+      has_pinwheel_account: @has_pinwheel_account,
+      query: search_params[:query]
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantSearchedForEmployer): #{ex}"

--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -12,4 +12,15 @@ class Cbv::ExpiredInvitationsController < Cbv::BaseController
 
     Rails.application.config.sites[params[:site_id]]
   end
+
+  def track_expired_event
+    NewRelicEventTracker.track("ApplicantLinkExpired", {
+      timestamp: Time.now.to_i,
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      has_pinwheel_account: @has_pinwheel_account
+    })
+  rescue => ex
+    Rails.logger.error "Unable to track NewRelic event (ApplicantLinkExpired): #{ex}"
+  end
 end

--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -1,4 +1,5 @@
 class Cbv::ExpiredInvitationsController < Cbv::BaseController
+  before_action :track_expired_event, only: :show
   skip_before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete
   helper_method :current_site
 
@@ -15,10 +16,7 @@ class Cbv::ExpiredInvitationsController < Cbv::BaseController
 
   def track_expired_event
     NewRelicEventTracker.track("ApplicantLinkExpired", {
-      timestamp: Time.now.to_i,
-      cbv_flow_id: @cbv_flow.id,
-      invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      has_pinwheel_account: @has_pinwheel_account
+      timestamp: Time.now.to_i
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantLinkExpired): #{ex}"

--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -1,5 +1,18 @@
 class Cbv::MissingResultsController < Cbv::BaseController
+  before_action :track_missing_results_event, only: :show
+
   def show
     @has_pinwheel_account = @cbv_flow.pinwheel_accounts.any?
+  end
+
+  def track_missing_results_event
+    NewRelicEventTracker.track("ApplicantAccessedMissingResultsPage", {
+      timestamp: Time.now.to_i,
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      has_pinwheel_account: @has_pinwheel_account
+    })
+  rescue => ex
+    Rails.logger.error "Unable to track NewRelic event (ApplicantAccessedMissingResultsPage): #{ex}"
   end
 end

--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -9,8 +9,7 @@ class Cbv::MissingResultsController < Cbv::BaseController
     NewRelicEventTracker.track("ApplicantAccessedMissingResultsPage", {
       timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
-      invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      has_pinwheel_account: @has_pinwheel_account
+      invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantAccessedMissingResultsPage): #{ex}"

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -5,7 +5,7 @@ class Cbv::SuccessesController < Cbv::BaseController
   def show
   end
 
-  def track_accessed_success_event()
+  def track_accessed_success_event
     NewRelicEventTracker.track("ApplicantAccessedSuccessPage", {
       timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
@@ -15,5 +15,4 @@ class Cbv::SuccessesController < Cbv::BaseController
   rescue => ex
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
   end
-
 end

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -9,8 +9,7 @@ class Cbv::SuccessesController < Cbv::BaseController
     NewRelicEventTracker.track("ApplicantAccessedSuccessPage", {
       timestamp: Time.now.to_i,
       cbv_flow_id: @cbv_flow.id,
-      invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      has_pinwheel_account: @has_pinwheel_account
+      invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -1,6 +1,19 @@
 class Cbv::SuccessesController < Cbv::BaseController
+  before_action :track_accessed_success_event, only: :show
   skip_before_action :ensure_cbv_flow_not_yet_complete
 
   def show
   end
+
+  def track_accessed_success_event()
+    NewRelicEventTracker.track("ApplicantAccessedSuccessPage", {
+      timestamp: Time.now.to_i,
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      has_pinwheel_account: @has_pinwheel_account
+    })
+  rescue => ex
+    Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
+  end
+
 end

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -25,7 +25,8 @@ class Cbv::SummariesController < Cbv::BaseController
           timestamp: Time.now.to_i,
           site_id: @cbv_flow.site_id,
           cbv_flow_id: @cbv_flow.id,
-          invitation_id: @cbv_flow.cbv_flow_invitation_id
+          invitation_id: @cbv_flow.cbv_flow_invitation_id,
+          locale: I18n.locale
         })
 
         render pdf: "#{@cbv_flow.id}",

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -40,6 +40,8 @@ class Cbv::SummariesController < Cbv::BaseController
           }
       end
     end
+
+    track_accessed_income_summary_event(@cbv_flow, @payments)
   end
 
   def update
@@ -203,6 +205,23 @@ class Cbv::SummariesController < Cbv::BaseController
     })
   rescue => ex
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
+  end
+
+  def track_accessed_income_summary_event(cbv_flow, payments)
+    NewRelicEventTracker.track("IncomeSummaryAccessed", {
+      timestamp: Time.now.to_i,
+      site_id: cbv_flow.site_id,
+      cbv_flow_id: cbv_flow.id,
+      invitation_id: cbv_flow.cbv_flow_invitation_id,
+      account_count: payments.map { |p| p[:account_id] }.uniq.count,
+      paystub_count: payments.count,
+      account_count_with_additional_information:
+        cbv_flow.additional_information.values.count { |info| info["comment"].present? },
+      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
+      language: I18n.locale
+    })
+  rescue => ex
+    Rails.logger.error "Unable to track NewRelic event (IncomeSummaryAccessed): #{ex}"
   end
 
   def generate_confirmation_code(prefix = nil)

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -209,7 +209,7 @@ class Cbv::SummariesController < Cbv::BaseController
   end
 
   def track_accessed_income_summary_event(cbv_flow, payments)
-    NewRelicEventTracker.track("IncomeSummaryAccessed", {
+    NewRelicEventTracker.track("ApplicantAccessedIncomeSummary", {
       timestamp: Time.now.to_i,
       site_id: cbv_flow.site_id,
       cbv_flow_id: cbv_flow.id,
@@ -222,7 +222,7 @@ class Cbv::SummariesController < Cbv::BaseController
       language: I18n.locale
     })
   rescue => ex
-    Rails.logger.error "Unable to track NewRelic event (IncomeSummaryAccessed): #{ex}"
+    Rails.logger.error "Unable to track NewRelic event (ApplicantAccessedIncomeSummary): #{ex}"
   end
 
   def generate_confirmation_code(prefix = nil)

--- a/app/app/mailers/application_mailer.rb
+++ b/app/app/mailers/application_mailer.rb
@@ -14,6 +14,7 @@ class ApplicationMailer < ActionMailer::Base
       mailer: self.class.name,
       action: action_name,
       message_id: mail.message_id,
+      locale: I18n.locale,
 
       # Include a couple attributes that are passed in as params to subclasses,
       # to help with linking metadata without including any PII.

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Cbv::EmployerSearchesController do
           ))
         get :show
       end
-
     end
 
     context "when there are no employer search results" do

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Cbv::EmployerSearchesController do
       it "tracks a NewRelic event" do
         expect(NewRelicEventTracker)
           .to receive(:track)
-          .with("ApplicantSearchedForEmployer", hash_including(
+          .with("ApplicantAccessedSearchPage", hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             num_results: 1,

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -73,20 +73,13 @@ RSpec.describe Cbv::EmployerSearchesController do
 
       it "tracks a NewRelic event" do
         expect(NewRelicEventTracker)
-        .to receive(:track)
-        .with("ApplicantAccessedSearchPage", hash_including(
-          timestamp: be_a(Integer),
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id
-        ))
-        expect(NewRelicEventTracker)
           .to receive(:track)
           .with("ApplicantSearchedForEmployer", hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             num_results: 1,
             has_pinwheel_account: false
-          ))
+            ))
         get :show, params: { query: "results" }
       end
     end

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Cbv::EmployerSearchesController do
         expect(NewRelicEventTracker)
           .to receive(:track)
           .with("ApplicantAccessedSearchPage", hash_including(
+            timestamp: be_a(Integer),
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             num_results: 1,

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Cbv::EmployerSearchesController do
         get :show
         expect(response).to be_successful
       end
+
+      it "tracks a NewRelic event" do
+        expect(NewRelicEventTracker)
+          .to receive(:track)
+          .with("ApplicantAccessedSearchPage", hash_including(
+            timestamp: be_a(Integer),
+            cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id
+          ))
+        get :show
+      end
+
     end
 
     context "when there are no employer search results" do
@@ -62,15 +74,20 @@ RSpec.describe Cbv::EmployerSearchesController do
 
       it "tracks a NewRelic event" do
         expect(NewRelicEventTracker)
+        .to receive(:track)
+        .with("ApplicantAccessedSearchPage", hash_including(
+          timestamp: be_a(Integer),
+          cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id
+        ))
+        expect(NewRelicEventTracker)
           .to receive(:track)
-          .with("ApplicantAccessedSearchPage", hash_including(
-            timestamp: be_a(Integer),
+          .with("ApplicantSearchedForEmployer", hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             num_results: 1,
             has_pinwheel_account: false
           ))
-
         get :show, params: { query: "results" }
       end
     end


### PR DESCRIPTION
## Ticket
Resolves [FFS-1839](https://jiraent.cms.gov/browse/FFS-1839)

## Changes
Several new events were added:
1. On the Search page, the ApplicantAccessedSearchPage event fires
1. On the Summary page, the ApplicantAccessedIncomeSummary event fires
1. On the Success page, the ApplicantAccessedSuccessPage fires
1. On the session_timeout page, the ApplicantTimedOut event fires
1. On the missing_results page, the ApplicantAccessedMissingResultsPage event fires
1. On the expired page, the ApplicantLinkExpired event fires

Several new attributes were added to existing events:
1. To the ApplicantSearchedForEmployer event we added the :query attribute, which contains the query the user provided.
1. To the EmailSent event we added the :locale attribute, which contains the language the email was sent in (en or es).
1. To the ApplicantDownloadedIncomePDF event we added the :locale attribute, which contains the language the email was sent in (en or es).

## Context for reviewers
Please take a critical look at all the attributes I added to new events. I mostly copied existing events, but I wonder if every attribute I brought along is necessary.

## Testing
The easiest way to test this is to run locally, go through the normal workflow in the sandbox, and watch the log for lines like "Sending New Relic event: ApplicantAccessedMissingResultsPage". Make sure that all the new events fire and that their attributes are populated as you'd expect. Also spot check the modified events to make sure the attributes were added appropriately.

### Timeout event testing
Because one of these events only fires on timeout, I'd recommend getting that out of the way first. Go through a flow and let it expire (while you wait, try testing the rest of this PR!), then refresh the page to check out the new ApplicantTimedOut event.

### Expired link event testing
Create an invite link and then manually expire it using rails c. Get the object you want, probably by calling something like `a = CbvFlowInvitation.last`. Then, call `a.redacted_at = Time.now` followed by `a.save(validate: false)`. Now, when you go to the url at a.to_url, you should trigger the new ApplicantLinkExpired event.

### All the rest
Otherwise, go through the flow and be prepared to observe the events in this order:
1. Send the applicant an invite to get the EmailSent event with the new attribute
2. ApplicantAccessedSearchPage on the /employer_search page
3. On the search page, after searching, click the "I can't find my company or payroll provider" button to find the ApplicantAccessedMissingResultsPage on the /missing_results page
4. Go back and search for an employer to get the ApplicantSearchedForEmployer with the new param
5. ApplicantAccessedIncomeSummary on the /summary page
6. ApplicantAccessedSuccessPage on the /success page
7. Click to download the PDF to get the ApplicantDownloadedIncomePDF with the new attribute
