### PR TITLE
Rewrite PR template to emphasize Acceptance Testing plan

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,31 @@
+<!-- ---------------------------------------------------------------------------
+Some examples of good, understandable PR titles:
+
+FFS-1111: Fix missing translation on /entry page
+FFS-2222: Implement invitation reminder emails
+
+(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
+--------------------------------------------------------------------------- -->
 ## Ticket
 
-Resolves #{TICKET NUMBER OR URL}
+Resolves [FFS-XXXX](https://jiraent.cms.gov/browse/FFS-XXXX).
+
 
 ## Changes
+<!-- What was added, updated, or removed in this PR. -->
 
-> What was added, updated, or removed in this PR.
 
 ## Context for reviewers
+<!-- Anything you'd like other engineers on the team to know. -->
 
-> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.
 
-## Testing
+## Acceptance testing
+<!-- Check one: -->
 
-> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
+- [ ] No acceptance testing needed
+  * This change will not affect the user experience (bugfix, dependency updates, etc.)
+- [ ] Acceptance testing prior to merge
+  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
+- [ ] Acceptance testing after merge
+  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
+  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ Resolves [FFS-XXXX](https://jiraent.cms.gov/browse/FFS-XXXX).
   * This change will not affect the user experience (bugfix, dependency updates, etc.)
 - [ ] Acceptance testing prior to merge
   * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
+  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
 - [ ] Acceptance testing after merge
   * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
   * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,4 +29,4 @@ Resolves [FFS-XXXX](https://jiraent.cms.gov/browse/FFS-XXXX).
   * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
 - [ ] Acceptance testing after merge
   * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
-  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production.
+  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -13,6 +13,9 @@
           "pattern": "^https://confluenceent.cms.gov"
         },
         {
+          "pattern": "^https://jiraent.cms.gov"
+        },
+        {
           "pattern": "^https://www.hhs.gov"
         }
     ],


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - No ticket


## Changes
<!-- What was added, updated, or removed in this PR. -->

* Changes PR template to emphasize Acceptance Testing plan


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This change is meant as a proposal to encourage a bit more team emphasis
on Acceptance Testing plan when creating new PRs. By selecting one of
the three main acceptance testing methods, the code reviewers will share
an understanding with the PR's author about future steps necessary
before the code is deployed to production.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo.`)