### PR TITLE
2401: Use different syntax

### DIFF
--- a/app/lib/tasks/users.rake
+++ b/app/lib/tasks/users.rake
@@ -1,23 +1,23 @@
 namespace :users do
   desc "Promote an existing account to service account status, returning an access token"
-  task :promote_to_service_account, [ :user_id ] => [ :environment ] do |_, args|
-    user = User.find(args[:user_id])
+  task :promote_to_service_account, [ :user_id ] => [ :environment ] do |_, user_id|
+    user = User.find(user_id)
 
     if user && user.update(is_service_account: true)
       token = user.api_access_tokens.create
 
-      puts "User #{args[:user_id]} (#{user.email}) is now a service account: #{token.access_token}"
+      puts "User #{user_id} (#{user.email}) is now a service account: #{token.access_token}"
     end
   end
 
   desc "Demote an existing account, deleting all associated access tokens"
-  task :demote_service_account, [ :user_id ] => [ :environment ] do |_, args|
-    user = User.find(args[:user_id])
+  task :demote_service_account, [ :user_id ] => [ :environment ] do |_, user_id|
+    user = User.find(user_id)
 
     if user && user.update(is_service_account: false)
       user.api_access_tokens.update_all(deleted_at: Time.now)
 
-      puts "User #{args[:user_id]} (#{user.email}) is no longer a service account."
+      puts "User #{user_id} (#{user.email}) is no longer a service account."
     end
   end
 end

--- a/app/spec/lib/users_rake_spec.rb
+++ b/app/spec/lib/users_rake_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "users.rake" do
   describe "promotes and demotes user service accounts" do
     it "promotes a user to a service account" do
       user = create(:user)
-      Rake::Task['users:promote_to_service_account'].invoke(user.id.to_s)
+      Rake::Task['users:promote_to_service_account'].execute(user.id.to_s)
       user.reload
       expect(user.is_service_account).to eq(true)
       expect(user.api_access_tokens.count).to eq(1)
@@ -12,7 +12,7 @@ RSpec.describe "users.rake" do
 
     it "demotes a service account user and removes all access tokens" do
       user = create(:user, :with_access_token, is_service_account: true)
-      Rake::Task['users:demote_service_account'].invoke(user.id.to_s)
+      Rake::Task['users:demote_service_account'].execute(user.id.to_s)
       user.reload
       expect(user.is_service_account).to eq(false)
       expect(user.api_access_tokens.where(deleted_at: nil).count).to eq(0)


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket
N/A


## Changes
Simplifies the syntax (sort of) so that it's easier to run these rake commands against a deployed environment through our infra platform tooling


## Context for reviewers
Instead of
```
bin/run-command --environment-variables '[{ "name" : "id", "value" : "1" }]' app env '["bin/rails", "users:promote_to_service_account"]'
```

It's
```
`bin/run-command app env '["bin/rails", "users:promote_to_service_account[123]"]'`
```



## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
