### PR TITLE
FFS-2247: Track user modal interaction events from Pinwheel

### DIFF
--- a/app/app/controllers/api/pinwheel_controller.rb
+++ b/app/app/controllers/api/pinwheel_controller.rb
@@ -1,6 +1,10 @@
 class Api::PinwheelController < ApplicationController
   after_action :track_event, only: :create_token
 
+  EVENT_NAMES = %w[
+    ApplicantSelectedEmployerOrPlatformItem
+  ]
+
   # run the token here with the included employer/payroll provider id
   def create_token
     @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
@@ -19,15 +23,27 @@ class Api::PinwheelController < ApplicationController
   def user_action
     @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
 
-    case user_action_params[:response_type]
-    when "platform"
-      track_selected_payroll_platform
-    when "employer"
-      track_selected_app_employer
+    base_attributes = {
+      timestamp: Time.now.to_i,
+      cbv_flow_id: @cbv_flow.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id
+    }
+    event_name = user_action_params[:event_name]
+    event_attributes = user_action_params[:attributes].merge(base_attributes)
+
+    if EVENT_NAMES.include?(event_name)
+      NewRelicEventTracker.track(
+        event_name,
+        event_attributes.to_h
+      )
+    else
+      raise "Unknown Event Type #{event_name.inspect}"
     end
 
     render json: { status: :ok }
   rescue => ex
+    raise ex unless Rails.env.production?
+
     Rails.logger.error "Unable to process user action: #{ex}"
     render json: { status: :error }, status: :unprocessable_entity
   end
@@ -35,39 +51,11 @@ class Api::PinwheelController < ApplicationController
   private
 
   def user_action_params
-    params.require(:pinwheel).permit(:response_type, :id, :name, :locale)
+    params.fetch(:pinwheel, {}).permit(:event_name, attributes: {})
   end
 
   def token_params
     params.require(:pinwheel).permit(:response_type, :id, :locale)
-  end
-
-  def track_selected_payroll_platform
-    @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
-
-    NewRelicEventTracker.track("ApplicantSelectedPopularPayrollPlatform", {
-      timestamp: Time.now.to_i,
-      cbv_flow_id: @cbv_flow.id,
-      payroll_platform_id: user_action_params[:id],
-      payroll_platform_name: user_action_params[:name],
-      locale: user_action_params[:locale]
-    })
-  rescue => ex
-    Rails.logger.error "Unable to track NewRelic event (ApplicantSelectedPopularPayrollPlatform): #{ex}"
-  end
-
-  def track_selected_app_employer
-    @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
-
-    NewRelicEventTracker.track("ApplicantSelectedPopularAppEmployer", {
-      timestamp: Time.now.to_i,
-      cbv_flow_id: @cbv_flow.id,
-      employer_id: user_action_params[:id],
-      employer_name: user_action_params[:name],
-      locale: user_action_params[:locale]
-    })
-  rescue => ex
-    Rails.logger.error "Unable to track NewRelic event (ApplicantSelectedPopularAppEmployer): #{ex}"
   end
 
   def track_event

--- a/app/app/controllers/api/pinwheel_controller.rb
+++ b/app/app/controllers/api/pinwheel_controller.rb
@@ -3,6 +3,14 @@ class Api::PinwheelController < ApplicationController
 
   EVENT_NAMES = %w[
     ApplicantSelectedEmployerOrPlatformItem
+    PinwheelAttemptClose
+    PinwheelAttemptLogin
+    PinwheelCloseModal
+    PinwheelError
+    PinwheelShowDefaultProviderSearch
+    PinwheelShowLoginPage
+    PinwheelShowProviderConfirmationPage
+    PinwheelSuccess
   ]
 
   # run the token here with the included employer/payroll provider id
@@ -51,7 +59,7 @@ class Api::PinwheelController < ApplicationController
   private
 
   def user_action_params
-    params.fetch(:pinwheel, {}).permit(:event_name, attributes: {})
+    params.fetch(:pinwheel, {}).permit(:event_name, :locale, attributes: {})
   end
 
   def token_params

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -30,20 +30,43 @@ export default class extends Controller {
     event.preventDefault()
   }
 
