### PR TITLE
FFS-2086: Invitation reminder mailer fixes

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -124,3 +124,11 @@ html {
   from {transform: rotate(0deg);}
   to {transform: rotate(360deg);}
 }
+
+// Allow decoupling header hierarchy from typographical style.
+// Currently only used in the invitation reminder mailer.
+
+.h3-style {
+  @include typeset-h3;
+  font-family: inherit;
+}

--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -8,6 +8,14 @@ html {
   min-width: 320px;
 }
 
+.usa-button--outline-email {
+  // Because css rendering in email is fraught, we must replace the default
+  // USWDS strategy of using a box-shadow (it doesn't appear at all in gmail).
+  background-color: transparent;
+  border: 2px solid #005ea2;
+  color: #005ea2;
+}
+
 #main-content {
   // These are rough approximations just to roughly get the footer to show up
   // at the bottom of the screen by default.

--- a/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
@@ -26,7 +26,7 @@
         </a>
       </p>
       <p><%= t(".instructions", agency_acronym: current_site.agency_short_name) %></p>
-      <h1 class="h3-style bmargin-top-3" ><%= t(".feedback_header") %></h1>
+      <h1 class="h3-style margin-top-3" ><%= t(".feedback_header") %></h1>
       <p>
         <a href="https://docs.google.com/forms/d/1E65H8Bcl3nYL8_OS5uwOqeN6p9G4aBXth6aHDoLlIoc/viewform" class="usa-button usa-button--outline-email width-auto" type="button">
           <%= t(".feedback_button") %>

--- a/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
@@ -28,7 +28,7 @@
       <p><%= t(".instructions", agency_acronym: current_site.agency_short_name) %></p>
       <h3 class="margin-top-3" ><%= t(".feedback_header") %></h3>
       <p>
-        <a href="https://docs.google.com/forms/d/1E65H8Bcl3nYL8_OS5uwOqeN6p9G4aBXth6aHDoLlIoc/viewform" class="usa-button usa-button--outline width-auto" type="button">
+        <a href="https://docs.google.com/forms/d/1E65H8Bcl3nYL8_OS5uwOqeN6p9G4aBXth6aHDoLlIoc/viewform" class="usa-button usa-button--outline-email width-auto" type="button">
           <%= t(".feedback_button") %>
         </a>
       </p>

--- a/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_reminder_email.html.erb
@@ -3,7 +3,7 @@
 
 <section class="usa-section">
   <div class="bg-white padding-y-7 padding-x-7 border border-base-lighter measure-5 line-height-sans-4 margin-x-auto font-body-xs">
-    <h3>
+    <h1 class="h3-style">
       <span class="text-primary"><%= t("shared.pilot_name") %> | </span>
       <% if current_site?(:ma) %>
         <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
@@ -12,7 +12,7 @@
       <% else %>
         <%= site_translation("shared.header.cbv_flow_title") %>
       <% end %>
-    </h3>
+    </h1>
     <div class="line-height-sans-5">
       <p>
         <%= t(".greeting") %>
@@ -26,7 +26,7 @@
         </a>
       </p>
       <p><%= t(".instructions", agency_acronym: current_site.agency_short_name) %></p>
-      <h3 class="margin-top-3" ><%= t(".feedback_header") %></h3>
+      <h1 class="h3-style bmargin-top-3" ><%= t(".feedback_header") %></h1>
       <p>
         <a href="https://docs.google.com/forms/d/1E65H8Bcl3nYL8_OS5uwOqeN6p9G4aBXth6aHDoLlIoc/viewform" class="usa-button usa-button--outline-email width-auto" type="button">
           <%= t(".feedback_button") %>

--- a/app/spec/mailers/previews/applicant_mailer_preview.rb
+++ b/app/spec/mailers/previews/applicant_mailer_preview.rb
@@ -14,6 +14,18 @@ class ApplicantMailerPreview < BaseMailerPreview
     ).invitation_email
   end
 
+  def invitation_reminder_email_dta
+    ApplicantMailer.with(
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :ma, user: unique_user, language: I18n.locale)
+    ).invitation_reminder_email
+  end
+
+  def invitation_reminder_email_nyc
+    ApplicantMailer.with(
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc, user: unique_user, language: I18n.locale)
+    ).invitation_reminder_email
+  end
+
   private
   def unique_user
     FactoryBot.create(:user, email: "#{SecureRandom.uuid}@example.com")


### PR DESCRIPTION
## [FFS-2086](https://jiraent.cms.gov/browse/FFS-2086)

## Changes
1. Previously, the "Share your feedback" button's border wasn't visible when rendered in gmail. Now, it will be.
2. Previously, the headers in the reminders were all h3, which is not proper structure. Now, they're all h1, and there is no visible change.

## Testing
1. In dev, if you're able, you can set up AWS in your console then make sure config.action_mailer.delivery_method is set to :sesv2 in your config/environments/development.rb. This should cause any triggered reminders to actually send to the listed email, which should allow you to observe the changes. This did not work for me, and so I plan to test more thoroughly in demo. However, the html was output to the console, and I was able to verify that the changes to the html/css appeared as I expected.
2. Similar to 1, observe that the h3 elements are now h1. Use the links at http://localhost:3000/rails/mailers/ to satisfy yourself that no visual changes were added.