### PR TITLE
FFS-2162: Set up mixpanel and use it to track page views

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -51,6 +51,7 @@ gem "device_detector"
 # Use Sass to process CSS
 # gem "sassc-rails"
 
+gem "mixpanel-ruby"
 gem "newrelic_rpm"
 
 gem "sidekiq", "~> 6.4"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.4)
+    mixpanel-ruby (2.3.0)
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -550,6 +551,7 @@ DEPENDENCIES
   i18n-tasks (~> 1.0)
   jbuilder
   jsbundling-rails
+  mixpanel-ruby
   newrelic_rpm
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection (~> 1.0)

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -80,6 +80,10 @@ class ApplicationController < ActionController::Base
     NewRelic::Agent.add_custom_attributes(attributes)
   end
 
+  def mixpanel
+    @mixpanel ||= MixpanelEventTracker.for_request(request)
+  end
+
   def redirect_if_maintenance_mode
     if ENV["MAINTENANCE_MODE"] == "true"
       redirect_to maintenance_path

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -87,6 +87,16 @@ class Cbv::BaseController < ApplicationController
 
   def capture_page_view
     client = DeviceDetector.new(request.headers["User-Agent"])
+    mixpanel.track("CbvPageView", {
+      device_name: client.device_name,
+      device_type: client.device_type,
+      browser: client.name,
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      site_id: @cbv_flow.site_id,
+      path: request.path
+    })
+
     NewRelicEventTracker.track("CbvPageView", {
       user_agent: request.headers["User-Agent"],
       device_name: client.device_name,

--- a/app/lib/mixpanel_event_tracker.rb
+++ b/app/lib/mixpanel_event_tracker.rb
@@ -1,0 +1,39 @@
+class MixpanelEventTracker
+  def self.for_request(request)
+    url_params = request.params.slice("site_id", "locale")
+
+    # Set these attributes as default (global) across all the tracked events.
+    new(
+      "$device_id" => request.session.id,
+      "ip" => request.ip,
+      "cbv_flow_id" => request.session[:cbv_flow_id],
+      "site_id" => url_params["site_id"],
+      "locale" => url_params["locale"],
+      "user_agent" => request.headers["User-Agent"],
+    )
+  end
+
+  def initialize(default_attributes)
+    @tracker = Mixpanel::Tracker.new(ENV["MIXPANEL_TOKEN"])
+    @default_attributes = default_attributes
+  end
+
+  def track(event_type, attributes = {})
+    start_time = Time.now
+    Rails.logger.info "Sending Mixpanel event: #{event_type} with attributes: #{attributes}"
+    combined_attributes = attributes.with_defaults(@default_attributes).stringify_keys
+
+    # Use the "invitation_id" attribute as the distinct_id as it currently best
+    # represents the concept of a unique user.
+    distinct_id = combined_attributes.fetch("invitation_id", "")
+    distinct_id.prepend("invitation-") if distinct_id.present?
+
+    response = @tracker.track(distinct_id, event_type, combined_attributes)
+    Rails.logger.info "Mixpanel event sent in #{Time.now - start_time}"
+    response
+  rescue StandardError => e
+    raise unless Rails.env.production?
+
+    Rails.logger.error "Failed to send Mixpanel event: #{e.message}"
+  end
+end

--- a/app/lib/new_relic_event_tracker.rb
+++ b/app/lib/new_relic_event_tracker.rb
@@ -1,8 +1,9 @@
 module NewRelicEventTracker
   def self.track(event_type, attributes = {})
+    start_time = Time.now
     Rails.logger.info "Sending New Relic event: #{event_type} with attributes: #{attributes}"
     response = NewRelic::Agent.record_custom_event(event_type, attributes)
-    Rails.logger.info "New Relic event sent"
+    Rails.logger.info "New Relic event sent in #{Time.now - start_time}s."
     response
   rescue StandardError => e
     Rails.logger.error "Failed to send New Relic event: #{e.message}"

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe Cbv::EntriesController do
         })
       end
 
+      it "tracks a CbvPageView event with Mixpanel (from the base controller)" do
+        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("CbvPageView", {
+          device_name: anything,
+          device_type: be_a(String),
+          browser: be_a(String),
+          invitation_id: invitation.id,
+          cbv_flow_id: be_a(Integer),
+          site_id: invitation.site_id,
+          path: "/cbv/entry"
+        })
+
+        request.headers["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        get :show, params: { token: invitation.auth_token }
+      end
+
       context "when returning to an already-visited flow invitation" do
         let!(:existing_cbv_flow) { create(:cbv_flow, cbv_flow_invitation: invitation) }
 

--- a/app/spec/spec_helper.rb
+++ b/app/spec/spec_helper.rb
@@ -102,6 +102,7 @@ RSpec.configure do |config|
   # Stub out NewRelicEventTracker so it doesn't make calls in test
   config.before(:each) do
     allow(NewRelicEventTracker).to receive(:track)
+    allow_any_instance_of(MixpanelEventTracker).to receive(:track)
   end
 
   # Mock the pinwheel method if it's not available in the test environment

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -43,6 +43,10 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/slack-test-email"
     },
+    MIXPANEL_TOKEN = {
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/mixpanel-token"
+    },
     NEWRELIC_KEY = {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/newrelic-key"


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2162](https://jiraent.cms.gov/browse/FFS-2162).


## Changes
<!-- What was added, updated, or removed in this PR. -->
* **Add MixpanelEventTracker proof of concept**

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
This is just an initial implementation. Plans for this PR:
- [x] Add environment variable to terraform

Plans for a subsequent PR that finishes the NewRelic -> Mixpanel transition:
- [ ] Call `mixpanel.identify` at some point to associate the distinct_id with the user's device id
- [x] Use `maybe_later` gem to move event tracking to happen after the body is sent to the client (for performance)
- [x] Audit event names to try and ensure consistency of "[subject][action][object]", e.g. "CaseworkerLoggedIn" or "ApplicantDownloadedIncomePDF" where possible.
- [ ] Try and simplify the metric tracking somehow, possibly by moving the tracking methods onto a separate module

Setup instructions:
1. Engineers will need to get the MIXPANEL_TOKEN value from the shared 1password .env.development.local file.
2. Engineers will need to create Mixpanel accounts.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
