### PR TITLE
Update bin/will-deploy script to handle "FFS-1234-2:" prefix

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -7,6 +7,22 @@
 # Cmd+Shift+F.
 set -euo pipefail
 
+linkify_jira() {
+  # Convert "FFS-1234:" (or just "1234:") into a Jira link
+  sed -E 's/(FFS-)?([0-9]{3,4})(-[0-9]*)?: (.*)/\4 \[[FFS-\2](https:\/\/jiraent.cms.gov\/browse\/FFS-\2)\]/g' |
+    # Convert "(#123)" into a Github PR link
+    sed -E 's|\(#([0-9]*)\)|([#\1](https://github.com/DSACMS/iv-cbv-payroll/pull/\1))|' /dev/stdin
+}
+
+# Run with --test to test the regular expressions above
+if [ ${1:-""} = "--test" ]; then
+  echo "1234: Foo bar baz" | linkify_jira
+  echo "FFS-1234: Foo bar baz" | linkify_jira
+  echo "FFS-1234-3: Foo bar baz" | linkify_jira
+  echo "FFS-1234-3: Foo bar baz (#123)" | linkify_jira
+  exit
+fi
+
 if [ -t 1 ]; then
   echo "Copy-paste this output into Slack (on macOS, pipe this script to 'pbcopy'):" >&2
   echo "=================================================================" >&2
@@ -14,12 +30,11 @@ else
   echo "Copying commit list... (use Cmd+Shift+F to apply formatting after pasting it into Slack)" >&2
 fi
 
-git fetch
+git fetch --quiet
 prod=$(curl --silent https://snap-income-pilot.com/health | jq -r .version)
 current_sha=$(git rev-parse origin/main)
 echo '🚀 Will deploy `'${current_sha:0:7}'` to production: 🚀 (cc @cbv-product-team)'
-git log --no-decorate --pretty="format:• *%s* - %an" ${prod}..${current_sha} | \
-  sed -E 's/(FFS-)?([0-9]{3,4}): (.*)/\3 \[[FFS-\2](https:\/\/jiraent.cms.gov\/browse\/FFS-\2)\]/g'
+git log --no-decorate --pretty="format:• *%s* - %an" ${prod}..${current_sha} | linkify_jira
 
 echo
 echo


### PR DESCRIPTION
Tim's been using prefixes like "FFS-1234-2:" to denote that it's his second PR addressing a certain ticket. Seems fine to me. Let's update the deploy script to linkify that syntax as well.

While here, it also makes the Github PR numbers, i.e. the "(#123)", a link to the PR on GH.

I added some tests to the script as well since those regular expressions are getting kind of bananas.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
