### PR TITLE
FFS-2546: Allow Argyle JS to support "production" environment

### DIFF
--- a/app/app/controllers/api/argyle_controller.rb
+++ b/app/app/controllers/api/argyle_controller.rb
@@ -3,7 +3,7 @@ class Api::ArgyleController < ApplicationController
     @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
     argyle = argyle_for(@cbv_flow)
     user = argyle.create_user
-    is_sandbox_environment = ENV["ARGYLE_SANDBOX"].present? && ENV["ARGYLE_SANDBOX"] == "true"
+    is_sandbox_environment = ENV["ARGYLE_SANDBOX"] == "true"
 
     render json: { status: :ok, user: user, isSandbox: is_sandbox_environment }
   end

--- a/app/app/controllers/api/argyle_controller.rb
+++ b/app/app/controllers/api/argyle_controller.rb
@@ -3,7 +3,8 @@ class Api::ArgyleController < ApplicationController
     @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
     argyle = argyle_for(@cbv_flow)
     user = argyle.create_user
+    is_sandbox_environment = ENV["ARGYLE_SANDBOX"].present? && ENV["ARGYLE_SANDBOX"] == "true"
 
-    render json: { status: :ok, user: user }
+    render json: { status: :ok, user: user, isSandbox: is_sandbox_environment }
   end
 end

--- a/app/app/controllers/api/argyle_controller.rb
+++ b/app/app/controllers/api/argyle_controller.rb
@@ -3,7 +3,7 @@ class Api::ArgyleController < ApplicationController
     @cbv_flow = CbvFlow.find(session[:cbv_flow_id])
     argyle = argyle_for(@cbv_flow)
     user = argyle.create_user
-    is_sandbox_environment = ENV["ARGYLE_SANDBOX"] == "true"
+    is_sandbox_environment = agency_config[@cbv_flow.client_agency_id].argyle_environment == "sandbox"
 
     render json: { status: :ok, user: user, isSandbox: is_sandbox_environment }
   end

--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -18,7 +18,7 @@ export default class ArgyleModalAdapter extends ModalAdapter {
         locale,
       })
 
-      const { user } = await fetchArgyleToken()
+      const { user, isSandbox } = await fetchArgyleToken()
       return Argyle.create({
         userToken: user.user_token,
         items: [this.requestData.id],
@@ -35,7 +35,7 @@ export default class ArgyleModalAdapter extends ModalAdapter {
         },
         onClose: this.onClose.bind(this),
         onError: this.onError.bind(this),
-        sandbox: true,
+        sandbox: isSandbox,
       }).open()
     } else {
       // TODO this should throw an error, which should be caught by a document.onerror handler to show the user a crash message.

--- a/app/spec/controllers/api/argyle_controller_spec.rb
+++ b/app/spec/controllers/api/argyle_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Api::ArgyleController, type: :controller do
+  describe "POST #create" do
+    it "includes isSandbox flag in response" do
+      allow(ENV).to receive(:[]).and_return(nil)
+      allow(ENV).to receive(:[]).with("ARGYLE_SANDBOX").and_return("true")
+      allow(CbvFlow).to receive(:find).and_return(double)
+      allow(controller).to receive(:argyle_for).and_return(double(create_user: {}))
+
+      post :create
+
+      expect(JSON.parse(response.body)["isSandbox"]).to eq(true)
+    end
+  end
+end

--- a/app/spec/controllers/api/argyle_controller_spec.rb
+++ b/app/spec/controllers/api/argyle_controller_spec.rb
@@ -3,10 +3,14 @@ require 'rails_helper'
 RSpec.describe Api::ArgyleController, type: :controller do
   describe "POST #create" do
     it "includes isSandbox flag in response" do
-      allow(ENV).to receive(:[]).and_return(nil)
-      allow(ENV).to receive(:[]).with("ARGYLE_SANDBOX").and_return("true")
-      allow(CbvFlow).to receive(:find).and_return(double)
-      allow(controller).to receive(:argyle_for).and_return(double(create_user: {}))
+      cbv_flow = double('cbv_flow', client_agency_id: 'test_agency')
+      argyle = double('argyle', create_user: {})
+
+      allow(CbvFlow).to receive(:find).and_return(cbv_flow)
+      allow(controller).to receive(:argyle_for).and_return(argyle)
+      allow(controller).to receive(:agency_config).and_return({
+        'test_agency' => double(argyle_environment: 'sandbox')
+      })
 
       post :create
 

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -43,6 +43,13 @@ describe("ArgyleModalAdapter", () => {
     it("opens argyle modal", async () => {
       expect(Argyle.create).toHaveBeenCalledTimes(1)
     })
+    it("passes sandbox flag from token response", async () => {
+      expect(Argyle.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sandbox: mockArgyleAuthToken.isSandbox,
+        })
+      )
+    })
   })
 
   describe("event:onSucces", () => {

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -49,6 +49,7 @@ describe("ArgyleModalAdapter", () => {
           sandbox: mockArgyleAuthToken.isSandbox,
         })
       )
+      expect(mockArgyleAuthToken.isSandbox).toBe(true)
     })
   })
 

--- a/app/spec/javascript/fixtures/argyle.fixture.js
+++ b/app/spec/javascript/fixtures/argyle.fixture.js
@@ -1,7 +1,7 @@
 import { vi, describe, beforeEach, it, expect } from "vitest"
 import loadScript from "load-script"
 
-export const mockArgyleAuthToken = { user: { user_token: "test-token" } }
+export const mockArgyleAuthToken = { user: { user_token: "test-token" }, isSandbox: true }
 export const mockArgyleAccountData = { accountId: "account-id", platformId: "platform-id" }
 
 const triggers = ({


### PR DESCRIPTION
## Ticket

Resolves [FFS-2545](https://jiraent.cms.gov/browse/FFS-2545).


## Changes
- Argyle controller sets the `isSandbox` flag based on the environment set in `client_agency_config.rb`
- `ArgyleModalAdapter` can receive and handle environment via token endpoint request


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
