### PR TITLE
FFS-2336: Move paystub, identity, employment, income into a response object

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -75,7 +75,6 @@ gem "pdf-reader", "~> 2.12.0"
 gem "net-imap", "0.4.19"  # Fixing CVE-2025-25186
 
 gem "maybe_later"
-gem "activeresource"
 
 group :development, :test do
   gem "brakeman", "~> 5.2"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -60,18 +60,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.1.5.1)
       activesupport (= 7.1.5.1)
-    activemodel-serializers-xml (1.0.3)
-      activemodel (>= 5.0.0.a)
-      activesupport (>= 5.0.0.a)
-      builder (~> 3.1)
     activerecord (7.1.5.1)
       activemodel (= 7.1.5.1)
       activesupport (= 7.1.5.1)
       timeout (>= 0.4.0)
-    activeresource (6.1.4)
-      activemodel (>= 6.0)
-      activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 6.0)
     activestorage (7.1.5.1)
       actionpack (= 7.1.5.1)
       activejob (= 7.1.5.1)
@@ -526,7 +518,6 @@ PLATFORMS
 
 DEPENDENCIES
   actioncable-enhanced-postgresql-adapter
-  activeresource
   aws-actionmailer-ses
   aws-sdk-rails
   aws-sdk-s3

--- a/app/app/models/response_objects/employment.rb
+++ b/app/app/models/response_objects/employment.rb
@@ -1,0 +1,30 @@
+EMPLOYMENT_FIELDS = %i[
+  account_id
+  employer_name
+  start_date
+  termination_date
+  status
+  employer_phone_number
+  employer_address
+]
+
+module ResponseObjects
+  Employment = Struct.new(*EMPLOYMENT_FIELDS, keyword_init: true) do
+    def self.from_pinwheel(response_body)
+      new(
+        account_id: response_body["account_id"],
+        employer_name: response_body["employer_name"],
+        start_date: response_body["start_date"],
+        termination_date: response_body["termination_date"],
+        status: response_body["status"],
+        employer_phone_number: OpenStruct.new(
+          value: response_body["employer_phone_number"]["value"],
+          type: response_body["employer_phone_number"]["type"],
+        ),
+        employer_address: OpenStruct.new(
+          raw: response_body["employer_address"]["raw"],
+        ),
+      )
+    end
+  end
+end

--- a/app/app/models/response_objects/identity.rb
+++ b/app/app/models/response_objects/identity.rb
@@ -1,0 +1,15 @@
+IDENTITY_FIELDS = %i[
+  account_id
+  full_name
+]
+
+module ResponseObjects
+  Identity = Struct.new(*IDENTITY_FIELDS, keyword_init: true) do
+    def self.from_pinwheel(response_body)
+      new(
+        account_id: response_body["account_id"],
+        full_name: response_body["full_name"],
+      )
+    end
+  end
+end

--- a/app/app/models/response_objects/income.rb
+++ b/app/app/models/response_objects/income.rb
@@ -1,0 +1,19 @@
+INCOME_FIELDS = %i[
+  account_id
+  pay_frequency
+  compensation_amount
+  compensation_unit
+]
+
+module ResponseObjects
+  Income = Struct.new(*INCOME_FIELDS, keyword_init: true) do
+    def self.from_pinwheel(response_body)
+      new(
+        account_id: response_body["account_id"],
+        pay_frequency: response_body["pay_frequency"],
+        compensation_amount: response_body["compensation_amount"],
+        compensation_unit: response_body["compensation_unit"],
+      )
+    end
+  end
+end

