### PR TITLE
Fix test for invitation reminder language

### DIFF
--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -144,10 +144,16 @@ RSpec.describe ApplicantMailer, type: :mailer do
       Rake::Task['invitation_reminders:send_all'].execute
     end
 
-    it "renders the subject and body in English because Spanish is not yet supported" do
-      Rake::Task['invitation_reminders:send_all'].execute
-      email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to eq(I18n.t('applicant_mailer.invitation_reminder_email.subject.ma'))
+    context "for an invitation in Spanish" do
+      before do
+        invitation.update(language: "es")
+      end
+
+      it "renders the subject and body in Spanish" do
+        Rake::Task['invitation_reminders:send_all'].execute
+        email = ActionMailer::Base.deliveries.last
+        expect(email.subject).to eq(I18n.t('applicant_mailer.invitation_reminder_email.subject.ma', locale: :es))
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket

N/A

## Changes

* Fix test for invitation reminder language

## Context for reviewers

The previous test was never setting the language of the invitation to Spanish, so of course it was going to send in English.

## Testing

It, itself, is a test.