### PR TITLE
FFS-2540-4: corrected sending some attributes to the event logger

### DIFF
--- a/app/app/controllers/api/pinwheel_controller.rb
+++ b/app/app/controllers/api/pinwheel_controller.rb
@@ -26,6 +26,7 @@ class Api::PinwheelController < ApplicationController
     event_logger.track("ApplicantBeganLinkingEmployer", request, {
       cbv_flow_id: @cbv_flow.id,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+      client_agency_id: @cbv_flow.client_agency_id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       response_type: token_params[:response_type]
     })

--- a/app/app/controllers/api/user_events_controller.rb
+++ b/app/app/controllers/api/user_events_controller.rb
@@ -53,6 +53,7 @@ class Api::UserEventsController < ApplicationController
       base_attributes.merge!({
         cbv_flow_id: @cbv_flow.id,
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+        client_agency_id: @cbv_flow.client_agency_id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id
       })
     end

--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -64,12 +64,14 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
       event_logger.track("ApplicantClickedEditInformationLink", request, {
         timestamp: Time.now.to_i,
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+        client_agency_id: current_agency&.id,
         cbv_flow_id: @cbv_flow.id
       })
     else
       event_logger.track("ApplicantAccessedInformationPage", request, {
         timestamp: Time.now.to_i,
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+        client_agency_id: current_agency&.id,
         cbv_flow_id: @cbv_flow.id
       })
     end
@@ -82,6 +84,7 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       error_string: error_string
     })
   rescue => ex

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -108,7 +108,8 @@ class Cbv::BaseController < ApplicationController
 
   def track_timeout_event
     event_logger.track("ApplicantTimedOut", request, {
-      timestamp: Time.now.to_i
+      timestamp: Time.now.to_i,
+      client_agency_id: current_agency&.id
     })
   rescue => ex
     Rails.logger.error "Unable to track NewRelic event (ApplicantTimedOut): #{ex}"
@@ -118,6 +119,7 @@ class Cbv::BaseController < ApplicationController
     event_logger.track("ApplicantLinkExpired", request, {
       invitation_id: invitation.id,
       cbv_applicant_id: invitation.cbv_applicant_id,
+      client_agency_id: current_agency&.id,
       timestamp: Time.now.to_i
     })
   rescue => ex
@@ -130,7 +132,7 @@ class Cbv::BaseController < ApplicationController
       invitation_id: invitation.id,
       cbv_flow_id: cbv_flow.id,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
-      client_agency_id: cbv_flow.client_agency_id,
+      client_agency_id: current_agency&.id,
       seconds_since_invitation: (Time.now - invitation.created_at).to_i
     })
   rescue => ex

--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -42,6 +42,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
@@ -53,6 +54,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
@@ -66,6 +68,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex
@@ -79,6 +82,7 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       num_results: @employers.length,
       has_payroll_account: @has_payroll_account,

