### PR TITLE
Fix missing I18n keys and reenable missing test

### DIFF
--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -115,17 +115,33 @@ search:
 #     formality: prefer_less
 ## Do not consider these keys missing:
 ignore_missing:
-  - 'shared.languages.*'
-  - 'shared.header.{title,close,demo_banner,menu}'
+  all:
+    - 'shared.languages.*'
+    - 'shared.header.{title,close,demo_banner,menu}'
+  en:
+    - "date.*"    # Defaults provided by rails-i18n
+    - "time.*"    # Defaults provided by rails-i18n
+    - "payment_frequencies.*"   # Helper method uses English values directly
+  es:
+    # Caseworker pages that are only supported in English:
+    - "caseworker.cbv_flow_invitations.*"
+    - "caseworker.dashboards.*"
+    - "caseworker.entries.*"
+    # Caseworker emails that are only supported in English:
+    - "activerecord.errors.models.cbv_flow_invitation.*"
+    - "caseworker_mailer.summary_email.*"
+    # Caseworker PDF strings that are only supported in English:
+    - "cbv.summaries.show.pdf.caseworker.*"
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 
 ## Consider these keys used:
 ignore_unused:
-  - "*.{nyc,ma,sandbox,default}" # site-specific translations
-  - "activerecord.errors.*" # model errors are not always explicitly used
-  - "date.*" # date formats are not always explicitly used
-  - "time.*" # time formats are not always explicitly used
+  all:
+    - "*.{nyc,ma,sandbox,default}" # site-specific translations
+    - "activerecord.errors.*" # model errors are not always explicitly used
+    - "date.*" # date formats are not always explicitly used
+    - "time.*" # time formats are not always explicitly used
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -425,6 +425,7 @@ en:
     boolean_true: 'Yes'
     date_picker_format: 'Format: mm/dd/yyyy'
     optional: Optional
+    tax_id_format: 'Format: 123456789'
   users:
     omniauth_callbacks:
       authentication_successful: You are signed in.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -217,6 +217,10 @@ es:
         none_found: No se encontraron pagos. Actualice la página después de unos minutos.
         payment: Pago de %{amount} antes de pago impuestos en %{date}
         pdf:
+          agency_header_name:
+            ma: Massachusetts Department of Transitional Assistance
+            nyc: NYC Human Resources Administration
+            sandbox: CBV Test Agency
           caseworker:
             pay_period: Período de pago (%{pay_frequency})
           client:
@@ -314,6 +318,7 @@ es:
   shared:
     agency_full_name:
       ma: Departamento de Asistencia Transitoria de Massachusetts
+      nyc: New York City Human Resources Administration
       sandbox: Agencia de pruebas CBV
     app_name:
       ma: DTA Connect
@@ -355,6 +360,7 @@ es:
     boolean_true: Sí
     date_picker_format: 'Formato: mm/dd/aaaa'
     optional: Opcional
+    tax_id_format: 'Formato: 123456789'
   users:
     omniauth_callbacks:
       authentication_successful: Ha iniciado sesión.

--- a/app/spec/i18n_spec.rb
+++ b/app/spec/i18n_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe I18n do
   let(:unused_keys) { i18n.unused_keys }
   let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
-  skip "does not have missing keys" do
+  it "does not have missing keys" do
     expect(missing_keys).to be_empty,
       "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end


### PR DESCRIPTION
## Ticket

N/A

## Changes

Early in the project (in May 2024 - b5035448), we disabled the test
that verified no missing I18n keys. Since then, we've implemented
Spanish and we should ensure that all strings are properly translated.

This commit dispenses with the ~160 missing strings by either:
1. Ignoring them (for caseworker functionality that we do not support in
   other languages)
2. Adding some value for them (for strings where the value is somewhat
   obvious to me)
3. Getting translated values (for strings that are legitimately missing)

## Context for reviewers

N/A

## Testing

N/A
