### PR TITLE
FFS-1809: Disable multiple clicking on send invitation button

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -71,7 +71,6 @@ gem "stackprof"
 gem "rexml", "~> 3.3.9"
 gem "gpgme", "~> 2.0", ">= 2.0.12"
 gem "pdf-reader", "~> 2.12.0"
-gem "skylight"
 
 group :development, :test do
   gem "brakeman", "~> 5.2"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -449,8 +449,6 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    skylight (6.0.4)
-      activesupport (>= 5.2.0)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
@@ -572,7 +570,6 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   sidekiq (~> 6.4)
-  skylight
   sprockets-rails
   stackprof
   standard (~> 1.7)

--- a/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
+++ b/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
@@ -33,10 +33,10 @@ class Caseworker::CbvFlowInvitationsController < Caseworker::BaseController
       error_messages = @cbv_flow_invitation.errors.messages.values.flatten.map { |msg| "<li>#{msg}</li>" }.join
       error_messages = "<ul>#{error_messages}</ul>"
 
-      flash[:alert_heading] = error_header
-      flash[:alert] = error_messages.html_safe
+      flash.now[:alert_heading] = error_header
+      flash.now[:alert] = error_messages.html_safe
 
-      return render :new
+      return render :new, status: :unprocessable_entity
     end
 
     # hydrate the cbv_client with the invitation if there are no cbv_flow_invitation errors

--- a/app/app/controllers/health_check_controller.rb
+++ b/app/app/controllers/health_check_controller.rb
@@ -1,5 +1,7 @@
 class HealthCheckController < ActionController::Base
   def ok
+    # keep the database connection alive
+    ActiveRecord::Base.connection.execute("SELECT 1")
     render json: { status: "ok", version: ENV["IMAGE_TAG"] }
   end
 

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -73,4 +73,14 @@ module ApplicationHelper
   def coalesce_to_completed(status)
     [ :unsupported, :failed ].include?(status) ? :completed : status
   end
+
+  def uswds_form_with(model: false, scope: nil, url: nil, format: nil, **options, &block)
+    options[:builder] = UswdsFormBuilder
+    options[:data] ||= {}
+    options[:data][:turbo_frame] = "_top"
+
+    turbo_frame_tag(model) do
+      form_with(model: model, scope: scope, url: url, format: format, **options, &block)
+    end
+  end
 end

--- a/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
@@ -4,7 +4,7 @@
 <div class="usa-prose">
   <%= site_translation(".description_html", pay_income_days: current_site.pay_income_days) %>
 </div>
-<%= form_with(model: @cbv_flow_invitation, data: { turbo: false }, url: invitations_path, builder: UswdsFormBuilder) do |f| %>
+<%= uswds_form_with(model: @cbv_flow_invitation, url: invitations_path) do |f| %>
   <%= render partial: "caseworker/cbv_flow_invitations/#{@cbv_flow_invitation.site_id}", locals: { f: f } %>
   <%= f.submit t(".form.submit") %>
 <% end %>

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    env_file: .env.local.bak
+    env_file: .env.development.local
     environment:
       - DOCKERIZED=true
       - DB_HOST=postgres

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -51,10 +51,6 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/new-relic-env"
     },
-    SKYLIGHT_AUTHENTICATION = {
-      manage_method     = "manual"
-      secret_store_name = "/service/${var.app_name}-${var.environment}/skylight-authentication"
-    },
     MAINTENANCE_MODE = {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/maintenance-mode"


### PR DESCRIPTION
## Ticket
Resolves [FFS-1809](https://jiraent.cms.gov/browse/FFS-1809).

## Changes
### Overview of the bug
When a user is presented with the invitation page, if the user clicks on the send button multiple times, then multiple duplicate invitations will be generated and sent to the invitee. The purpose of this fix is to make sure that only one invite is generated.

### Summary of changes
Note: This work went through several iterations of approaches. This final approach is deemed most ideal as it maintains the use of the Turbo framework and allows for component reuse. 

1. app/app/views/caseworker/cbv_flow_invitations/new.html.erb - Wrap the invitation form in a turbo form so that form field errors will be rendered. 
2. app/app/helpers/application_helper.rb - Create a custom "form_with" that will assist with the proper rendering of page errors in the header area and default the builder to UswdsFormBuilder.
3. app/app/controllers/caseworker/cbv_flow_invitations_controller.rb - Fixed a couple bugs that appeared when page errors (i.e., validation errors) were present. First, used `flash.now` instead of `flash` when setting the page's errors. The former will make sure the messages are shown on the page when no redirect occurs. Second, the page returns a 4XX status as opposed to a 2XX status. This fixes the error rendering at the top of the page.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshots

#### Validation errors are rendering properly
<img width="692" alt="Screenshot 2024-12-23 at 7 08 13 PM" src="https://github.com/user-attachments/assets/097c9e4e-b4b6-4e72-ad06-b23f99fadf3c" />

#### Screenshot of disabled button
<img width="695" alt="Screenshot 2024-12-18 at 11 12 58 AM" src="https://github.com/user-attachments/assets/da0ac628-d279-4ca1-a5f0-2339d01b8e73" />

#### Query of before and after an invitation was generated after the fix
Created an invitation for "Jimmy J". The first query is prior to invitation creation and the second is after.

<img width="1311" alt="Screenshot 2024-12-18 at 10 25 22 AM" src="https://github.com/user-attachments/assets/11429341-cee3-41af-bcee-ed23d0b47c26" />

#### For context, prior to changes, I was able to generate multiple invitations by continuously clicking the send button
<img width="1299" alt="Screenshot 2024-12-18 at 11 15 04 AM" src="https://github.com/user-attachments/assets/f3714b24-05cf-460a-a85b-a976affeac98" />

