### PR TITLE
FFS-2453: Replace Help Modal iframe with Turbo Frame

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -136,26 +136,6 @@ html {
 /**
  * Help Modal
  */
-#help-iframe {
-  min-height: 600px;
-  line-height: 1;
-
-  // Small screens such as mobile
-  @media screen and (max-width: 375px) {
-    height: 73vh;
-  }
-
-  // Medium screens such as tablets
-  @media screen and (min-width: 810px) {
-    height: 630px;
-  }
-
-  // Larger screens such as desktop
-  @include at-media(desktop) {
-    height: 660px;
-  }
-}
-
 .main-bullets {
   list-style-type: disc;
 }

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -92,11 +92,9 @@ class ApplicationController < ActionController::Base
   def check_help_param
     if params[:help] == "true"
       help_link = helpers.render(partial: "help/help_link", locals: { text: t("help.alert.help_options"), source: "banner" })
-      flash.merge!(
-        alert: "#{t('help.alert.text_before')} #{help_link}",
-        alert_heading: t("help.alert.heading"),
-        alert_type: "warning"
-      )
+      flash.now[:alert] = "#{t('help.alert.text_before')} #{help_link}"
+      flash.now[:alert_heading] = t("help.alert.heading")
+      flash.now[:alert_type] = "warning"
     end
   end
 end

--- a/app/app/controllers/help_controller.rb
+++ b/app/app/controllers/help_controller.rb
@@ -4,6 +4,7 @@ class HelpController < ApplicationController
 
   def index
     @title = t("help.index.title")
+    render layout: false if turbo_frame_request?
   end
 
   def show
@@ -25,6 +26,8 @@ class HelpController < ApplicationController
     rescue => ex
       Rails.logger.error "Unable to track event (ApplicantViewedHelpTopic): #{ex}"
     end
+
+    render layout: false if turbo_frame_request?
   end
 
   private

--- a/app/app/controllers/help_controller.rb
+++ b/app/app/controllers/help_controller.rb
@@ -4,7 +4,7 @@ class HelpController < ApplicationController
 
   def index
     @title = t("help.index.title")
-    render layout: false if turbo_frame_request?
+    render layout: false
   end
 
   def show

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -4,16 +4,17 @@ import { trackUserAction } from "../utilities/api";
 export default class extends Controller {
   static targets = ["content"];
 
+  handleClick(event) {
+    if (event.target.href?.includes("#help-modal")) {
+      trackUserAction("ApplicantOpenedHelpModal", {
+        source: event.target.dataset.source,
+      });
+      // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
+      document.querySelector("#help_modal_content").src = "/help";
+    }
+  }
+
   connect() {
-    this.handleClick = (event) => {
-      if (event.target.href?.includes("#help-modal")) {
-        trackUserAction("ApplicantOpenedHelpModal", {
-          source: event.target.dataset.source,
-        });
-        // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
-        document.querySelector("#help_modal_content").src = "/help";
-      }
-    };
     document.addEventListener("click", this.handleClick);
   }
 

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -11,10 +11,31 @@ export default class extends Controller {
       }
     }
 
+    // Watch for modal visibility changes
+    this.observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {        
+        if (mutation.target.classList.contains('is-hidden')) {
+          const frame = document.querySelector('#help_modal_content')
+          if (frame) {
+            frame.src = '/help'
+          }
+        }
+      })
+    })
+
+    const modalElement = document.getElementById('help-modal')
+    this.observer.observe(modalElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    })
+
     document.addEventListener("click", this.handleClick)
   }
 
   disconnect() {
     document.removeEventListener("click", this.handleClick)
+    if (this.observer) {
+      this.observer.disconnect()
+    }
   }
 }

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -13,6 +13,8 @@ export default class extends Controller {
       }
     };
 
+    
+     // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
     document
       .querySelector('[aria-controls="help-modal"]')
       .addEventListener("mousedown", () => {

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -1,41 +1,28 @@
-import { Controller } from "@hotwired/stimulus"
-import { trackUserAction } from "../utilities/api"
+import { Controller } from "@hotwired/stimulus";
+import { trackUserAction } from "../utilities/api";
 
 export default class extends Controller {
-  static targets = ["content"]
+  static targets = ["content"];
 
   connect() {
     this.handleClick = (event) => {
       if (event.target.href?.includes("#help-modal")) {
-        trackUserAction("ApplicantOpenedHelpModal", { source: event.target.dataset.source })
+        trackUserAction("ApplicantOpenedHelpModal", {
+          source: event.target.dataset.source,
+        });
       }
-    }
+    };
 
-    // Watch for modal visibility changes
-    this.observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {        
-        if (mutation.target.classList.contains('is-hidden')) {
-          const frame = document.querySelector('#help_modal_content')
-          if (frame) {
-            frame.src = '/help'
-          }
-        }
-      })
-    })
+    document
+      .querySelector('[aria-controls="help-modal"]')
+      .addEventListener("mousedown", () => {
+        document.querySelector("#help_modal_content").src = "/help";
+      });
 