--- a/app/app/models/response_objects/paystub.rb
+++ b/app/app/models/response_objects/paystub.rb
@@ -1,0 +1,79 @@
+module ResponseObjects
+  Paystub = Struct.new(
+    :account_id,
+    :gross_pay_amount,
+    :net_pay_amount,
+    :gross_pay_ytd,
+    :pay_period_start,
+    :pay_period_end,
+    :pay_date,
+    :earnings,
+    :deductions,
+
+    keyword_init: true
+  ) do
+    def self.from_pinwheel(response_body)
+      new(
+        account_id: response_body["account_id"],
+        gross_pay_amount: response_body["gross_pay_amount"],
+        net_pay_amount: response_body["net_pay_amount"],
+        gross_pay_ytd: response_body["gross_pay_ytd"],
+        pay_period_start: response_body["pay_period_start"],
+        pay_period_end: response_body["pay_period_end"],
+        pay_date: response_body["pay_date"],
+        earnings: response_body["earnings"].map do |earning|
+          PaystubEarning.new(
+            category: earning["category"],
+            hours: earning["hours"],
+          )
+        end,
+        deductions: response_body["deductions"].map do |deduction|
+          PaystubDeduction.new(
+            category: deduction["category"],
+            amount: deduction["amount"],
+          )
+        end,
+      )
+    end
+
+    alias_attribute :start, :pay_period_start
+    alias_attribute :end, :pay_period_end
+
+    def hours
+      base_hours = earnings
+        .filter { |e| e.category != "overtime" }
+        .map { |e| e.hours }
+        .compact
+        .max
+      return unless base_hours
+
+      # Add overtime hours to the base hours, because they tend to be additional
+      # work beyond the other entries. (As opposed to category="premium", which
+      # often duplicates other earnings' hours.)
+      #
+      # See FFS-1773.
+      overtime_hours = earnings
+        .filter { |e| e.category == "overtime" }
+        .sum { |e| e.hours || 0.0 }
+
+      base_hours + overtime_hours
+    end
+
+    def hours_by_earning_category
+      earnings
+        .filter { |e| e.hours && e.hours > 0 }
+        .group_by { |e| e.category }
+        .transform_values { |earnings| earnings.sum { |e| e.hours } }
+    end
+  end
+
+  PaystubEarning = Struct.new(
+    :category,
+    :hours,
+  )
+
+  PaystubDeduction = Struct.new(
+    :category,
+    :amount,
+  )
+end

--- a/app/app/models/response_objects/paystub.rb
+++ b/app/app/models/response_objects/paystub.rb
@@ -1,17 +1,17 @@
-module ResponseObjects
-  Paystub = Struct.new(
-    :account_id,
-    :gross_pay_amount,
-    :net_pay_amount,
-    :gross_pay_ytd,
-    :pay_period_start,
-    :pay_period_end,
-    :pay_date,
-    :earnings,
-    :deductions,
+PAYSTUB_FIELDS = %i[
+  account_id
+  gross_pay_amount
+  net_pay_amount
+  gross_pay_ytd
+  pay_period_start
+  pay_period_end
+  pay_date
+  earnings
+  deductions
+]
 
-    keyword_init: true
-  ) do
+module ResponseObjects
+  Paystub = Struct.new(*PAYSTUB_FIELDS, keyword_init: true) do
     def self.from_pinwheel(response_body)
       new(
         account_id: response_body["account_id"],

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -103,21 +103,6 @@ class PinwheelService
     }
   ]
 
-  # Base class for wrapping responses from Pinwheel to allow accessing the data
-  # via dot-notation.
-  class ResponseObject < ActiveResource::Base
-    def initialize(*params, environment:)
-      # ActiveResource requires us to set the `site` (the API base url) on the
-      # class. Since Pinwheel's API base URL's differ per-environment, let's
-      # set the value dynamically as these records are instantiated.
-      self.class.site = environment[:base_url]
-      super(*params)
-    end
-  end
-  # Employment = Class.new(ResponseObject)
-  Identity = Class.new(ResponseObject)
-  Income = Class.new(ResponseObject)
-
   def initialize(environment, api_key = nil)
     @api_key = api_key || ENVIRONMENTS.fetch(environment.to_sym)[:api_key]
     @environment = ENVIRONMENTS.fetch(environment.to_sym) { |env| raise KeyError.new("PinwheelService unknown environment: #{env}") }
@@ -174,7 +159,7 @@ class PinwheelService
   def fetch_identity(account_id:)
     json = @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/identity")).body
 
