### PR TITLE
FFS-2585 Fix Expired Invitations crash

### DIFF
--- a/app/app/controllers/cbv/expired_invitations_controller.rb
+++ b/app/app/controllers/cbv/expired_invitations_controller.rb
@@ -1,5 +1,5 @@
 class Cbv::ExpiredInvitationsController < Cbv::BaseController
-  skip_before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete
+  skip_before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete, :capture_page_view
   helper_method :current_agency
 
   def show


### PR DESCRIPTION
## Ticket

Resolves [FFS-2585](https://jiraent.cms.gov/browse/FFS-2585).

## Background
This bug likely affects production, and the user would get the wrong error page.

![image](https://github.com/user-attachments/assets/c8ffc4de-cc96-4ed1-a67e-ac41a396667b)

When I attempt to access a CBV flow at an expired token, I see this crash page. http://localhost:3000/en/cbv/entry?token={token} 

The CBV Entry page was calling :set_cbv_flow (via BaseController's before_action methods) and redirecting to the expired_invitations_controller.  The problem is that expired_invitations_controller was then calling capture_page_view but it doesn't have a cbv_flow to log there and it crashes.

## Changes
* Skip :capture_page_view in the expired_invitations_controller to prevent crash

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