--- a/app/app/controllers/cbv/entries_controller.rb
+++ b/app/app/controllers/cbv/entries_controller.rb
@@ -2,7 +2,7 @@ class Cbv::EntriesController < Cbv::BaseController
   def show
     event_logger.track("ApplicantViewedAgreement", request, {
       timestamp: Time.now.to_i,
-      client_agency_id: @cbv_flow.client_agency_id,
+      client_agency_id: current_agency&.id,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
@@ -13,7 +13,7 @@ class Cbv::EntriesController < Cbv::BaseController
     if params["agreement"] == "1"
       event_logger.track("ApplicantAgreed", request, {
         timestamp: Time.now.to_i,
-        client_agency_id: @cbv_flow.client_agency_id,
+        client_agency_id: current_agency&.id,
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
         cbv_flow_id: @cbv_flow.id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id

--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -9,6 +9,7 @@ class Cbv::MissingResultsController < Cbv::BaseController
     event_logger.track("ApplicantAccessedMissingResultsPage", request, {
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+      client_agency_id: current_agency&.id,
       cbv_flow_id: @cbv_flow.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
     })

--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -119,6 +119,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     event_logger.track("ApplicantViewedPaymentDetails", request, {
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       pinwheel_account_id: @pinwheel_account.id,
       payments_length: @payroll_account_report.paystubs.length,
@@ -136,6 +137,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
     event_logger.track("ApplicantSavedPaymentDetails", request, {
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
       additional_information_length: comment_data ? comment_data["comment"].length : 0
     })

--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -21,7 +21,7 @@ class Cbv::SubmitsController < Cbv::BaseController
       format.pdf do
         event_logger.track("ApplicantDownloadedIncomePDF", request, {
           timestamp: Time.now.to_i,
-          client_agency_id: @cbv_flow.client_agency_id,
+          client_agency_id: current_agency&.id,
           cbv_applicant_id: @cbv_flow.cbv_applicant_id,
           cbv_flow_id: @cbv_flow.id,
           invitation_id: @cbv_flow.cbv_flow_invitation_id,
@@ -195,7 +195,7 @@ class Cbv::SubmitsController < Cbv::BaseController
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },
       flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
-      language: I18n.locale
+      locale: I18n.locale
     })
   rescue => ex
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
@@ -230,12 +230,12 @@ class Cbv::SubmitsController < Cbv::BaseController
   def track_accessed_submit_event(cbv_flow)
     event_logger.track("ApplicantAccessedSubmitPage", request, {
       timestamp: Time.now.to_i,
-      client_agency_id: cbv_flow.client_agency_id,
+      client_agency_id: current_agency&.id,
       cbv_flow_id: cbv_flow.id,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,
       flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
-      language: I18n.locale
+      locale: I18n.locale
     })
   rescue => ex
     Rails.logger.error "Unable to track event (ApplicantAccessedIncomeSummary): #{ex}"

--- a/app/app/controllers/cbv/successes_controller.rb
+++ b/app/app/controllers/cbv/successes_controller.rb
@@ -10,6 +10,7 @@ class Cbv::SuccessesController < Cbv::BaseController
       timestamp: Time.now.to_i,
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
     })
   rescue => ex

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -10,7 +10,7 @@ class Cbv::SummariesController < Cbv::BaseController
   def track_accessed_income_summary_event(cbv_flow, payments)
     event_logger.track("ApplicantAccessedIncomeSummary", request, {
       timestamp: Time.now.to_i,
-      client_agency_id: cbv_flow.client_agency_id,
+      client_agency_id: current_agency&.id,
       cbv_flow_id: cbv_flow.id,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,

--- a/app/app/controllers/help_controller.rb
+++ b/app/app/controllers/help_controller.rb
@@ -21,7 +21,7 @@ class HelpController < ApplicationController
         invitation_id: cbv_flow&.cbv_flow_invitation_id,
         client_agency_id: current_agency&.id,
         flow_started_seconds_ago: cbv_flow ? (Time.now - cbv_flow.created_at).to_i : nil,
-        language: I18n.locale
+        locale: I18n.locale
       })
     rescue => ex
       Rails.logger.error "Unable to track event (ApplicantViewedHelpTopic): #{ex}"

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -54,6 +54,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
       event_logger.track("ApplicantCreatedPinwheelAccount", request, {
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
         cbv_flow_id: @cbv_flow.id,
+        client_agency_id: @cbv_flow.client_agency_id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id,
         platform_name: params["payload"]["platform_name"]
       })
@@ -61,6 +62,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
       event_logger.track("ApplicantFinishedPinwheelSync", request, {
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
         cbv_flow_id: @cbv_flow.id,
+        client_agency_id: @cbv_flow.client_agency_id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id,
         identity_success: @payroll_account.job_succeeded?("identity"),
         identity_supported: @payroll_account.supported_jobs.include?("identity"),

--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -5,6 +5,7 @@ class GenericEventTracker
     defaults = {}
     if request.present?
       url_params = request.params.slice("client_agency_id", "locale")
+
       defaults = {
         # Not setting device_id because Mixpanel fixates on that as the distinct_id, which we do not want
         ip: request.remote_ip,

--- a/app/spec/controllers/help_controller_spec.rb
+++ b/app/spec/controllers/help_controller_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe HelpController, type: :controller do
             device_name: nil,
             device_type: nil,
             ip: "0.0.0.0",
-            language: I18n.locale,
-            locale: nil,
+            locale: I18n.locale,
             client_agency_id: cbv_flow.client_agency_id,
             topic: "employer",
             user_agent: "Rails Testing"
@@ -43,8 +42,7 @@ RSpec.describe HelpController, type: :controller do
             device_name: nil,
             device_type: nil,
             ip: "0.0.0.0",
-            language: I18n.locale,
-            locale: nil,
+            locale: I18n.locale,
             client_agency_id: cbv_flow.client_agency_id,
             topic: "employer",
             user_agent: "Rails Testing"
@@ -72,8 +70,7 @@ RSpec.describe HelpController, type: :controller do
             device_name: nil,
             device_type: nil,
             ip: "0.0.0.0",
-            language: I18n.locale,
-            locale: nil,
+            locale: I18n.locale,
             client_agency_id: "sandbox",
             topic: "employer",
             user_agent: "Rails Testing"


### PR DESCRIPTION
## [FFS-2540-4](https://jiraent.cms.gov/browse/FFS-2540)

## Changes
Corrected an issue Eryn noticed during acceptance testing: not all new events were properly getting the client_agency_id or locale attributes set. I fixed this for the new events and re-tested many of the existing ones.

There are a few events directly from pinwheel that still don't get these 100% correctly, but I think that's acceptable since so many other events do; it will be easy to determine what the values for these attributes likely were if they're missing, since they'll be on a user with many other events with these attributes set correctly.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
