### PR TITLE
FFS-2607: Add `employment_type` field to ResponseObjects::Employment

### DIFF
--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -158,6 +158,9 @@ class Webhooks::Argyle::EventsController < ApplicationController
         employment_employer_phone_number_present: report.employments.first&.employer_name&.present?,
         employment_start_date: report.employments.first&.start_date,
         employment_termination_date: report.employments.first&.termination_date,
+        employment_type: report.employments.first&.employment_type&.to_s,
+        employment_type_w2_count: report.employments.count { |e| e.employment_type == :w2 },
+        employment_type_gig_count: report.employments.count { |e| e.employment_type == :gig },
 
         # Gigs fields
         gigs_success: payroll_account.job_succeeded?("gigs"),

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -122,7 +122,10 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         employment_employer_address_present: report.employments.first&.employer_address&.present?,
         employment_employer_phone_number_present: report.employments.first&.employer_name&.present?,
         employment_start_date: report.employments.first&.start_date,
-        employment_termination_date: report.employments.first&.termination_date
+        employment_termination_date: report.employments.first&.termination_date,
+        employment_type: report.employments.first&.employment_type&.to_s,
+        employment_type_w2_count: report.employments.count { |e| e.employment_type == :w2 },
+        employment_type_gig_count: report.employments.count { |e| e.employment_type == :gig }
 
         # TODO: Add fields from /shifts after FFS-2550.
       })

--- a/app/app/services/aggregators/format_methods/argyle.rb
+++ b/app/app/services/aggregators/format_methods/argyle.rb
@@ -48,4 +48,12 @@ module Aggregators::FormatMethods::Argyle
     return unless seconds
     (seconds / 3600.0).round(2)
   end
+
+  def self.employment_type(employment_type)
+    if employment_type == "contractor"
+      :gig
+    else
+      :w2
+    end
+  end
 end

--- a/app/app/services/aggregators/format_methods/pinwheel.rb
+++ b/app/app/services/aggregators/format_methods/pinwheel.rb
@@ -1,4 +1,19 @@
 module Aggregators::FormatMethods::Pinwheel
+  # See on Google Drive:
+  # "Pinwheel Payroll Providers (Sandbox/Production) 2024-07-02"
+  # "Mapping in Code" sheet
+  #
+  # We have to do this by matching employer_name because there is no employer
+  # ID in any of the pinwheel endpoints.
+  GIG_PLATFORM_NAMES = [
+    "Airbnb (Host)", "Amazon Flex", "Bite Squad", "Care.com", "DoorDash (Dasher)",
+    "Ebay (Seller)", "Etsy", "Field Agent", "GrubHub (Driver)", "Handy",
+    "Instacart (Full Service Shopper)", "Lyft (Driver)", "OnlyFans",
+    "Patreon (Freelancer)", "Poshmark (Seller)", "Postmates (Fleet)",
+    "Roadie", "Shipt (Shopper)", "Shopify Store", "Thumbtack, Inc.",
+    "Twitch", "Uber (Driver)", "Via (Driver)", "Wonolo"
+  ]
+
   def self.hours(earnings)
     base_hours = earnings
       .filter { |e| e["category"] != "overtime" }
@@ -24,5 +39,13 @@ module Aggregators::FormatMethods::Pinwheel
       .filter { |e| e["hours"] && e["hours"] > 0 }
       .group_by { |e| e["category"] }
       .transform_values { |earnings| earnings.sum { |e| e["hours"] } }
+  end
+
+  def self.employment_type(employer_name)
+    if GIG_PLATFORM_NAMES.include?(employer_name)
+      :gig
+    else
+      :w2
+    end
   end
 end

--- a/app/app/services/aggregators/response_objects/employment.rb
+++ b/app/app/services/aggregators/response_objects/employment.rb
@@ -1,14 +1,15 @@
-EMPLOYMENT_FIELDS = %i[
-  account_id
-  employer_name
-  start_date
-  termination_date
-  status
-  employer_phone_number
-  employer_address
-]
-
 module Aggregators::ResponseObjects
+  EMPLOYMENT_FIELDS = %i[
+    account_id
+    employer_name
+    start_date
+    termination_date
+    status
+    employer_phone_number
+    employer_address
+    employment_type
+  ]
+
   Employment = Struct.new(*EMPLOYMENT_FIELDS, keyword_init: true) do
     def self.from_pinwheel(response_body)
       new(
@@ -18,7 +19,8 @@ module Aggregators::ResponseObjects
         termination_date: response_body["termination_date"],
         status: response_body["status"],
         employer_phone_number: response_body.dig("employer_phone_number", "value"),
-        employer_address: response_body.dig("employer_address", "raw")
+        employer_address: response_body.dig("employer_address", "raw"),
+        employment_type: Aggregators::FormatMethods::Pinwheel.employment_type(response_body["id"])
       )
     end
 
