### PR TITLE
1804: Fix untranslated strings in PDF

### DIFF
--- a/app/app/views/cbv/summaries/show.pdf.erb
+++ b/app/app/views/cbv/summaries/show.pdf.erb
@@ -33,7 +33,7 @@
 
 <%= render(TableComponent.new) do |table| %>
   <%= table.with_header do %>
-    <h3 class="margin-0">Client Information</h3>
+    <h3 class="margin-0"><%= t(".pdf.shared.client_information") %></h3>
   <% end %>
   <% if current_site?(:ma) && !is_caseworker %>
     <%= table.with_row(t(".pdf.client.agency_id_number"), @cbv_flow.cbv_flow_invitation.agency_id_number) %>
@@ -57,7 +57,7 @@
 
 <%= render(TableComponent.new) do |table| %>
   <%= table.with_header do %>
-    <h3 class="margin-0">Report details</h3>
+    <h3 class="margin-0"><%= t(".pdf.shared.report_details") %></h3>
   <% end %>
   <% if @cbv_flow.confirmation_code.present? %>
     <%= table.with_row(t(".pdf.shared.confirmation_code"), @cbv_flow.confirmation_code) %>
@@ -85,7 +85,7 @@
         <% if employer_name %>
           <%= employer_name %> &mdash;
         <% end %>
-        Employment Information
+        <%= t(".pdf.shared.employment_information") %>
       </h4>
     <% end %>
     <% if is_caseworker && summary[:has_identity_data] %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -352,7 +352,10 @@ en:
             employment_payment_details: Employment and Payment details
             header: Income Verification Report
           shared:
+            client_information: Client Information
             confirmation_code: Confirmation code
+            employment_information: Employment information
+            report_details: Report Details
         phone_number: Employer phone
         send_report: Share my report with %{agency_acronym}
         table_caption: 'Employer %{number}: %{employer_name}'

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -228,11 +228,14 @@ es:
             employment_payment_details: Datos de empleo y pago
             header: Informe de verificación de ingresos
           shared:
+            client_information: Información del cliente
             confirmation_code: Código de confirmación
+            employment_information: Información del empleo
+            report_details: Detalles del reporte
         phone_number: Teléfono del empleador
         send_report: Comparta mi informe con %{agency_acronym}
         table_caption: 'Empleador %{number}: %{employer_name}'
-        table_caption_no_name: 'Empleador %{number}:'
+        table_caption_no_name: Empleador %{number}
         total_income_from: 'Ingresos totales provenientes de %{employer_name}, antes del pago de impuestos: %{amount}'
         total_income_from_no_employer_name: 'Ingresos totales antes del pago de impuestos: %{amount}'
         total_payments: 'Ingresos totales de los últimos 90 días, antes del pago de impuestos: %{amount}'
@@ -339,7 +342,7 @@ es:
         nyc: Un sitio web en colaboración con la Ciudad de Nueva York.
       primary: Menú principal
     languages:
-      en: Inglés
+      en: English
       es: Español
       fr: Francés
       zh: Chino


### PR DESCRIPTION
## Ticket

Resolves FFS-1804.

## Changes

* Use `English` for name of English in Spanish
* Move a couple non-I18n'd strings into I18n files

## Context for reviewers

The spanish translations themselves need review.

## Testing

Tested locally.
