### PR TITLE
1934: Add hours breakdown to the payment details page

### DIFF
--- a/app/app/components/pinwheel_data_point_component.rb
+++ b/app/app/components/pinwheel_data_point_component.rb
@@ -44,6 +44,15 @@ class PinwheelDataPointComponent < ViewComponent::Base
     }
   end
 
+  def earnings_entry(category, hours)
+    translated_category_name = translate_pinwheel_value("earnings_category", category)
+
+    {
+      label: I18n.t("cbv.payment_details.show.hours_paid", category: translated_category_name),
+      value: I18n.t("cbv.payment_details.show.hours", count: hours)
+    }
+  end
+
   def deduction(category, amount)
     translated_deduction_category = translate_pinwheel_value("deductions", category)
     {

--- a/app/app/controllers/concerns/cbv/payments_helper.rb
+++ b/app/app/controllers/concerns/cbv/payments_helper.rb
@@ -27,12 +27,13 @@ module Cbv::PaymentsHelper
         start: payment["pay_period_start"],
         end: payment["pay_period_end"],
         hours: total_hours_from_earnings(payment["earnings"]),
+        hours_by_earning_category: hours_by_earning_category(payment["earnings"]),
         gross_pay_amount: payment["gross_pay_amount"].to_i,
         net_pay_amount: payment["net_pay_amount"].to_i,
         gross_pay_ytd: payment["gross_pay_ytd"].to_i,
         pay_date: payment["pay_date"],
         deductions: payment["deductions"].map { |deduction| { category: deduction["category"], amount: deduction["amount"] } },
-        account_id: payment["account_id"]
+        account_id: payment["account_id"],
       }
     end
   end
@@ -61,5 +62,12 @@ module Cbv::PaymentsHelper
       .sum { |e| e["hours"] || 0.0 }
 
     base_hours + overtime_hours
+  end
+
+  def hours_by_earning_category(earnings)
+    earnings
+      .filter { |e| e["hours"].present? && e["hours"] > 0 }
+      .group_by { |e| e["category"] }
+      .transform_values { |earnings| earnings.sum { |e| e["hours"] } }
   end
 end

--- a/app/app/controllers/concerns/cbv/payments_helper.rb
+++ b/app/app/controllers/concerns/cbv/payments_helper.rb
@@ -33,7 +33,7 @@ module Cbv::PaymentsHelper
         gross_pay_ytd: payment["gross_pay_ytd"].to_i,
         pay_date: payment["pay_date"],
         deductions: payment["deductions"].map { |deduction| { category: deduction["category"], amount: deduction["amount"] } },
-        account_id: payment["account_id"],
+        account_id: payment["account_id"]
       }
     end
   end

--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -37,24 +37,25 @@ module ViewHelper
   end
 
   def translate_pinwheel_value(namespace, value)
-    # if the key isn't in spanish, just return the original value
-    return value unless I18n.locale == :es
-
     i18n_key = "pinwheel.#{namespace}.#{value}"
 
     # convert the key to snake_case, replacing hyphens with underscores
     i18n_key = i18n_key.gsub("-", "_").downcase
 
     if I18n.exists?(i18n_key)
-      return I18n.t(i18n_key)
-    end
+      I18n.t(i18n_key)
+    elsif I18n.locale == :en
+      # if the key isn't in spanish, just return the original value
+      value
+    else
+      if Rails.env.development? || Rails.env.test?
+        raise "Missing Pinwheel translation for #{namespace}.#{value}"
+      end
 
-    if Rails.env.development? || Rails.env.test?
-      raise "Missing Pinwheel translation for #{namespace}.#{value}"
-    end
+      # In production, log warning and return original value
+      Rails.logger.warn "Unknown Pinwheel value for #{namespace}: #{value}"
 
-    # In production, log warning and return original value
-    Rails.logger.warn "Unknown Pinwheel value for #{namespace}: #{value}"
-    value
+      value
+    end
   end
 end

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -50,14 +50,12 @@
 
       <%= table.with_data_point(:pay_period, payment[:start], payment[:end]) %>
       <%= table.with_data_point(:pay_gross, payment[:gross_pay_amount]) %>
-      <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
       <%= table.with_data_point(:number_of_hours_worked, payment[:hours]) %>
-
       <% payment[:hours_by_earning_category].each do |category, total_hours| %>
         <% category_name = t("cbv.payment_details.show.hours_category.#{category}") %>
