### PR TITLE
Fix reviewer-lottery by granting it access to manage PRs

### DIFF
--- a/.github/workflows/pr-reviewer-lottery.yml
+++ b/.github/workflows/pr-reviewer-lottery.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - uses: uesteibar/reviewer-lottery@v3


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A

## Changes
<!-- What was added, updated, or removed in this PR. -->

* Fix reviewer-lottery by granting it access to manage PRs


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

I believe this may not work until it is merged to `main`. The issue is:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/4e68be87-88e7-4ec6-b15c-3f2dbf5420c5" />


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
