### PR TITLE
FFS-1740: [Tech Debt] Fix “unpermitted parameter” warning

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -67,13 +67,11 @@ class ApplicationController < ActionController::Base
   end
 
   def add_newrelic_metadata
-    newrelic_params = params.slice(:site_id, :locale).permit
-
     attributes = {
       cbv_flow_id: session[:cbv_flow_id],
       session_id: session.id.to_s,
-      site_id: newrelic_params[:site_id],
-      locale: newrelic_params[:locale],
+      site_id: params[:site_id],
+      locale: params[:locale],
       user_id: current_user.try(:id)
     }
 

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -21,7 +21,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
   private
 
   def search_params
-    params.permit(:query, :type)
+    params.slice(:query, :type)
   end
 
   def fetch_employers(query = "")


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-1740](https://jiraent.cms.gov/browse/FFS-1740).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-1740: Fix unpermitted parameter developer warnings**
> These warnings were not causing any trouble, but they were creating
> confusion. Since I'm about to rework the analytics code, may as well fix
> this along the way.

> This fixes the warnings by not using "permit", since permitting specific
> attributes is mainly useful for mass assignment. In these controllers,
> by contrast, we directly index the params according to the indexes we're
> expecting, so no sense in also having the same list of allowed
> parameters being passed into `permit`.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
