### PR TITLE
FFS-2351: Change calculation of account_count to be correct in filed events

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -193,7 +193,7 @@ class Cbv::SummariesController < Cbv::BaseController
       site_id: cbv_flow.site_id,
       cbv_flow_id: cbv_flow.id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,
-      account_count: payments.map { |p| p[:account_id] }.uniq.count,
+      account_count: cbv_flow.pinwheel_accounts.count,
       paystub_count: payments.count,
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },
@@ -210,7 +210,7 @@ class Cbv::SummariesController < Cbv::BaseController
       site_id: cbv_flow.site_id,
       cbv_flow_id: cbv_flow.id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,
-      account_count: payments.map { |p| p.account_id }.uniq.count,
+      account_count: cbv_flow.pinwheel_accounts.count,
       paystub_count: payments.count,
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },


### PR DESCRIPTION
## [FFS-2351](https://jiraent.cms.gov/browse/FFS-2351)

## Changes
ApplicantSharedIncomeSummary and ApplicantAccessedIncomeSummary events now contain a correct value for account_count.

## Testing Instructions
0. Go through the normal CBV workflow until you've shared the income summary with a caseworker.
1. Access Mixpanel and observe the two modified events. The account_count property should be set and seem reasonable.
2. Optionally, verify the same on NewRelic (but there's no reason to think it would differ).

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
