### PR TITLE
Fix ThrottlingError when running migrations

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -144,7 +144,7 @@ while true; do
     echo "Timing out task ${ecs_task_id} waiting for logs"
     exit 1
   fi
-  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "${log_group}" --query "length(logStreams[?logStreamName==\`${log_stream}\`])")
+  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "${log_group}" --log-stream-name-prefix "${log_stream}" --query "length(logStreams)")
   if [ "${is_log_stream_created}" == "1" ]; then
     break
   fi


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - Bugfix to address issue I've seen while deploying a few times now.


## Changes
<!-- What was added, updated, or removed in this PR. -->
* Fix ThrottlingError when running migrations

I will upstream this after verifying it works in our repo. (I tested the AWS command locally and it seems to work well.)

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

We've been getting a ThrottlingError when running migrations a few times
(see [1], [2], [3]).

It's because the `--query` argument is evaluated client-side after
receiving the full list from the server, and therefore the
`describe-log-streams` call is paginating through all 174 pages of our
8300+ log streams just to select the single one we're looking for.
Github Actions' internet connection seems to be fast enough to hit the
[25 requests/second rate limit][4].

Let's use the `--log-stream-name-prefix` option instead to filter it
server-side. We can still use a (simpler) `--query` to count the
results client-side.

[1]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13775537056/job/38524000928
[2]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13730036473/job/38405238446
[3]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13727774147/job/38398210761
[4]: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
