### PR TITLE
Treat pending as error

### DIFF
--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -22,7 +22,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
       pinwheel_account = PinwheelAccount.find_by_pinwheel_account_id(params["payload"]["account_id"])
       pinwheel_account.update!(PinwheelAccount::EVENTS_MAP[params["event"]] => Time.now) if pinwheel_account.present?
 
-      if params.dig("payload", "outcome") == "error"
+      if params.dig("payload", "outcome") == "error" || params.dig("payload", "outcome") == "pending"
         pinwheel_account.update!(PinwheelAccount::EVENTS_ERRORS_MAP[params["event"]] => Time.now) if pinwheel_account.present?
       end
 

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -122,5 +122,24 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
         post :create, params: valid_params
       end
     end
+
+    context "for an 'pending' event outcome" do
+      let(:event_name) { "paystubs.fully_synced" }
+      let(:payload) do
+        {
+          "account_id" => account_id,
+          "end_user_id" => cbv_flow.pinwheel_end_user_id,
+          "outcome" => "pending"
+        }
+      end
+      let(:pinwheel_account) { PinwheelAccount.create!(cbv_flow: cbv_flow, supported_jobs: supported_jobs, pinwheel_account_id: account_id) }
+
+      it "updates the PinwheelAccount object with an error state" do
+        expect { post :create, params: valid_params }
+          .to change { pinwheel_account.reload.paystubs_errored_at }
+          .from(nil)
+          .to(within(1.second).of(Time.now))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket

https://nava.slack.com/archives/C0792AR4570/p1730920893503459

## Changes

Treat "pending" event outcomes as "error"

## Context for reviewers

Some jobs can end up [pending](https://docs.pinwheelapi.com/public/docs/webhooks-1#pending-webhook-job-outcomes) but complete up to 24 hours later. We're not sure that's useful at this point.