-        <% table.with_row("", t("cbv.payment_details.show.hours", description: category_name, count: total_hours)) %>
+        <% table.with_row(t("cbv.payment_details.show.hours_paid", category: category_name), t("cbv.payment_details.show.hours", count: total_hours)) %>
       <% end %>
-
+      <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
       <% payment[:deductions].filter { |deduction| deduction[:amount] > 0 }.each do |deduction| %>
         <%= table.with_data_point(:deduction, deduction[:category], deduction[:amount]) %>
       <% end %>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -52,8 +52,7 @@
       <%= table.with_data_point(:pay_gross, payment[:gross_pay_amount]) %>
       <%= table.with_data_point(:number_of_hours_worked, payment[:hours]) %>
       <% payment[:hours_by_earning_category].each do |category, total_hours| %>
-        <% category_name = t("cbv.payment_details.show.hours_category.#{category}") %>
-        <% table.with_row(t("cbv.payment_details.show.hours_paid", category: category_name), t("cbv.payment_details.show.hours", count: total_hours)) %>
+        <%= table.with_data_point(:earnings_entry, category, total_hours) %>
       <% end %>
       <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
       <% payment[:deductions].filter { |deduction| deduction[:amount] > 0 }.each do |deduction| %>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -53,6 +53,11 @@
       <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
       <%= table.with_data_point(:number_of_hours_worked, payment[:hours]) %>
 
+      <% payment[:hours_by_earning_category].each do |category, total_hours| %>
+        <% category_name = t("cbv.payment_details.show.hours_category.#{category}") %>
+        <% table.with_row("", t("cbv.payment_details.show.hours", description: category_name, count: total_hours)) %>
+      <% end %>
+
       <% payment[:deductions].filter { |deduction| deduction[:amount] > 0 }.each do |deduction| %>
         <%= table.with_data_point(:deduction, deduction[:category], deduction[:amount]) %>
       <% end %>

--- a/app/app/views/cbv/summaries/show.pdf.erb
+++ b/app/app/views/cbv/summaries/show.pdf.erb
@@ -121,8 +121,7 @@
       <%= table.with_data_point(:pay_gross, payment[:gross_pay_amount], highlight: is_caseworker) %>
       <%= table.with_data_point(:number_of_hours_worked, payment[:hours], highlight: is_caseworker) %>
       <% payment[:hours_by_earning_category].each do |category, total_hours| %>
-        <% category_name = t("cbv.payment_details.show.hours_category.#{category}") %>
-        <% table.with_row(t("cbv.payment_details.show.hours_paid", category: category_name), t("cbv.payment_details.show.hours", count: total_hours)) %>
+        <%= table.with_data_point(:earnings_entry, category, total_hours) %>
       <% end %>
       <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
       <% payment[:deductions].filter { |deduction| deduction[:amount] > 0 }.each do |deduction| %>

--- a/app/app/views/cbv/summaries/show.pdf.erb
+++ b/app/app/views/cbv/summaries/show.pdf.erb
@@ -120,12 +120,14 @@
       <% end %>
       <%= table.with_data_point(:pay_gross, payment[:gross_pay_amount], highlight: is_caseworker) %>
       <%= table.with_data_point(:number_of_hours_worked, payment[:hours], highlight: is_caseworker) %>
+      <% payment[:hours_by_earning_category].each do |category, total_hours| %>
+        <% category_name = t("cbv.payment_details.show.hours_category.#{category}") %>
+        <% table.with_row(t("cbv.payment_details.show.hours_paid", category: category_name), t("cbv.payment_details.show.hours", count: total_hours)) %>
+      <% end %>
       <%= table.with_data_point(:net_pay_amount, payment[:net_pay_amount]) %>
-
       <% payment[:deductions].filter { |deduction| deduction[:amount] > 0 }.each do |deduction| %>
         <%= table.with_data_point(:deduction, deduction[:category], deduction[:amount]) %>
       <% end %>
-
       <%= table.with_data_point(:pay_gross_ytd, payment[:gross_pay_ytd]) %>
     <% end %>
   <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -266,6 +266,36 @@ en:
         header: Your payment information from %{employer_name}
         header_no_employer_name: Your payment information from your employer
         hourly_rate: Compensation amount