-    Identity.new(json["data"], environment: @environment)
+    ResponseObjects::Identity.from_pinwheel(json["data"])
   end
 
   def fetch_income(account_id:)

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -114,7 +114,7 @@ class PinwheelService
       super(*params)
     end
   end
-  Employment = Class.new(ResponseObject)
+  # Employment = Class.new(ResponseObject)
   Identity = Class.new(ResponseObject)
   Income = Class.new(ResponseObject)
 
@@ -168,7 +168,7 @@ class PinwheelService
   def fetch_employment(account_id:)
     json = @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/employment")).body
 
-    Employment.new(json["data"], environment: @environment)
+    ResponseObjects::Employment.from_pinwheel(json["data"])
   end
 
   def fetch_identity(account_id:)

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -180,7 +180,7 @@ class PinwheelService
   def fetch_income(account_id:)
     json = @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/income")).body
 
-    Income.new(json["data"], environment: @environment)
+    ResponseObjects::Income.from_pinwheel(json["data"])
   end
 
   def fetch_platform(platform_id:)

--- a/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
+++ b/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
@@ -18,10 +18,7 @@ RSpec.describe Cbv::PinwheelDataHelper, type: :helper do
   end
 
   let(:incomes) do
-    PinwheelService::Income.new(
-      load_relative_json_file('request_income_metadata_response.json')['data'],
-      environment: PinwheelService::ENVIRONMENTS[:sandbox]
-    )
+    ResponseObjects::Income.from_pinwheel(load_relative_json_file('request_income_metadata_response.json')['data'])
   end
 
   let(:identities) do

--- a/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
+++ b/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
@@ -22,10 +22,7 @@ RSpec.describe Cbv::PinwheelDataHelper, type: :helper do
   end
 
   let(:identities) do
-    PinwheelService::Identity.new(
-      load_relative_json_file('request_identity_response.json')['data'],
-      environment: PinwheelService::ENVIRONMENTS[:sandbox]
-    )
+    ResponseObjects::Identity.from_pinwheel(load_relative_json_file('request_identity_response.json')['data'])
   end
 
   let!(:cbv_flow) { create(:cbv_flow, :with_pinwheel_account) }

--- a/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
+++ b/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe Cbv::PinwheelDataHelper, type: :helper do
     raw_payments_json = load_relative_json_file('request_end_user_paystubs_response.json')['data']
 
     raw_payments_json.map do |payment_json|
-      PinwheelService::Paystub.new(
-        payment_json,
-        environment: PinwheelService::ENVIRONMENTS[:sandbox]
-      )
+      ResponseObjects::Paystub.from_pinwheel(payment_json)
     end
   end
 

--- a/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
+++ b/app/spec/helpers/cbv/pinwheel_data_helper_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe Cbv::PinwheelDataHelper, type: :helper do
   end
 
   let(:employment) do
-    PinwheelService::Employment.new(
-      load_relative_json_file('request_employment_info_response.json')['data'],
-      environment: PinwheelService::ENVIRONMENTS[:sandbox]
-    )
+    ResponseObjects::Employment.from_pinwheel(load_relative_json_file('request_employment_info_response.json')['data'])
   end
 
   let(:incomes) do

--- a/app/spec/services/pinwheel_service_spec.rb
+++ b/app/spec/services/pinwheel_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe PinwheelService, type: :service do
     it "returns an Employment object with expected attributes" do
       employment = service.fetch_employment(account_id: account_id)
 
-      expect(employment).to be_a(PinwheelService::Employment)
+      expect(employment).to be_a(ResponseObjects::Employment)
       expect(employment).to have_attributes(status: "employed", start_date: "2010-01-01")
       expect(employment.employer_phone_number).to have_attributes(value: "+16126597057", type: "work")
     end

--- a/app/spec/services/pinwheel_service_spec.rb
+++ b/app/spec/services/pinwheel_service_spec.rb
@@ -75,17 +75,14 @@ RSpec.describe PinwheelService, type: :service do
     end
   end
 