-  onPinwheelError(event) {
-    const { type, code } = event;
-    console.error("Got Pinwheel Error:", type, event);
-
-    if (window.NREUM) {
-      window.NREUM.addPageAction("PinwheelError", { type, code, cbvFlowId: this.cbvFlowIdValue })
-    }
-  }
-
   onPinwheelEvent(eventName, eventPayload) {
     if (eventName === 'success') {
-      const { accountId } = eventPayload;
+      const { accountId } = eventPayload
       this.userAccountIdTarget.value = accountId
+      trackUserAction("PinwheelSuccess", {
+        account_id: eventPayload.accountId,
+        platform_id: eventPayload.platformId
+      })
       this.formTarget.submit();
+    } else if (eventName === 'screen_transition') {
+      const { screenName } = eventPayload
+
+      switch (screenName) {
+        case "LOGIN":
+          trackUserAction("PinwheelShowLoginPage", {
+            screen_name: screenName,
+            employer_name: eventPayload.selectedEmployerName,
+            platform_name: eventPayload.selectedPlatformName
+          })
+          break
+        case "PROVIDER_CONFIRMATION":
+          trackUserAction("PinwheelShowProviderConfirmationPage", {})
+          break
+        case "SEARCH_DEFAULT":
+          trackUserAction("PinwheelShowDefaultProviderSearch", {})
+          break
+        case "EXIT_CONFIRMATION":
+          trackUserAction("PinwheelAttemptClose", {})
+          break
+      }
+    } else if (eventName === 'login_attempt') {
+      trackUserAction("PinwheelAttemptLogin", {})
+    } else if (eventName === 'error') {
+      const { type, code, message } = eventPayload
+      trackUserAction("PinwheelError", { type, code, message })
+    } else if (eventName === 'exit') {
+      trackUserAction("PinwheelCloseModal", {})
     }
   }
 