+        hours_category:
+          bereavement: Bereavement
+          bonus: Bonus
+          commission: Commission
+          disability: Disability
+          double_overtime: Double Overtime
+          employer_contribution: Employer Contribution
+          fare: Fare
+          holiday: Holiday
+          hourly: Hourly Wage
+          life_insurance: Life Insurance
+          meal_comp: Meal Comp
+          medical: Medical
+          other: Other Pay
+          overtime: Overtime
+          parental: Parental
+          premium: Premium
+          pto: Paid Time Off
+          retirement: Retirement
+          retro_pay: Retroactive Pay
+          salary: Salary
+          shift_differential: Shift Differential
+          sick: Sick Time
+          stock: Stock
+          tips: Tips
+          unpaid: Unpaid
+          vacation: Vacation
+        hours:
+          one: "%{description} - %{count} hour"
+          other: "%{description} - %{count} hours"
         none_found: We didn't find any payments from this employer in the past 90 days.
         none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
         number_of_hours_worked: Number of hours worked

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -294,8 +294,9 @@ en:
           unpaid: Unpaid
           vacation: Vacation
         hours:
-          one: "%{description} - %{count} hour"
-          other: "%{description} - %{count} hours"
+          one: "%{count} hour"
+          other: "%{count} hours"
+        hours_paid: "%{category}: Hours paid"
         none_found: We didn't find any payments from this employer in the past 90 days.
         none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
         number_of_hours_worked: Number of hours worked

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -266,6 +266,9 @@ en:
         header: Your payment information from %{employer_name}
         header_no_employer_name: Your payment information from your employer
         hourly_rate: Compensation amount
+        hours:
+          one: "%{count} hour"
+          other: "%{count} hours"
         hours_category:
           bereavement: Bereavement
           bonus: Bonus
@@ -293,9 +296,6 @@ en:
           tips: Tips
           unpaid: Unpaid
           vacation: Vacation
-        hours:
-          one: "%{count} hour"
-          other: "%{count} hours"
         hours_paid: "%{category}: Hours paid"
         none_found: We didn't find any payments from this employer in the past 90 days.
         none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -269,37 +269,10 @@ en:
         hours:
           one: "%{count} hour"
           other: "%{count} hours"
-        hours_category:
-          bereavement: Bereavement
-          bonus: Bonus
-          commission: Commission
-          disability: Disability
-          double_overtime: Double Overtime
-          employer_contribution: Employer Contribution
-          fare: Fare
-          holiday: Holiday
-          hourly: Hourly Wage
-          life_insurance: Life Insurance
-          meal_comp: Meal Comp
-          medical: Medical
-          other: Other Pay
-          overtime: Overtime
-          parental: Parental
-          premium: Premium
-          pto: Paid Time Off
-          retirement: Retirement
-          retro_pay: Retroactive Pay
-          salary: Salary
-          shift_differential: Shift Differential
-          sick: Sick Time
-          stock: Stock
-          tips: Tips
-          unpaid: Unpaid
-          vacation: Vacation
         hours_paid: "%{category}: Hours paid"
         none_found: We didn't find any payments from this employer in the past 90 days.
         none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
-        number_of_hours_worked: Number of hours worked
+        number_of_hours_worked: Number of hours paid
         pay_date: 'Pay Date: %{pay_date}'
         pay_frequency: Pay period frequency
         pay_gross: Payment before taxes (gross)
@@ -413,6 +386,34 @@ en:
       description_2: Please note this pilot is currently available only to SNAP participants in New York City and Massachusetts.
       description_3_html: '<p>To participate, you can request an invitation from your SNAP agency:</p><ul><li>Massachusetts applicants: Contact the <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank" rel="noopener noreferrer">Department of Transitional Assistance (DTA)</a></li><li>New York City applicants: Contact the <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page">Human Resources Administration (HRA)</a></li></ul>'
       header: Welcome to the SNAP Income Pilot
+  pinwheel:
+    earnings_category:
+      bereavement: Bereavement
+      bonus: Bonus
+      commission: Commission
+      disability: Disability
+      double_overtime: Double Overtime
+      employer_contribution: Employer Contribution
+      fare: Fare
+      holiday: Holiday
+      hourly: Hourly Wage
+      life_insurance: Life Insurance
+      meal_comp: Meal Comp
+      medical: Medical
+      other: Other Pay
+      overtime: Overtime
+      parental: Parental
+      premium: Premium
+      pto: Paid Time Off
+      retirement: Retirement
+      retro_pay: Retroactive Pay
+      salary: Salary
+      shift_differential: Shift Differential
+      sick: Sick Time
+      stock: Stock
+      tips: Tips
+      unpaid: Unpaid
+      vacation: Vacation
   shared:
     agency_full_name:
       ma: Massachusetts Department of Transitional Assistance

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -272,7 +272,7 @@ en:
         hours_paid: "%{category}: Hours paid"
         none_found: We didn't find any payments from this employer in the past 90 days.
         none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