@@ -29,7 +31,8 @@ module Aggregators::ResponseObjects
         start_date: identity_response_body["hire_date"],
         termination_date: identity_response_body["termination_date"],
         status: Aggregators::FormatMethods::Argyle.format_employment_status(identity_response_body["employment_status"]),
-        employer_address: Aggregators::FormatMethods::Argyle.format_employer_address(a_paystub_response_body)
+        employer_address: Aggregators::FormatMethods::Argyle.format_employer_address(a_paystub_response_body),
+        employment_type: Aggregators::FormatMethods::Argyle.employment_type(identity_response_body["employment_type"])
       )
     end
   end

--- a/app/app/services/aggregators/sdk/argyle_service.rb
+++ b/app/app/services/aggregators/sdk/argyle_service.rb
@@ -168,7 +168,7 @@ module Aggregators::Sdk
       @http.get(GIGS_ENDPOINT, params).body
     end
 
-    # https://docs.argyle.com/api-reference/gigs#list
+    # https://docs.argyle.com/api-reference/shifts#list
     def fetch_shifts_api(**params)
       @http.get(SHIFTS_ENDPOINT, params).body
     end

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
         allow_any_instance_of(Aggregators::Sdk::ArgyleService)
           .to receive(:fetch_paystubs_api)
           .and_return(argyle_load_relative_json_file("sarah", "request_paystubs.json"))
+        allow_any_instance_of(Aggregators::Sdk::ArgyleService)
+          .to receive(:fetch_gigs_api)
+          .and_return(argyle_load_relative_json_file("bob", "request_gigs.json"))
         allow(controller).to receive(:event_logger).and_return(fake_event_logger)
         allow(fake_event_logger).to receive(:track)
       end
@@ -190,11 +193,14 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
             employment_success: true,
             employment_supported: true,
             employment_status: "employed",
+            employment_type: "w2",
             employment_employer_name: "Whole Foods",
             employment_employer_address_present: true,
             employment_employer_phone_number_present: true,
             employment_start_date: "2022-08-08",
             employment_termination_date: nil,
+            employment_type_w2_count: 1,
+            employment_type_gig_count: 0,
 
             # Gigs fields
             gigs_success: true,

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -170,12 +170,15 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               # Employment fields
               employment_success: true,
               employment_supported: true,
+              employment_type: "w2",
               employment_status: "employed",
               employment_employer_name: "Acme Corporation",
               employment_employer_address_present: true,
               employment_employer_phone_number_present: true,
               employment_start_date: "2010-01-01",
-              employment_termination_date: nil
+              employment_termination_date: nil,
+              employment_type_w2_count: 1,
+              employment_type_gig_count: 0
             )
           end
 

--- a/app/spec/services/aggregators/format_methods/argyle_spec.rb
+++ b/app/spec/services/aggregators/format_methods/argyle_spec.rb
@@ -97,4 +97,24 @@ RSpec.describe Aggregators::FormatMethods::Argyle, type: :service do
       expect(described_class.format_employer_address(a_paystub_json)).to eq("123 Main St, Unit 2, Anytown, NY 12345")
     end
   end
+
+  describe ".employment_type" do
+    context "when employment_type is 'contractor'" do
+      let(:employment_type) { "contractor" }
+
+      it "returns :gig" do
+        expect(described_class.employment_type(employment_type))
+          .to eq(:gig)
+      end
+    end
+
+    context "when employment_type is not 'contractor'" do
+      let(:employment_type) { "full-time" }
+
+      it "returns :w2" do
+        expect(described_class.employment_type(employment_type))
+          .to eq(:w2)
+      end
+    end
+  end
 end

--- a/app/spec/services/aggregators/format_methods/pinwheel_spec.rb
+++ b/app/spec/services/aggregators/format_methods/pinwheel_spec.rb
@@ -63,4 +63,24 @@ RSpec.describe Aggregators::FormatMethods::Pinwheel do
       expect(described_class.hours_by_earning_category(earnings)).to eq({})
     end
   end
+
+  describe ".employment_type" do
+    context "for a gig platform (Uber)" do
+      let(:employer_name) { "Uber (Driver)" }
+
+      it "returns :gig" do
+        expect(described_class.employment_type(employer_name))
+          .to eq(:gig)
+      end
+    end
+
+    context "for a non-gig platform (Walmart)" do
+      let(:employer_name) { "Walmart" }
+
+      it "returns :w2" do
+        expect(described_class.employment_type(employer_name))
+          .to eq(:w2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2607](https://jiraent.cms.gov/browse/FFS-2607).


## Changes
<!-- What was added, updated, or removed in this PR. -->

* **Add `employment_type` field to ResponseObjects::Employment**


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This field, whose value is currently only `:w2` or `:gig`, is determined
by our own logic so we can use it in future stories (FFS-2542):
* For Pinwheel, we use a list of employer names from Pinwheel's support
  team. We have to match the name because the /employments endpoint
  doesn't have any ID to associate that employment with the employer
  that was linked.
* For Argyle, we can just look at whether they classify the user as a
  "contractor".


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
