### PR TITLE
FFS-1836-2: quick fix to make reminder emails only send once each

### DIFF
--- a/app/lib/tasks/invitation_reminders.rake
+++ b/app/lib/tasks/invitation_reminders.rake
@@ -9,7 +9,7 @@ namespace :invitation_reminders do
         next if invitation.complete?
 
         ApplicantMailer.with(cbv_flow_invitation: invitation).invitation_reminder_email.deliver_now
-        invitation.update(invitation_reminder_sent_at: DateTime.now)
+        invitation.touch(:invitation_reminder_sent_at)
       end
   end
 end


### PR DESCRIPTION
## [FFS-1836](https://jiraent.cms.gov/browse/FFS-1836)

This is a quick fix to FFS-1836 that prevents reminder emails from being sent over and over to the same people. Previously, we used the update method, and it was failing because of validation issues on other fields. Now, we use the touch method, which will not have the same problem.