### PR TITLE
FFS-2466: Infer supported jobs from within Pinwheel subclass

### DIFF
--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -11,9 +11,8 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
     end
 
     if params["event"] == "account.added"
-      supported_jobs = get_supported_jobs(params["payload"]["platform_id"])
       PayrollAccount
-        .create_with(cbv_flow: @cbv_flow, supported_jobs: supported_jobs)
+        .create_with(cbv_flow: @cbv_flow)
         .find_or_create_by(pinwheel_account_id: params["payload"]["account_id"])
       track_account_created_event(@cbv_flow, params["payload"]["platform_name"])
     end
@@ -91,9 +90,5 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
 
   def set_pinwheel
     @pinwheel = @cbv_flow.present? ? pinwheel_for(@cbv_flow) : PinwheelService.new("sandbox", DUMMY_API_KEY)
-  end
-
-  def get_supported_jobs(platform_id)
-    @pinwheel.fetch_platform(platform_id: platform_id)["data"]["supported_jobs"]
   end
 end

--- a/app/app/models/payroll_account/pinwheel.rb
+++ b/app/app/models/payroll_account/pinwheel.rb
@@ -1,5 +1,5 @@
 class PayrollAccount::Pinwheel < PayrollAccount
-  after_create :lookup_supported_jobs
+  after_create :lookup_supported_jobs, if: ->(payroll_account) { payroll_account.supported_jobs.empty? }
 
   EVENTS_MAP = {
     "employment.added" => :employment_synced_at,

--- a/app/app/services/pinwheel_service.rb
+++ b/app/app/services/pinwheel_service.rb
@@ -141,6 +141,10 @@ class PinwheelService
     @http.get(build_url(ITEMS_ENDPOINT), options).body
   end
 
+  def fetch_account(account_id:)
+    json = @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}")).body
+  end
+
   def fetch_accounts(end_user_id:)
     @http.get(build_url("#{END_USERS}/#{end_user_id}/accounts")).body
   end

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
 
     before do
       stub_request_platform_response
+      stub_request_account_response
     end
 
     context "for an 'account.added' event" do

--- a/app/spec/support/fixtures/pinwheel/request_account_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_account_response.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "created_at": "2025-02-26T23:22:39.113479+00:00",
+    "link_token_id": "f1d64987-7149-418a-be34-defaf8a6f6d9",
+    "platform_id": "913170d1-393c-4f35-8c23-df3133ce7529",
+    "connected": true,
+    "monitoring_status": "active",
+    "end_user_id": "7ac7d1fd-f80a-4f9b-ad7d-2fb15f1cb86f",
+    "id": "b4437a5a-cd80-4522-be35-810acfa7e389",
+    "data_updated_at": {
+      "direct_deposit_allocations": "2025-02-26T23:22:45.286680+00:00",
+      "income": "2025-02-26T23:22:47.337140+00:00",
+      "employment": "2025-02-26T23:22:45.892272+00:00",
+      "identity": "2025-02-26T23:22:46.688357+00:00",
+      "shifts": "2025-02-26T23:22:53.734883+00:00",
+      "paystubs": "2025-02-26T23:22:43.607708+00:00"
+    },
+    "data_refreshed_at": {
+      "direct_deposit_allocations": "2025-02-26T23:22:45.286680+00:00",
+      "income": "2025-02-26T23:22:47.337140+00:00",
+      "employment": "2025-02-26T23:22:45.892272+00:00",
+      "identity": "2025-02-26T23:22:46.688357+00:00",
+      "shifts": "2025-02-26T23:22:53.734883+00:00",
+      "paystubs": "2025-02-26T23:22:43.607708+00:00"
+    }
+  }
+}

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -94,6 +94,15 @@ module PinwheelApiHelper
       )
   end
 
+  def stub_request_account_response
+    stub_request(:get, %r{#{PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}})
+      .to_return(
+        status: 200,
+        body: load_relative_json_file('request_account_response.json').to_json,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' }
+      )
+  end
+
   def request_employment_info_response_null_employment_status_bug
     stub_request(:get, %r{#{PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/employment})
       .to_return(


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Addresses [FFS-2466](https://jiraent.cms.gov/browse/FFS-2466).


## Changes
This makes the model infer the pinwheel accounts supported jobs through the provided pinwheel_account_id.

## Context for reviewers
We need to do this to make it easier to support multi-provider. The reason for this is that we want to create a payrol_acount earlier in the process, not when the webhook is received. In order to do that, we needed a tidier way to create payroll account objects. 

Before, we would look up the support jobs in the events controller and provide that to the model.

Now, we do that in an after_create hook. This means we can create payroll acounts anywhere without also needing to supply the supported jobs.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