-    const modalElement = document.getElementById('help-modal')
-    this.observer.observe(modalElement, {
-      attributes: true,
-      attributeFilter: ['class']
-    })
-
-    document.addEventListener("click", this.handleClick)
+    document.addEventListener("click", this.handleClick);
   }
 
   disconnect() {
-    document.removeEventListener("click", this.handleClick)
-    if (this.observer) {
-      this.observer.disconnect()
-    }
+    document.removeEventListener("click", this.handleClick);
   }
 }

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -10,16 +10,10 @@ export default class extends Controller {
         trackUserAction("ApplicantOpenedHelpModal", {
           source: event.target.dataset.source,
         });
+        // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
+        document.querySelector("#help_modal_content").src = "/help";
       }
     };
-    
-    // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
-    document
-      .querySelector('[aria-controls="help-modal"]')
-      .addEventListener("mousedown", () => {
-        document.querySelector("#help_modal_content").src = "/help";
-      });
-
     document.addEventListener("click", this.handleClick);
   }
 

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -12,9 +12,8 @@ export default class extends Controller {
         });
       }
     };
-
     
-     // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
+    // reset the help modal src on mousedown to ensure the help modal src is reset to "/help"
     document
       .querySelector('[aria-controls="help-modal"]')
       .addEventListener("mousedown", () => {

--- a/app/app/javascript/controllers/help.js
+++ b/app/app/javascript/controllers/help.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { trackUserAction } from "../utilities/api"
 
 export default class extends Controller {
-  static targets = ["iframe"]
+  static targets = ["content"]
 
   connect() {
     this.handleClick = (event) => {
@@ -16,25 +16,5 @@ export default class extends Controller {
 
   disconnect() {
     document.removeEventListener("click", this.handleClick)
-  }
-
-  /**
-   * This function is used to prepare the next URL for the iframe.
-   * It generates a new random parameter and updates the iframe src
-   * so that when the modal is opened, the iframe will load the
-   * default help topics rather than the last viewed topic.
-   */
-  prepareNextUrl() {
-    const iframe = this.iframeTarget
-    const currentSrc = new URL(iframe.src)
-
-    // Generate a new random parameter
-    const randomHex = Array.from(crypto.getRandomValues(new Uint8Array(2)))
-      .map(b => b.toString(16).padStart(2, "0"))
-      .join("")
-
-    // Update the iframe src with new random parameter
-    currentSrc.searchParams.set("r", randomHex)
-    iframe.src = currentSrc.toString()
   }
 }

--- a/app/app/views/help/_help_modal.html.erb
+++ b/app/app/views/help/_help_modal.html.erb
@@ -6,17 +6,11 @@
   data-controller="help"
 >
   <div class="usa-modal__content">
-    <div class="usa-modal__main padding-0 margin-0 maxw-none-important">
-      <div class="usa-modal__body padding-0">
-        <iframe
-          id="help-iframe"
-          src="<%= help_path(site_id: params[:site_id]) %>"
-          class="width-full border-0"
-          title="Help Content"
-          data-help-target="iframe"
-          scrolling="no"
-          >
-        </iframe>
+    <div class="usa-modal__main">
+      <div class="usa-modal__body" data-help-target="content">
+        <%= turbo_frame_tag "help_content" do %>
+          <%= render template: "help/index" %>
+        <% end %>
       </div>
     </div>
 

--- a/app/app/views/help/_help_topic_link.html.erb
+++ b/app/app/views/help/_help_topic_link.html.erb
@@ -1,4 +1,5 @@
 <%= link_to help_topic_path(topic: topic, locale: I18n.locale),
-    class: "usa-button margin-bottom-1 height-5 text-left display-block" do %>
+    class: "usa-button margin-bottom-1 height-5 text-left display-block",
+    data: { turbo_frame: "help_content" } do %>
   <%= text %>
 <% end %>

--- a/app/app/views/help/_help_topic_link.html.erb
+++ b/app/app/views/help/_help_topic_link.html.erb
@@ -1,5 +1,5 @@
 <%= link_to help_topic_path(topic: topic, locale: I18n.locale),
     class: "usa-button margin-bottom-1 height-5 text-left display-block",
-    data: { turbo_frame: "help_content" } do %>
+    data: { turbo_frame: "help_modal_content" } do %>
   <%= text %>
 <% end %>

--- a/app/app/views/help/index.html.erb
+++ b/app/app/views/help/index.html.erb
@@ -1,20 +1,22 @@
-<div class="padding-2">
-  <h2 class="margin-top-0"><%= t("help.index.title") %></h2>
-  <div class="usa-prose">
-    <p><%= t("help.index.select_prompt") %></p>
+<%= turbo_frame_tag "help_content" do %>
+  <div class="padding-2">
+    <h2 class="margin-top-0"><%= t("help.index.title") %></h2>
+    <div class="usa-prose">
+      <p><%= t("help.index.select_prompt") %></p>
 
-    <%= render "help_topic_link", topic: "username", text: t("help.index.username") %>
-    <%= render "help_topic_link", topic: "password", text: t("help.index.password") %>
-    <%= render "help_topic_link", topic: "company-id", text: t("help.index.company_id") %>
-    <%= render "help_topic_link", topic: "employer", text: t("help.index.employer") %>
-    <%= render "help_topic_link", topic: "provider", text: t("help.index.provider") %>
-    <%= render "help_topic_link", topic: "credentials", text: t("help.index.credentials") %>
+      <%= render "help/help_topic_link", topic: "username", text: t("help.index.username") %>
+      <%= render "help/help_topic_link", topic: "password", text: t("help.index.password") %>
+      <%= render "help/help_topic_link", topic: "company-id", text: t("help.index.company_id") %>
+      <%= render "help/help_topic_link", topic: "employer", text: t("help.index.employer") %>
+      <%= render "help/help_topic_link", topic: "provider", text: t("help.index.provider") %>
+      <%= render "help/help_topic_link", topic: "credentials", text: t("help.index.credentials") %>
 
-    <% if current_agency && current_agency.caseworker_feedback_form.present? %>
-      <%= link_to feedback_form_url, class: "usa-button margin-bottom-1 height-5 text-left display-block", target: "_blank" do %>
-        <%= t("help.index.feedback") %>
+      <% if current_agency && current_agency.caseworker_feedback_form.present? %>
+        <%= link_to feedback_form_url, class: "usa-button margin-bottom-1 height-5 text-left display-block", target: "_blank" do %>
+          <%= t("help.index.feedback") %>
+        <% end %>
       <% end %>
-    <% end %>
 
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/app/views/help/index.html.erb
+++ b/app/app/views/help/index.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "help_content" do %>
+<%= turbo_frame_tag "help_modal_content" do %>
   <div class="padding-2">
     <h2 class="margin-top-0"><%= t("help.index.title") %></h2>
     <div class="usa-prose">

--- a/app/app/views/help/show.html.erb
+++ b/app/app/views/help/show.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "help_content" do %>
+<%= turbo_frame_tag "help_modal_content" do %>
   <div class="padding-3">
     <h2 class="margin-top-0">
       <%= t("help.show.#{@help_topic}.title") %>
@@ -10,7 +10,7 @@
       <%= link_to t("help.show.go_back"),
           help_path,
           class: "usa-link",
-          data: { turbo_frame: "help_content" } %>
+          data: { turbo_frame: "help_modal_content" } %>
     </div>
   </div>
 <% end %>

--- a/app/app/views/help/show.html.erb
+++ b/app/app/views/help/show.html.erb
@@ -1,11 +1,16 @@
-<div class="padding-3">
-  <h2 class="margin-top-0">
-    <%= t("help.show.#{@help_topic}.title") %>
-  </h2>
+<%= turbo_frame_tag "help_content" do %>
+  <div class="padding-3">
+    <h2 class="margin-top-0">
+      <%= t("help.show.#{@help_topic}.title") %>
+    </h2>
 
-  <%= render partial: "help_topic_content", locals: { topic: @help_topic } %>
+    <%= render partial: "help_topic_content", locals: { topic: @help_topic } %>
 
-  <div class="margin-top-3">
-    <%= link_to t("help.show.go_back"), help_path, class: "usa-link" %>
+    <div class="margin-top-3">
+      <%= link_to t("help.show.go_back"),
+          help_path,
+          class: "usa-link",
+          data: { turbo_frame: "help_content" } %>
+    </div>
   </div>
-</div>
+<% end %>


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2453](https://jiraent.cms.gov/browse/FFS-2453).


## Changes
- Swapped out the iframe with a turbo frame
- Removed the CSS for the now deprecated iframe
- Removed the JS functionality for refreshing the iframe URL

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
