### PR TITLE
Fix Docker build error by upgrading system dependencies

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -29,9 +29,12 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential=12.9 \
-    git=1:2.39.5-0+deb12u1 libpq-dev=15.8-0+deb12u1 pkg-config=1.8.1-1 \
-    npm=9.2.0~ds1-1
+    apt-get install --no-install-recommends -y \
+      build-essential=12.9 \
+      git=1:2.39.5-0+deb12u1 \
+      libpq-dev=15.8-0+deb12u1 \
+      npm=9.2.0~ds1-1 \
+      pkg-config=1.8.1-1
 
 # Copy application code
 COPY . .
@@ -61,8 +64,9 @@ ENV TMPDIR="/rails/tmp"
 
 # Install packages needed for development
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y postgresql-client=15+248 \
-        graphviz=2.42.2-7+b3 && \
+    apt-get install --no-install-recommends -y \
+      postgresql-client=15+248 \
+      graphviz=2.42.2-7+b3 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 RUN gem install bundler --no-document -v ${BUNDLER_VERSION} && \
@@ -108,10 +112,11 @@ ENV PIDFILE="/rails/tmp/pids/server.pid"
 # Install packages needed for deployment
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-        curl=7.88.1-10+deb12u7 \
+        curl=7.88.1-10+deb12u8 \
         libgpgme11=1.18.0-3+b1 \
         libvips42=8.14.1-3+deb12u1 \
-        linux-libc-dev=6.1.112-1 \
+        linux-libc-dev=6.1.115-1 \
+        openssl=3.0.15-1~deb12u1 \
         postgresql-client=15+248 \
         python-is-python3=3.11.2-1+deb12u1 \
         python3-venv=3.11.2-1+b1 \

--- a/docs/infra/vulnerability-management.md
+++ b/docs/infra/vulnerability-management.md
@@ -35,7 +35,7 @@ The trivy scanner allows you to ignore or safelist certain findings, which can b
 ### Anchore (Grype)
 The Grype scanner is a Docker image scanner made by the company Anchore. It allows you to ignore or safelist certain findings, which can be specified in the [.grype.yml](../../.grype.yml) file. There are flags set to ignore findings that are in the state `not-fixed`, `wont-fix`, and `unknown`.
 
-To debug a vulnerable system-level dependency of unknown origin, [download the CI-built image](/docs/app/runbooks/running-built-images-locally.md) and run:
+To debug a vulnerable system-level dependency of unknown origin, either build the image locally (with `make release-build`) or [download the CI-built image](/docs/app/runbooks/running-built-images-locally.md) and run:
 
 ```bash
 image_name=730335532059.dkr.ecr.us-east-1.amazonaws.com/iv-cbv-payroll-app:[image_tag]


### PR DESCRIPTION
## Ticket

N/A - Build issue on main branch.

## Changes

* Upgrade curl
* Upgrade linux-libc-dev
* Upgrade and pin version of openssl

## Context for reviewers

The upstream repos have a new version of these dependencies. Let's
upgrade to it. It would be really nice if these dependencies could be
managed automatically somehow.

## Testing

N/A
