### PR TITLE
No ticket: added two missing Spanish translations for reminder emails

### DIFF
--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -388,7 +388,7 @@ es:
       fr: Francés
       zh: Chino
     not_applicable: N/C
-    pilot_name: Programa piloto de ingresos de SNAP
+    pilot_name: SNAP Income Pilot
     skip_link: Saltar al contenido principal
   time:
     formats:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -31,7 +31,8 @@ es:
       main_action_html:
         default: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
         ma: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
-        nyc: "<strong>Verify your income</strong> as part of your SNAP application or recertification by <strong>%{deadline}</strong>."
+        nyc: "<strong>Verifique sus ingresos</strong> como parte de su solicitud o recertificación de SNAP antes del
+<strong>%{deadline}</strong>."
         sandbox: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
       subject:
         default: 'Recordatorio: Verifique sus ingresos para renovar sus beneficios de SNAP'
@@ -388,7 +389,7 @@ es:
       fr: Francés
       zh: Chino
     not_applicable: N/C
-    pilot_name: SNAP Income Pilot
+    pilot_name: Programa piloto de ingresos de SNAP
     skip_link: Saltar al contenido principal
   time:
     formats:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -31,8 +31,7 @@ es:
       main_action_html:
         default: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
         ma: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
-        nyc: "<strong>Verifique sus ingresos</strong> como parte de su solicitud o recertificación de SNAP antes del
-<strong>%{deadline}</strong>."
+        nyc: "<strong>Verifique sus ingresos</strong> como parte de su solicitud o recertificación de SNAP antes del <strong>%{deadline}</strong>."
         sandbox: "<strong>Verifique sus ingresos</strong> como parte de su recertificación de SNAP antes del <strong>%{deadline}</strong>."
       subject:
         default: 'Recordatorio: Verifique sus ingresos para renovar sus beneficios de SNAP'

--- a/app/spec/mailers/previews/applicant_mailer_preview.rb
+++ b/app/spec/mailers/previews/applicant_mailer_preview.rb
@@ -26,6 +26,12 @@ class ApplicantMailerPreview < BaseMailerPreview
     ).invitation_reminder_email
   end
 
+  def invitation_reminder_email_nyc_spanish
+    ApplicantMailer.with(
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc, user: unique_user, language: "es")
+    ).invitation_reminder_email
+  end
+
   private
   def unique_user
     FactoryBot.create(:user, email: "#{SecureRandom.uuid}@example.com")


### PR DESCRIPTION
## No ticket

## Changes
Two Spanish strings were not translated in the NYC reminder email:
![image](https://github.com/user-attachments/assets/213c7af6-1188-4672-a7c6-1a887861ef2d)

Now, it will look like this. Note that, after discussion, we decided NOT to translate the header string, since it's used in multiple places (not just these emails), matches the URL, and is too long in Spanish.
![image](https://github.com/user-attachments/assets/4763d537-0ca0-4ca1-ad6d-9d7a78bae31f)

## Testing
Take a look at es.yml and convince yourself that all Spanish translations are now present.

Once this is merged and in demo, trigger a reminder email by sending a new invite to your own email in Spanish, then call the following:
last = CbvFlowInvitation.last
last.created_at = 4.days.ago
last.snap_application_date = 1.hour.ago
last.save!
ApplicantMailer.with(cbv_flow_invitation: last).invitation_reminder_email.deliver_now

Verify the email you receive is completely in Spanish.