### PR TITLE
FFS-2397: Improve Mixpanel's user profile data

### DIFF
--- a/app/lib/mixpanel_event_tracker.rb
+++ b/app/lib/mixpanel_event_tracker.rb
@@ -13,7 +13,7 @@ class MixpanelEventTracker
     invitation_id = attributes.fetch(:invitation_id, "")
     distinct_id = ""
     if invitation_id.present?
-      distinct_id = "invitation-#{invitation_id}"
+      distinct_id = "applicant-#{invitation_id}"
 
       # This creates a profile for a distinct user
       flow_id = attributes.fetch(:cbv_flow_id, "")

--- a/app/lib/mixpanel_event_tracker.rb
+++ b/app/lib/mixpanel_event_tracker.rb
@@ -17,7 +17,13 @@ class MixpanelEventTracker
 
       # This creates a profile for a distinct user
       flow_id = attributes.fetch(:cbv_flow_id, "")
-      @tracker.people.set(distinct_id, { cbv_flow_id: flow_id })
+
+      tracker_attrs =  { cbv_flow_id: flow_id }
+      if request.present?
+        tracker_attrs.merge!({ ip: request.ip })
+      end
+
+      @tracker.people.set(distinct_id, tracker_attrs)
     end
 
     # MaybeLater tries to run this code after the request has finished


### PR DESCRIPTION
## [FFS-2397](https://jiraent.cms.gov/browse/FFS-2397)

## Changes
Mixpanel user profiles will now have accurate locations associated with them.

## Testing Instructions
0. Create a brand new invite
1. Proceed through the CBV flow enough to file an event 
2. Click on the Distinct ID in Mixpanel for your new event and observe the User Profile section. It should contain your correct location (or the location of your VPN). Previously, it was just wrong (the theory is that it was the location of the AWS server being used).
![image](https://github.com/user-attachments/assets/07d9b20f-de88-4c30-b661-034704ac953b)


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
