### PR TITLE
Display Pinwheel initialization error alert during employer search

### DIFF
--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -512,6 +512,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-22
   x86_64-darwin-23

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -1,6 +1,7 @@
 class Cbv::EmployerSearchesController < Cbv::BaseController
   # Disable CSP since Pinwheel relies on inline styles
   content_security_policy false, only: :show
+  before_action :check_pinwheel_initialization
   after_action :track_accessed_search_event, only: :show
   after_action :track_applicant_searched_event, only: :show
 
@@ -19,6 +20,14 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
   end
 
   private
+
+  def check_pinwheel_initialization
+    return unless Rails.env.development?
+
+    if Rails.application.config.pinwheel_initialization_error
+      flash.now[:alert] = "Unable to initialize Pinwheel: #{Rails.application.config.pinwheel_initialization_error}"
+    end
+  end
 
   def provider_search(query = "")
     ProviderSearchService.new(@cbv_flow.client_agency_id).search(query)

--- a/app/config/initializers/ngrok_development.rb
+++ b/app/config/initializers/ngrok_development.rb
@@ -1,4 +1,5 @@
 Rails.application.config.to_prepare do
+  Rails.application.config.pinwheel_initialization_error = nil
   # Only run this when running the Rails server in development
   if Rails.env.development? && defined?(::Rails::Server)
     begin
@@ -15,6 +16,8 @@ Rails.application.config.to_prepare do
     rescue => ex
       puts "🟥 Unable to configure Ngrok for development: #{ex}"
       puts ex.inspect
+
+      Rails.application.config.pinwheel_initialization_error = ex.message
     end
   end
 end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

n/a


## Changes
- Store Pinwheel initialization error during app config
- In dev only, display alert with initialization error during employer search
- Add `arm64-darwin-24` to Gemfile.lock platforms


## Context for reviewers
We have a limit of 10 webhooks with Pinwheel before it will error out and cause issues during employer search. There is a line in the logs, but this PR makes it more obvious to developers that there's an issue from the UI. 

My computer adds `arm64-darwin-24` during `bundle install`.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<img width="1074" alt="Screenshot 2025-03-07 at 3 55 56 PM" src="https://github.com/user-attachments/assets/8feebe05-3fb3-4b40-80c4-fc6a1619f4b9" />

### Ngrok [url](https://2196-2600-1700-5135-a000-a874-1f55-5353-642.ngrok-free.app/)
