### PR TITLE
FFS-2402: Add delivery_method parameter to invite method

### DIFF
--- a/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
+++ b/app/app/controllers/caseworker/cbv_flow_invitations_controller.rb
@@ -17,8 +17,13 @@ class Caseworker::CbvFlowInvitationsController < Caseworker::BaseController
     invitation_params = base_params.merge(site_specific_params)
     # handle errors from the mail service
     begin
-      @cbv_flow_invitation = CbvInvitationService.new(event_logger).invite(invitation_params, current_user)
+      @cbv_flow_invitation = CbvInvitationService.new(event_logger).invite(
+        invitation_params,
+        current_user,
+        delivery_method: :email
+      )
     rescue => e
+      Rails.logger.error("Error inviting applicant: #{e.message}")
       flash[:alert] = t(".invite_failed",
                         email_address: cbv_flow_invitation_params[:email_address],
                         error_message: e.message)

--- a/app/spec/services/cbv_invitation_service_spec.rb
+++ b/app/spec/services/cbv_invitation_service_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe CbvInvitationService, type: :service do
+  let(:event_logger) { instance_double('GenericEventTracker') }
+  let(:service) { described_class.new(event_logger) }
+  let(:cbv_flow_invitation_params) { attributes_for(:cbv_flow_invitation) }
+  let(:current_user) { create(:user) }
+
+  before do
+    allow(event_logger).to receive(:track)
+  end
+
+  describe '#invite' do
+    context 'when delivery method is :email' do
+      it 'creates an invitation with correct parameters' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: :email
+        )
+
+        invitation = CbvFlowInvitation.last
+        expect(invitation).to have_attributes(
+          user: current_user,
+          case_number: cbv_flow_invitation_params[:case_number]
+        )
+      end
+
+      it 'sends an email invitation' do
+        expect do
+          service.invite(
+            cbv_flow_invitation_params,
+            current_user,
+            delivery_method: :email
+          )
+        end.to change { ActionMailer::Base.deliveries.count }
+          .by(1)
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email.to).to include(cbv_flow_invitation_params[:email_address])
+      end
+
+      it 'tracks the event' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: :email
+        )
+
+        invitation = CbvFlowInvitation.last
+        expect(event_logger).to have_received(:track).with(
+          'ApplicantInvitedToFlow',
+          nil,
+          hash_including(invitation_id: invitation.id)
+        )
+      end
+    end
+
+    context 'when delivery method is nil' do
+      it 'creates an invitation with correct parameters' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: nil
+        )
+
+        invitation = CbvFlowInvitation.last
+        expect(invitation).to have_attributes(
+          user: current_user,
+          case_number: cbv_flow_invitation_params[:case_number]
+        )
+      end
+
+      it 'logs a message instead of sending an email' do
+        allow(Rails.logger).to receive(:info)
+
+        expect do
+          service.invite(
+            cbv_flow_invitation_params,
+            current_user,
+            delivery_method: nil
+          )
+        end.to change { ActionMailer::Base.deliveries.count }
+          .by(0)
+
+        expect(Rails.logger).to have_received(:info).with(/Generated invitation ID:/)
+      end
+
+      it 'tracks the event' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: nil
+        )
+
+        invitation = CbvFlowInvitation.last
+        expect(event_logger).to have_received(:track).with(
+          'ApplicantInvitedToFlow',
+          nil,
+          hash_including(invitation_id: invitation.id)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2402](https://jiraent.cms.gov/browse/FFS-2402).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2402: Add delivery_method parameter to invite method**



## Context for reviewers
> In addition to this, I removed the exception catching from the service
> itself, since the controller that calls the service also catches
> exceptions.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