-        number_of_hours_worked: Number of hours paid
+        number_of_hours_worked: Total number of hours paid
         pay_date: 'Pay Date: %{pay_date}'
         pay_frequency: Pay period frequency
         pay_gross: Payment before taxes (gross)

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -147,6 +147,9 @@ es:
         header: Su información de pago de %{employer_name}
         header_no_employer_name: Su información de pago por parte de su empleador
         hourly_rate: Monto de compensación
+        hours:
+          one: "%{count} hora"
+          other: "%{count} horas"
         hours_category:
           bereavement: Duelo
           bonus: Bono
@@ -174,9 +177,6 @@ es:
           tips: Propinas
           unpaid: Sin paga
           vacation: Vacaciones
-        hours:
-          one: "%{count} hora"
-          other: "%{count} horas"
         none_found: No se encontraron pagos.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
         number_of_hours_worked: Número de horas trabajadas

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -150,33 +150,7 @@ es:
         hours:
           one: "%{count} hora"
           other: "%{count} horas"
-        hours_category:
-          bereavement: Duelo
-          bonus: Bono
-          commission: Comisión
-          disability: Incapacidad
-          double_overtime: Horas extras dobles
-          employer_contribution: Contribución del empleador
-          fare: Tarifa
-          holiday: Vacaciones
-          hourly: Salario por hora
-          life_insurance: Seguro de vida
-          meal_comp: Compensación por comidas
-          medical: Médico
-          other: Otros pagos
-          overtime: Horas extras
-          parental: Pago por maternidad o paternidad
-          premium: Prima
-          pto: Tiempo libre pagado
-          retirement: Jubilación
-          retro_pay: Pago retroactivo
-          salary: Salario
-          shift_differential: Diferencial de turno
-          sick: Tiempo por enfermedad
-          stock: Acciones
-          tips: Propinas
-          unpaid: Sin paga
-          vacation: Vacaciones
+        hours_paid: "%{category}: Horas pagadas"
         none_found: No se encontraron pagos.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
         number_of_hours_worked: Número de horas trabajadas
@@ -326,6 +300,33 @@ es:
   pinwheel:
     deductions:
       other: Otro
+    earnings_category:
+      bereavement: Duelo
+      bonus: Bono
+      commission: Comisión
+      disability: Incapacidad
+      double_overtime: Horas extras dobles
+      employer_contribution: Contribución del empleador
+      fare: Tarifa
+      holiday: Vacaciones
+      hourly: Salario por hora
+      life_insurance: Seguro de vida
+      meal_comp: Compensación por comidas
+      medical: Médico
+      other: Otros pagos
+      overtime: Horas extras
+      parental: Pago por maternidad o paternidad
+      premium: Prima
+      pto: Tiempo libre pagado
+      retirement: Jubilación
+      retro_pay: Pago retroactivo
+      salary: Salario
+      shift_differential: Diferencial de turno
+      sick: Tiempo por enfermedad
+      stock: Acciones
+      tips: Propinas
+      unpaid: Sin paga
+      vacation: Vacaciones
     employment_statuses:
       employed: empleado
     payment_frequencies:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -175,8 +175,8 @@ es:
           unpaid: Sin paga
           vacation: Vacaciones
         hours:
-          one: "%{description} - %{count} hora"
-          other: "%{description} - %{count} horas"
+          one: "%{count} hora"
+          other: "%{count} horas"
         none_found: No se encontraron pagos.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
         number_of_hours_worked: Número de horas trabajadas

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -153,7 +153,7 @@ es:
         hours_paid: "%{category}: Horas pagadas"
         none_found: No se encontraron pagos.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
-        number_of_hours_worked: Número de horas trabajadas
+        number_of_hours_worked: Número total de horas pagadas
         pay_date: 'Fecha de pago: %{pay_date}'
         pay_frequency: Frecuencia del período de pago
         pay_gross: Pago antes de impuestos (bruto)

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -147,6 +147,36 @@ es:
         header: Su información de pago de %{employer_name}
         header_no_employer_name: Su información de pago por parte de su empleador
         hourly_rate: Monto de compensación
