### PR TITLE
FFS-2615: Form validation errors not applied to individual fields in CBV flow invitation form

### DIFF
--- a/app/app/views/caseworker/cbv_flow_invitations/_ma.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/_ma.html.erb
@@ -1,10 +1,32 @@
 <% cbv_applicant = @cbv_flow_invitation.cbv_applicant || @cbv_flow_invitation.build_cbv_applicant(snap_application_date: Date.today) %>
 <%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
-  <%= f2.text_field :first_name, label: t(".invite.first_name") %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>">
+    <legend class="usa-legend"><%= t(".invite.first_name") %></legend>
+    <%= f.field_error :'cbv_applicant.first_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_first_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][first_name]"
+      type="text"
+      autocomplete="given-name"
+      value="<%= cbv_applicant.first_name %>"
+    >
+  </div>
 
   <%= f2.text_field :middle_name, label: t(".invite.middle_name") %>
 
-  <%= f2.text_field :last_name, label: t(".invite.last_name") %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>">
+    <legend class="usa-legend"><%= t(".invite.last_name") %></legend>
+    <%= f.field_error :'cbv_applicant.last_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_last_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][last_name]"
+      type="text"
+      autocomplete="family-name"
+      value="<%= cbv_applicant.last_name %>"
+    >
+  </div>
 
   <%= f2.text_field :agency_id_number, label: t(".invite.agency_id_number"), hint: "Format: 1234567" %>
 

--- a/app/app/views/caseworker/cbv_flow_invitations/_nyc.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/_nyc.html.erb
@@ -1,10 +1,32 @@
 <% cbv_applicant = @cbv_flow_invitation.cbv_applicant || @cbv_flow_invitation.build_cbv_applicant %>
 <%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
-  <%= f2.text_field :first_name, label: t(".invite.first_name") %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>">
+    <legend class="usa-legend"><%= t(".invite.first_name") %></legend>
+    <%= f.field_error :'cbv_applicant.first_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_first_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][first_name]"
+      type="text"
+      autocomplete="given-name"
+      value="<%= cbv_applicant.first_name %>"
+    >
+  </div>
 
   <%= f2.text_field :middle_name, label: t(".invite.middle_name") %>
 
-  <%= f2.text_field :last_name, label: t(".invite.last_name") %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>">
+    <legend class="usa-legend"><%= t(".invite.last_name") %></legend>
+    <%= f.field_error :'cbv_applicant.last_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_last_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][last_name]"
+      type="text"
+      autocomplete="family-name"
+      value="<%= cbv_applicant.last_name %>"
+    >
+  </div>
 
   <%= f2.text_field :client_id_number, label: t(".invite.client_id_number"), hint: "Format: AB12345C" %>
 

--- a/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
@@ -1,11 +1,17 @@
 <% cbv_applicant = @cbv_flow_invitation.cbv_applicant ||
      @cbv_flow_invitation.build_cbv_applicant(client_agency_id: @cbv_flow_invitation.client_agency_id) %>
 <%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
-  <%= f2.text_field :first_name, label: t(".invite.first_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present?) %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>">
+    <%= f2.text_field :first_name, label: t(".invite.first_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present?) %>
+    <%= f.field_error :'cbv_applicant.first_name' %>
+  </div>
 
   <%= f2.text_field :middle_name, label: t(".invite.middle_name") %>
 
-  <%= f2.text_field :last_name, label: t(".invite.last_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present?) %>
+  <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>">
+    <%= f2.text_field :last_name, label: t(".invite.last_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present?) %>
+    <%= f.field_error :'cbv_applicant.last_name' %>
+  </div>
 
   <%= f2.text_field :case_number, label: t(".invite.case_number") %>
 

--- a/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
@@ -1,11 +1,11 @@
 <% cbv_applicant = @cbv_flow_invitation.cbv_applicant ||
      @cbv_flow_invitation.build_cbv_applicant(client_agency_id: @cbv_flow_invitation.client_agency_id) %>
 <%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
-  <%= f2.text_field :first_name, label: t(".invite.first_name") %>
+  <%= f2.text_field :first_name, label: t(".invite.first_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present?) %>
 
   <%= f2.text_field :middle_name, label: t(".invite.middle_name") %>
 
-  <%= f2.text_field :last_name, label: t(".invite.last_name") %>
+  <%= f2.text_field :last_name, label: t(".invite.last_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present?) %>
 
   <%= f2.text_field :case_number, label: t(".invite.case_number") %>
 

--- a/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/_sandbox.html.erb
@@ -2,15 +2,31 @@
      @cbv_flow_invitation.build_cbv_applicant(client_agency_id: @cbv_flow_invitation.client_agency_id) %>
 <%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
   <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>">
-    <%= f2.text_field :first_name, label: t(".invite.first_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present?) %>
+    <legend class="usa-legend"><%= t(".invite.first_name") %></legend>
     <%= f.field_error :'cbv_applicant.first_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.first_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_first_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][first_name]"
+      type="text"
+      autocomplete="given-name"
+      value="<%= cbv_applicant.first_name %>"
+    >
   </div>
 
   <%= f2.text_field :middle_name, label: t(".invite.middle_name") %>
 
   <div class="usa-form-group <%= "usa-form-group--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>">
-    <%= f2.text_field :last_name, label: t(".invite.last_name"), class: ("usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present?) %>
+    <legend class="usa-legend"><%= t(".invite.last_name") %></legend>
     <%= f.field_error :'cbv_applicant.last_name' %>
+    <input
+      class="usa-input <%= "usa-input--error" if @cbv_flow_invitation.errors[:'cbv_applicant.last_name'].present? %>"
+      id="<%= f.object_name %>_cbv_applicant_attributes_last_name"
+      name="<%= f.object_name %>[cbv_applicant_attributes][last_name]"
+      type="text"
+      autocomplete="family-name"
+      value="<%= cbv_applicant.last_name %>"
+    >
   </div>
 
   <%= f2.text_field :case_number, label: t(".invite.case_number") %>


### PR DESCRIPTION
## Ticket

Resolves [FFS-2615](https://jiraent.cms.gov/browse/FFS-2615).


## Changes
Validation on the First Name and Last Name fields is back!

## Context for reviewers
Fixed form validation errors for name fields. Used the same pattern as the radio buttons with `<input>`. 

Considered adding a helper to our USWDS UswdsFormBuilder that could handle nested errors, but it got overly complicated and specific to solve this problem. This solution was more work in the view, but followed current conventions and was less of a 'surprise' to just keep the logic with our forms.

This regressed when we needed to display errors for nested fields, which broke the standard error display pattern. For nested error handling in our forms, we need to manually implement the error display.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
  ### Behold, validation errors
<img width="583" alt="Screenshot 2025-03-28 at 3 24 58 PM" src="https://github.com/user-attachments/assets/a1226638-3bd4-4fde-80c8-51294a787a44" />