-  describe PinwheelService::Paystub do
+  describe ResponseObjects::Paystub do
     let(:raw_paystubs_json) do
       load_relative_json_file('request_end_user_paystubs_response.json')['data']
     end
 
     let(:payments) do
       raw_paystubs_json.map do |payment_json|
-        described_class.new(
-          payment_json,
-          environment: PinwheelService::ENVIRONMENTS[:sandbox]
-        )
+        described_class.from_pinwheel(payment_json)
       end
     end
 

--- a/app/spec/support/test_helpers.rb
+++ b/app/spec/support/test_helpers.rb
@@ -43,7 +43,7 @@ module TestHelpers
         "title" => nil
       }
 
-      PinwheelService::Employment.new(fields, environment: PinwheelService::ENVIRONMENTS[:sandbox])
+      ResponseObjects::Employment.from_pinwheel(fields)
     end
   end
 

--- a/app/spec/support/test_helpers.rb
+++ b/app/spec/support/test_helpers.rb
@@ -60,7 +60,7 @@ module TestHelpers
         "pay_frequency" => "bi-weekly"
       }
 
-      PinwheelService::Income.new(fields, environment: PinwheelService::ENVIRONMENTS[:sandbox])
+      ResponseObjects::Income.from_pinwheel(fields)
     end
   end
 

--- a/app/spec/support/test_helpers.rb
+++ b/app/spec/support/test_helpers.rb
@@ -9,23 +9,20 @@ module TestHelpers
   def stub_payments(account_id = SecureRandom.uuid)
     5.times.map do |i|
       json = {
-        account_id: account_id,
-        employer: "Employer #{i + 1}",
-        net_pay_amount: (100 * (i + 1)),
-        gross_pay_amount: (120 * (i + 1)),
-        rate: (10 + i),
-        pay_date: "2020-01-14",
-        pay_period_start: "2020-01-01",
-        pay_period_end: "2020-01-14",
-        gross_pay_ytd: 1_000,
-        deductions: [],
-        earnings: []
+        "account_id" => account_id,
+        "employer" => "Employer #{i + 1}",
+        "net_pay_amount" => (100 * (i + 1)),
+        "gross_pay_amount" => (120 * (i + 1)),
+        "rate" => (10 + i),
+        "pay_date" => "2020-01-14",
+        "pay_period_start" => "2020-01-01",
+        "pay_period_end" => "2020-01-14",
+        "gross_pay_ytd" => 1_000,
+        "deductions" => [],
+        "earnings" => []
       }
 
-      PinwheelService::Paystub.new(
-        json,
-        environment: PinwheelService::ENVIRONMENTS[:sandbox]
-      )
+      ResponseObjects::Paystub.from_pinwheel(json)
     end
   end
 

--- a/app/spec/support/test_helpers.rb
+++ b/app/spec/support/test_helpers.rb
@@ -94,7 +94,7 @@ module TestHelpers
         ]
       }
 
-      PinwheelService::Identity.new(fields, environment: PinwheelService::ENVIRONMENTS[:sandbox])
+      ResponseObjects::Identity.from_pinwheel(fields)
     end
   end
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Follow up from https://github.com/DSACMS/iv-cbv-payroll/pull/442 to migrate existing "response object" definitions to /models, leveraging Struct over Active Resource.


## Context for reviewers
We needed a way to model API responses so we have explicit definitions for those things.

Our first attempt was in PinwheelService, where we leveraged ActiveResource (gem) to model these responses. We found this got us most of the way there with dot-notation accessor style and some clarity around the concepts. But they didn't help document the expected domain used throughout CBV.

This change moves the Paystub object into a ResponseObject that leverages Struct to enforce required fields. We define a `from_pinwheel` method to help map Pinwheel's values into our domain modeling

That said, our "domain modeling" here so far is just however Pinwheel does it. When Argyle comes in, we'll basically be twisting it to fit in to how we've deferred to Pinwheel's design. We should find a middle ground that makes the most sense to CBV.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