@@ -74,7 +97,6 @@ export default class extends Controller {
   submit(token) {
     this.pinwheel.then(Pinwheel => initializePinwheel(Pinwheel, token, {
       onEvent: this.onPinwheelEvent.bind(this),
-      onError: this.onPinwheelError.bind(this),
       onExit: this.reenableButtons.bind(this),
     }));
   }

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -57,9 +57,14 @@ export default class extends Controller {
 
   async select(event) {
     const locale = this.getDocumentLocale();
-
-    const { responseType, id, name } = event.target.dataset;
-    await trackUserAction(responseType, id, name, locale)
+    const { responseType, id, name, isDefaultOption } = event.target.dataset;
+    await trackUserAction("ApplicantSelectedEmployerOrPlatformItem", {
+      item_type: responseType,
+      item_id: id,
+      item_name: name,
+      is_default_option: isDefaultOption,
+      locale
+    })
 
     this.disableButtons()
     const { token } = await fetchToken(responseType, id, locale);

--- a/app/app/javascript/utilities/pinwheel.js
+++ b/app/app/javascript/utilities/pinwheel.js
@@ -25,14 +25,14 @@ export function initializePinwheel(Pinwheel, linkToken, callbacks) {
   return Pinwheel;
 }
 
-export const trackUserAction = (response_type, id, name, locale) => {
+export const trackUserAction = (eventName, attributes) => {
   return fetch(PINWHEEL_USER_ACTION, {
     method: 'post',
     headers: {
       'X-CSRF-Token': CSRF.token,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ response_type, id, name, locale }),
+    body: JSON.stringify({ pinwheel: { event_name: eventName, attributes } }),
   }).then(response => response.json());
 }
 

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -26,6 +26,8 @@
               data-action="click->cbv-employer-search#select"
               data-id="<%= employer["id"] %>"
               data-response-type="<%= employer["response_type"] %>"
+              data-is-default-option="false"
+              data-name="<%= employer["name"] %>"
               data-cbv-employer-search-target="employerButton"
               class="usa-button usa-button--outline"
               type="button"

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -47,6 +47,7 @@
             data-id="<%= provider[:id] %>"
             data-name="<%= provider[:name] %>"
             data-response-type="<%= provider[:response_type] %>"
+            data-is-default-option="true"
             data-cbv-employer-search-target="employerButton"
             type="button"
             class="width-full usa-button usa-button--outline box-shadow-gray"

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -49,4 +49,71 @@ RSpec.describe Api::PinwheelController do
       end
     end
   end
+
+  describe "#user_action" do
+    let(:cbv_flow) { create :cbv_flow }
+    let(:valid_params) do
+      { pinwheel: { event_name: event_name, attributes: event_attributes } }
+    end
+
+    before do
+      session[:cbv_flow_id] = cbv_flow.id
+    end
+
+    context "when tracking a ApplicantSelectedEmployerOrPlatformItem event" do
+      let(:event_name) { "ApplicantSelectedEmployerOrPlatformItem" }
+
+      context "when selecting the payroll providers tab" do
+        let(:event_attributes) do
+          {
+            item_type: "platform",
+            item_id: 123,
+            item_name: "Test Payroll Provider",
+            locale: "en",
+            is_default_option: "true"
+          }
+        end
+
+        it "tracks an event with NewRelic (with selected_tab = platform)" do
+          expect(NewRelicEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", {
+            timestamp: be_a(Integer),
+            cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
+            item_type: "platform",
+            item_id: "123",
+            item_name: "Test Payroll Provider",
+            is_default_option: "true",
+            locale: "en"
+          }.stringify_keys)
+          post :user_action, params: valid_params
+        end
+      end
+
+      context "when selecting the common employers tab" do
+        let(:event_attributes) do
+          {
+            item_type: "employer",
+            item_id: 123,
+            item_name: "Test Employer",
+            locale: "en",
+            is_default_option: "true"
+          }
+        end
+
+        it "tracks an event with NewRelic (with selected_tab = employer)" do
+          expect(NewRelicEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", {
+            timestamp: be_a(Integer),
+            cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
+            item_type: "employer",
+            item_id: "123",
+            item_name: "Test Employer",
+            is_default_option: "true",
+            locale: "en"
+          }.stringify_keys)
+          post :user_action, params: valid_params
+        end
+      end
+    end
+  end
 end

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -115,5 +115,30 @@ RSpec.describe Api::PinwheelController do
         end
       end
     end
+
+    context "when tracking a PinwheelShowLoginPage event" do
+      let(:event_name) { "PinwheelShowLoginPage" }
+      let(:event_attributes) do
+        {
+          screen_name: "LOGIN",
+          employer_name: "Bob's Burgers",
+          platform_name: "Test Payroll Platform Name",
+          locale: "en"
+        }
+      end
+
+      it "tracks an event with NewRelic" do
+        expect(NewRelicEventTracker).to receive(:track).with("PinwheelShowLoginPage", {
+          timestamp: be_a(Integer),
+          cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          locale: "en",
+          screen_name: "LOGIN",
+          employer_name: "Bob's Burgers",
+          platform_name: "Test Payroll Platform Name"
+        }.stringify_keys)
+        post :user_action, params: valid_params
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2247](https://jiraent.cms.gov/browse/FFS-2247).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Refactor "user action" tracking on employer search page**
> * Make the /api/pinwheel/user_action endpoint generic so it can receive
>   an "eventName" and arbitrary "attributes" for an event. This will be
>   used in subsequent commits for Pinwheel modal events.
> * Create new event, `ApplicantSelectedEmployerOrPlatformItem`, to
>   replace events `ApplicantSelectedPopularPayrollPlatform` and
>   `ApplicantSelectedPopularAppEmployer`. A unified event prevents the
>   javascript from having to know which event to send, and will also make
>   funnel analysis and future maintenance easier.
> * Add an attribute `is_default_option` to the new event so we can tell
>   apart clicks on the 12 default items from clicks on search results.
> * Add the `name` attribute to also be present on search results (as it
>   was previously only present on the default options)
> * Add tests for user action API

**Track eight events from Pinwheel modal interactions**
> These events cover most of what we're hoping to instrument for future
> Pinwheel sessions. In the order a user may experience them:

> 1. `PinwheelShowProviderConfirmationPage` - sent when a provider
>    confirmation screen is shown (e.g. "Amazon" showing multiple
>    platforms like A to Z and ADP)
> 2. `PinwheelShowLoginPage` - sent when the first screen of a login is
>    shown (whether it's employer disambiguation, username/password, or
>    other input required by user)
> 3. `PinwheelAttemptLogin` - sent when the user attempts login (sent only
>    once on the first screen even if there are subsequent screens for MFA
>    or other employer-specific questions). Unfortunately, there are no
>    Pinwheel events on the subsequent login pages.
> 4. `PinwheelError` - sent when an error occurs, likely an incorrect
>    login or MFA code, but also a system error.
> 5. `PinwheelSuccess` - sent when the login completes.

> If the user doesn't follow the intended path through the modal, they may
> trigger:

> 6. `PinwheelShowDefaultProviderSearch` - sent when the user deselects
>    the employer or platform and returns to the beginning of the pinwheel
>    modal
> 7. `PinwheelAttemptClose` - shown when the user clicks the "X" in the
>    modal, before confirming the closure
> 8. `PinwheelCloseModal` - shown when the modal actually closes


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
