### PR TITLE
Disable readonly filesystem in AWS ECS production

### DIFF
--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -35,7 +35,7 @@ jobs:
           terraform_version: 1.8.3
           terraform_wrapper: false
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ">=1.19.0"
 

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Run Checkov check

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -72,13 +72,16 @@ resource "aws_ecs_task_definition" "app" {
 
   container_definitions = jsonencode([
     {
-      name                   = local.container_name,
-      image                  = local.image_url,
-      memory                 = var.memory,
-      cpu                    = var.cpu,
-      networkMode            = "awsvpc",
-      essential              = true,
-      readonlyRootFilesystem = !var.enable_command_execution,
+      name        = local.container_name,
+      image       = local.image_url,
+      memory      = var.memory,
+      cpu         = var.cpu,
+      networkMode = "awsvpc",
+      essential   = true,
+      # TODO: Reenable readonlyRootFilesystem when we can have it behave
+      # consistently in dev (demo) and production.
+      # readonlyRootFilesystem = !var.enable_command_execution,
+      readonlyRootFilesystem = false,
 
       # Need to define all parameters in the healthCheck block even if we want
       # to use AWS's defaults, otherwise the terraform plan will show a diff


### PR DESCRIPTION
## Ticket

N/A - Bugfix

## Changes

We had initially enabled this for security's sake, but it continues to
cause problems (first with GPG, now PDF rendering with
the auto-extracting wkhtmltopdf-binary gem).

Until we can have consistent behavior between demo and production
images, let's disable the readonly filesystem.

## Context for reviewers

N/A

## Testing

Will test in production.
