### PR TITLE
fixing vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2024-49761

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -61,7 +61,7 @@ gem "actioncable-enhanced-postgresql-adapter"
 gem "aws-sdk-rails"
 
 # https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/
-gem "rexml", "~> 3.3.6"
+gem "rexml", "~> 3.3.9"
 gem "gpgme", "~> 2.0", ">= 2.0.12"
 gem "pdf-reader", "~> 2.12.0"
 

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -395,8 +395,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.1)
@@ -486,7 +485,6 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
-    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.2)
@@ -571,7 +569,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd (~> 1.7)
   redis (~> 4.0)
-  rexml (~> 3.3.6)
+  rexml (~> 3.3.9)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails-omakase


### PR DESCRIPTION
n/a

Resolves a critical a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2024-49761)  in versions of rexml prior to `3.3.9` which prevents merging. 