### PR TITLE
FFS-2397-2: use remote_ip instead of ip

### DIFF
--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -7,7 +7,7 @@ class GenericEventTracker
       url_params = request.params.slice("client_agency_id", "locale")
       defaults = {
         # Not setting device_id because Mixpanel fixates on that as the distinct_id, which we do not want
-        ip: request.ip,
+        ip: request.remote_ip,
         cbv_flow_id: request.session[:cbv_flow_id],
         client_agency_id: url_params["client_agency_id"],
         locale: url_params["locale"],


### PR DESCRIPTION
## [FFS-2397](https://jiraent.cms.gov/browse/FFS-2397)

## Changes
In acceptance testing, we found that the user profile created did not ALWAYS match the location of the user creating the event. This is an experimental fix because I can't figure out how to test it locally... I need it to be running in demo so that request.ip and request.remote_ip resolve to something other than 127.0.0.1.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
