### PR TITLE
Revert "another attempt at fixing mixpanel profile location"

### DIFF
--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -7,7 +7,7 @@ class GenericEventTracker
       url_params = request.params.slice("client_agency_id", "locale")
       defaults = {
         # Not setting device_id because Mixpanel fixates on that as the distinct_id, which we do not want
-        ip: "0",
+        ip: request.remote_ip,
         cbv_flow_id: request.session[:cbv_flow_id],
         client_agency_id: url_params["client_agency_id"],
         locale: url_params["locale"],

--- a/app/lib/mixpanel_event_tracker.rb
+++ b/app/lib/mixpanel_event_tracker.rb
@@ -19,9 +19,9 @@ class MixpanelEventTracker
       flow_id = attributes.fetch(:cbv_flow_id, "")
 
       tracker_attrs =  { cbv_flow_id: flow_id }
-      # if request.present?
-        tracker_attrs.merge!({ "$ip": "0" })
-      # end
+      if request.present?
+        tracker_attrs.merge!({ "$ip": request.remote_ip })
+      end
 
       @tracker.people.set(distinct_id, tracker_attrs)
     end


### PR DESCRIPTION
I accidentally committed these changes directly to main. This reverts commit e2949b289c8efed7c9e4a7363f257b6023323cca.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
