### PR TITLE
Fix build by upgrading two dependencies (libpq, cross-spawn)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
       build-essential=12.9 \
       git=1:2.39.5-0+deb12u1 \
-      libpq-dev=15.8-0+deb12u1 \
+      libpq-dev=15.9-0+deb12u1 \
       npm=9.2.0~ds1-1 \
       pkg-config=1.8.1-1
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1390,10 +1390,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
## Ticket

N/A - Fixes broken build.

## Changes

* Upgrade libpq 15.8 -> 15.9
* Upgrade npm cross-spawn 7.0.3 -> 7.0.6

## Context for reviewers

The libpq 15.8 version is no longer in the package registry, causing Docker builds to fail.

The npm package cross-spawn has a security vulnerability.

## Testing

Will rely on automated tests.