+        hours_category:
+          bereavement: Duelo
+          bonus: Bono
+          commission: Comisión
+          disability: Incapacidad
+          double_overtime: Horas extras dobles
+          employer_contribution: Contribución del empleador
+          fare: Tarifa
+          holiday: Vacaciones
+          hourly: Salario por hora
+          life_insurance: Seguro de vida
+          meal_comp: Compensación por comidas
+          medical: Médico
+          other: Otros pagos
+          overtime: Horas extras
+          parental: Pago por maternidad o paternidad
+          premium: Prima
+          pto: Tiempo libre pagado
+          retirement: Jubilación
+          retro_pay: Pago retroactivo
+          salary: Salario
+          shift_differential: Diferencial de turno
+          sick: Tiempo por enfermedad
+          stock: Acciones
+          tips: Propinas
+          unpaid: Sin paga
+          vacation: Vacaciones
+        hours:
+          one: "%{description} - %{count} hora"
+          other: "%{description} - %{count} horas"
         none_found: No se encontraron pagos.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
         number_of_hours_worked: Número de horas trabajadas

--- a/app/spec/controllers/concerns/cbv/payments_helper_spec.rb
+++ b/app/spec/controllers/concerns/cbv/payments_helper_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Cbv::PaymentsHelper, type: :helper do
             gross_pay_ytd: 6971151,
             net_pay_amount: 321609,
             hours: 80,
+            hours_by_earning_category: { "salary" => 80 },
             pay_date: "2020-12-31",
             start: "2020-12-10" }
         ]

--- a/app/spec/controllers/concerns/cbv/reports_helper_spec.rb
+++ b/app/spec/controllers/concerns/cbv/reports_helper_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Cbv::ReportsHelper, type: :helper do
               start: "2020-12-10",
               gross_pay_ytd: 6971151,
               gross_pay_amount: 480720,
+              hours_by_earning_category: { "salary" => 80 },
               net_pay_amount: 321609
             }
           ],

--- a/app/spec/helpers/view_helper_spec.rb
+++ b/app/spec/helpers/view_helper_spec.rb
@@ -2,14 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ViewHelper, type: :helper do
   describe '#translate_pinwheel_value' do
-    # Store the original locale before all tests
-    let(:original_locale) { I18n.default_locale }
-
-    # Reset locale after each test
-    after { I18n.locale = original_locale }
+    around do |ex|
+      I18n.with_locale(locale, &ex)
+    end
 
     context 'when locale is :es' do
-      before { I18n.locale = :es }
+      let(:locale) { :es }
 
       it 'returns the translated value if translation exists' do
         I18n.backend.store_translations(:es, {
@@ -45,11 +43,26 @@ RSpec.describe ViewHelper, type: :helper do
     end
 
     context 'when locale is not :es' do
-      before { I18n.locale = :en }
+      let(:locale) { :en }
 
-      it 'returns the original value regardless of translations' do
-        result = helper.translate_pinwheel_value('namespace', 'any_value')
-        expect(result).to eq('any_value')
+      it 'returns the English value' do
+        I18n.backend.store_translations(:en, {
+          pinwheel: {
+            namespace: {
+              some_value: 'Translated Value'
+            }
+          }
+        })
+
+        result = helper.translate_pinwheel_value('namespace', 'some_value')
+        expect(result).to eq('Translated Value')
+      end
+
+      context 'when there is no English value given' do
+        it 'returns the original value regardless of translations' do
+          result = helper.translate_pinwheel_value('namespace', 'any_value')
+          expect(result).to eq('any_value')
+        end
       end
     end
   end

--- a/app/spec/support/test_helpers.rb
+++ b/app/spec/support/test_helpers.rb
@@ -17,7 +17,8 @@ module TestHelpers
         end: Date.today.end_of_month + i.months,
         hours: (40 * (i + 1)),
         rate: (10 + i),
-        deductions: []
+        deductions: [],
+        hours_by_earning_category: { salary: 80 }
       }
     end
   end


### PR DESCRIPTION
## Ticket

Resolves FFS-1934.

## Changes

Ready for merge - 11/18.

### Payment Details Page
![image](https://github.com/user-attachments/assets/df029536-f5ec-4745-91b8-0edef44d3b3f)

### Client-facing PDF:
<img width="789" alt="Screenshot 2024-11-19 at 11 54 22 AM" src="https://github.com/user-attachments/assets/d5d03d3e-67f0-434b-bdf7-d38e97c9fbf8">

### Caseworker PDF:
<img width="920" alt="Screenshot 2024-11-19 at 11 54 47 AM" src="https://github.com/user-attachments/assets/57f95681-817d-47db-af82-be58706276bc">

## Context for reviewers

N/A

## Testing

Tested locally.
