### PR TITLE
FFS-2723: Updated strategy for aggregator string tokenization

### DIFF
--- a/app/app/components/pinwheel_data_point_component.rb
+++ b/app/app/components/pinwheel_data_point_component.rb
@@ -16,7 +16,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def pay_period_with_frequency(start_date, end_date, pay_frequency)
-    translated_pay_frequency = translate_pinwheel_value("payment_frequencies", pay_frequency)
+    translated_pay_frequency = translate_aggregator_value("payment_frequencies", pay_frequency)
     {
       label: I18n.t("cbv.submits.show.pdf.caseworker.pay_period", pay_frequency: translated_pay_frequency),
       value: I18n.t("cbv.payment_details.show.pay_period_value", start_date: format_date(start_date), end_date: format_date(end_date))
@@ -45,7 +45,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def earnings_entry(category, hours)
-    translated_category_name = translate_pinwheel_value("earnings_category", category)
+    translated_category_name = translate_aggregator_value("earnings_category", category)
 
     {
       label: I18n.t("cbv.payment_details.show.hours_paid", category: translated_category_name),
@@ -54,7 +54,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def deduction(category, amount)
-    translated_deduction_category = translate_pinwheel_value("deductions", category)
+    translated_deduction_category = translate_aggregator_value("deductions", category)
     {
       label: I18n.t("cbv.payment_details.show.deductions", category: translated_deduction_category&.humanize),
       value: format_money(amount)
@@ -83,7 +83,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def employment_status(status)
-    translated_status = translate_pinwheel_value("employment_statuses", status)
+    translated_status = translate_aggregator_value("employment_statuses", status)
     {
       label: I18n.t("cbv.payment_details.show.employment_status"),
       value: translated_status&.humanize
@@ -91,7 +91,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def pay_frequency(frequency)
-    translated_pay_frequency = translate_pinwheel_value("payment_frequencies", frequency)
+    translated_pay_frequency = translate_aggregator_value("payment_frequencies", frequency)
     {
       label: I18n.t("cbv.payment_details.show.pay_frequency"),
       value: translated_pay_frequency
@@ -99,7 +99,7 @@ class PinwheelDataPointComponent < ViewComponent::Base
   end
 
   def hourly_rate(amount, unit)
-    translated_unit = translate_pinwheel_value("payment_frequencies", unit)
+    translated_unit = translate_aggregator_value("payment_frequencies", unit)
     {
       label: I18n.t("cbv.payment_details.show.hourly_rate"),
       value: "#{format_money(amount)} #{translated_unit}"

--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -39,8 +39,6 @@ module ViewHelper
   def translate_aggregator_value(namespace, value)
     i18n_key = "aggregator_strings.#{namespace}.#{value}"
 
-    Rails.logger.info("TIMOTEST translate_aggregator_value: #{i18n_key}")
-
     # convert the key to snake_case, replacing hyphens with underscores
     i18n_key = i18n_key.gsub("-", "_").downcase
 

--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -36,8 +36,10 @@ module ViewHelper
     number_to_currency(dollars_in_cents.to_f / 100)
   end
 
-  def translate_pinwheel_value(namespace, value)
-    i18n_key = "pinwheel.#{namespace}.#{value}"
+  def translate_aggregator_value(namespace, value)
+    i18n_key = "aggregator_strings.#{namespace}.#{value}"
+
+    Rails.logger.info("TIMOTEST translate_aggregator_value: #{i18n_key}")
 
     # convert the key to snake_case, replacing hyphens with underscores
     i18n_key = i18n_key.gsub("-", "_").downcase

--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -49,11 +49,11 @@ module ViewHelper
       value
     else
       if Rails.env.development? || Rails.env.test?
-        raise "Missing Pinwheel translation for #{namespace}.#{value}"
+        raise "Missing aggregator translation for #{namespace}.#{value}"
       end
 
       # In production, log warning and return original value
-      Rails.logger.warn "Unknown Pinwheel value for #{namespace}: #{value}"
+      Rails.logger.warn "Unknown aggregator value for #{namespace}: #{value}"
 
       value
     end

--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -117,7 +117,7 @@
           <% if employer_name %>
             <%= employer_name %> &mdash;
           <% end %>
-          Pay Date: <%= format_date(paystub.pay_date) %></h4>
+          <%= t(".pdf.shared.pay_date", pay_date: format_date(paystub.pay_date)) %></h4>
       <% end %>
       <% if summary[:has_income_data] %>
         <%= table.with_data_point(:pay_period_with_frequency, paystub.start, paystub.end, summary[:income].pay_frequency&.humanize, highlight: is_caseworker) %>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -136,15 +136,20 @@ ignore_missing:
 
     # Currently awaiting translation:
     # - "example.strings.*"   # Tag with ticket number that created or modified the string
-    - "cbv.summaries.show.description"              # FFS-2562
-    - "cbv.summaries.show.header"                   # FFS-2494
-    - "aggregator_strings.deductions.401k"          # FFS-2723
-    - "aggregator_strings.deductions.dental"        # FFS-2723
-    - "aggregator_strings.deductions.garnishment"   # FFS-2723
-    - "aggregator_strings.deductions.other"         # FFS-2723
-    - "aggregator_strings.deductions.vision"        # FFS-2723
-    - "aggregator_strings.earnings_category.base"   # FFS-2723
-    - "aggregator_strings.payment_frequencies.usd"  # FFS-2723
+    - "cbv.summaries.show.description"                    # FFS-2562
+    - "cbv.summaries.show.header"                         # FFS-2494
+    - "aggregator_strings.deductions.401k"                # FFS-2723
+    - "aggregator_strings.deductions.dental"              # FFS-2723
+    - "aggregator_strings.deductions.garnishment"         # FFS-2723
+    - "aggregator_strings.deductions.other"               # FFS-2723
+    - "aggregator_strings.deductions.vision"              # FFS-2723
+    - "aggregator_strings.earnings_category.base"         # FFS-2723
+    - "aggregator_strings.payment_frequencies.usd"        # FFS-2723
+    - "aggregator_strings.earnings_category.benefits"     # FFS-2723
+    - "aggregator_strings.employment_statuses.inactive"   # FFS-2723
+    - "aggregator_strings.employment_statuses.terminated" # FFS-2723
+    - "aggregator_strings.payment_frequencies.quarterly"  # FFS-2723
+    - "aggregator_strings.deductions.roth"                # FFS-2723
 
 ## Consider these keys used:
 ignore_unused:

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -133,28 +133,31 @@ ignore_missing:
     - "caseworker_mailer.summary_email.*"
     # Caseworker PDF strings that are only supported in English:
     - "cbv.submits.show.pdf.caseworker.*"
-    # Pinwheel values that are only supported in English:
-    - "pinwheel.*"
+
     # Currently awaiting translation:
-    - "cbv.summaries.show.description"  # FFS-2562
-    - "cbv.summaries.show.header"       # FFS-2494
-    # - "example.strings.*" # Tag with ticket number that created or modified the string
+    # - "example.strings.*"   # Tag with ticket number that created or modified the string
+    - "cbv.summaries.show.description"              # FFS-2562
+    - "cbv.summaries.show.header"                   # FFS-2494
+    - "aggregator_strings.deductions.401k"          # FFS-2723
+    - "aggregator_strings.deductions.dental"        # FFS-2723
+    - "aggregator_strings.deductions.garnishment"   # FFS-2723
+    - "aggregator_strings.deductions.other"         # FFS-2723
+    - "aggregator_strings.deductions.vision"        # FFS-2723
+    - "aggregator_strings.earnings_category.base"   # FFS-2723
+    - "aggregator_strings.payment_frequencies.usd"  # FFS-2723
 
 ## Consider these keys used:
 ignore_unused:
   all:
-    - "*.{nyc,ma,sandbox,az_des,default}" # site-specific translations
-    - "activerecord.errors.*" # model errors are not always explicitly used
-    - "date.*" # date formats are not always explicitly used
-    - "time.*" # time formats are not always explicitly used
-    - "pinwheel.*" # dynamically looked up pinwheel translations
-    - "help.show.*.intro" # dynamically looked up help translations
-    - "help.show.credentials.security_message" # dynamically looked up help translations
-# - 'activerecord.attributes.*'
-# - '{devise,kaminari,will_paginate}.*'
-# - 'simple_form.{yes,no}'
-# - 'simple_form.{placeholders,hints,labels}.*'
-# - 'simple_form.{error_notification,required}.:'
+    - "*.{nyc,ma,sandbox,az_des,default}"       # site-specific translations
+    - "activerecord.errors.*"                   # model errors are not always explicitly used
+    - "date.*"                                  # date formats are not always explicitly used
+    - "time.*"                                  # time formats are not always explicitly used
+    - "aggregator_strings.*"                    # dynamically looked up aggregator translations
+    - "help.show.*.intro"                       # dynamically looked up help translations
+    - "help.show.credentials.security_message"  # dynamically looked up help translations
+
+## Unused examples of how to use this file:
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -56,9 +56,11 @@ en:
       dental: Dental
       garnishment: Garnishment
       other: Other
+      roth: Roth
       vision: Vision
     earnings_category:
       base: Base Pay
+      benefits: Benefits
       bereavement: Bereavement
       bonus: Bonus
       commission: Commission
@@ -87,15 +89,20 @@ en:
       vacation: Vacation
     employment_statuses:
       employed: employed
+      inactive: inactive
+      terminated: terminated
     payment_frequencies:
       annual: annual
       annually: annual
       bi_weekly: bi-weekly
+      biweekly: bi-weekly
       daily: daily
       hourly: hourly
       monthly: monthly
       per_mile: per mile
+      quarterly: quarterly
       semi_monthly: semi-monthly
+      semimonthly: semi-monthly
       usd: USD
       variable: variable
       weekly: weekly

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -50,6 +50,55 @@ en:
               invalid_format: Enter an email address in the correct format, like name@example.com
             language:
               invalid_format: Language must be either English (en) or Spanish (es).
+  aggregator_strings:
+    deductions:
+      401k: 401k
+      dental: Dental
+      garnishment: Garnishment
+      other: Other
+      vision: Vision
+    earnings_category:
+      base: Base Pay
+      bereavement: Bereavement
+      bonus: Bonus
+      commission: Commission
+      disability: Disability
+      double_overtime: Double Overtime
+      employer_contribution: Employer Contribution
+      fare: Fare
+      holiday: Holiday
+      hourly: Hourly Wage
+      life_insurance: Life Insurance
+      meal_comp: Meal Comp
+      medical: Medical
+      other: Other Pay
+      overtime: Overtime
+      parental: Parental
+      premium: Premium
+      pto: Paid Time Off
+      retirement: Retirement
+      retro_pay: Retroactive Pay
+      salary: Salary
+      shift_differential: Shift Differential
+      sick: Sick Time
+      stock: Stock
+      tips: Tips
+      unpaid: Unpaid
+      vacation: Vacation
+    employment_statuses:
+      employed: employed
+    payment_frequencies:
+      annual: annual
+      annually: annual
+      bi_weekly: bi-weekly
+      daily: daily
+      hourly: hourly
+      monthly: monthly
+      per_mile: per mile
+      semi_monthly: semi-monthly
+      usd: USD
+      variable: variable
+      weekly: weekly
   applicant_mailer:
     invitation_email:
       body_1:
@@ -571,34 +620,6 @@ en:
       description_1: The SNAP Income Pilot is a new tool designed to help you connect your income details from your employer or payroll provider directly to your SNAP agency.
       description_2: Please note this pilot is not currently available.
       header: Welcome to the SNAP Income Pilot
-  pinwheel:
-    earnings_category:
-      bereavement: Bereavement
-      bonus: Bonus
-      commission: Commission
-      disability: Disability
-      double_overtime: Double Overtime
-      employer_contribution: Employer Contribution
-      fare: Fare
-      holiday: Holiday
-      hourly: Hourly Wage
-      life_insurance: Life Insurance
-      meal_comp: Meal Comp
-      medical: Medical
-      other: Other Pay
-      overtime: Overtime
-      parental: Parental
-      premium: Premium
-      pto: Paid Time Off
-      retirement: Retirement
-      retro_pay: Retroactive Pay
-      salary: Salary
-      shift_differential: Shift Differential
-      sick: Sick Time
-      stock: Stock
-      tips: Tips
-      unpaid: Unpaid
-      vacation: Vacation
   session_timeout:
     modal:
       description: It looks like you're inactive. For your security, we will sign you out soon unless you choose to extend your session.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -433,6 +433,7 @@ en:
             client_information: Client Information
             confirmation_code: Confirmation code
             employment_information: Employment information
+            pay_date: 'Pay Date: %{pay_date}'
             report_details: Report Details
         share_report_button: Share my report with %{agency_acronym}
         table_caption_no_name: Employer %{number}

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -34,11 +34,13 @@ es:
       annual: anual
       annually: anual
       bi_weekly: cada dos semanas
+      biweekly: cada dos semanas
       daily: diario
       hourly: por hora
       monthly: mensual
       per_mile: Por milla
       semi_monthly: dos veces al mes
+      semimonthly: dos veces al mes
       variable: variable
       weekly: semanal
   applicant_mailer:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -1,5 +1,46 @@
 ---
 es:
+  aggregator_strings:
+    earnings_category:
+      bereavement: Duelo
+      bonus: Bono
+      commission: Comisión
+      disability: Incapacidad
+      double_overtime: Horas extras dobles
+      employer_contribution: Contribución del empleador
+      fare: Tarifa
+      holiday: Vacaciones
+      hourly: Salario por hora
+      life_insurance: Seguro de vida
+      meal_comp: Compensación por comidas
+      medical: Médico
+      other: Otros pagos
+      overtime: Horas extras
+      parental: Pago por maternidad o paternidad
+      premium: Prima
+      pto: Tiempo libre pagado
+      retirement: Jubilación
+      retro_pay: Pago retroactivo
+      salary: Salario
+      shift_differential: Diferencial de turno
+      sick: Tiempo por enfermedad
+      stock: Acciones
+      tips: Propinas
+      unpaid: Sin paga
+      vacation: Vacaciones
+    employment_statuses:
+      employed: empleado
+    payment_frequencies:
+      annual: anual
+      annually: anual
+      bi_weekly: cada dos semanas
+      daily: diario
+      hourly: por hora
+      monthly: mensual
+      per_mile: Por milla
+      semi_monthly: dos veces al mes
+      variable: variable
+      weekly: semanal
   applicant_mailer:
     invitation_email:
       body_1:
@@ -462,48 +503,6 @@ es:
       description_1: El SNAP Income Pilot es una nueva herramienta diseñada para ayudarle a conectar los detalles de sus ingresos de su empleador o proveedor de nómina directamente con su agencia de SNAP. Actualmente estamos probando esta herramienta para asegurarnos de que funcione de manera eficaz.
       description_2: Tenga en cuenta que este piloto está disponible actualmente solo para los participantes de SNAP en la ciudad de Nueva York y Massachusetts.
       header: Bienvenido al SNAP Income Pilot
-  pinwheel:
-    deductions:
-      other: Otro
-    earnings_category:
-      bereavement: Duelo
-      bonus: Bono
-      commission: Comisión
-      disability: Incapacidad
-      double_overtime: Horas extras dobles
-      employer_contribution: Contribución del empleador
-      fare: Tarifa
-      holiday: Vacaciones
-      hourly: Salario por hora
-      life_insurance: Seguro de vida
-      meal_comp: Compensación por comidas
-      medical: Médico
-      other: Otros pagos
-      overtime: Horas extras
-      parental: Pago por maternidad o paternidad
-      premium: Prima
-      pto: Tiempo libre pagado
-      retirement: Jubilación
-      retro_pay: Pago retroactivo
-      salary: Salario
-      shift_differential: Diferencial de turno
-      sick: Tiempo por enfermedad
-      stock: Acciones
-      tips: Propinas
-      unpaid: Sin paga
-      vacation: Vacaciones
-    employment_statuses:
-      employed: empleado
-    payment_frequencies:
-      annually: anual
-      bi_weekly: cada dos semanas
-      daily: diario
-      hourly: por hora
-      monthly: mensual
-      per_mile: Por milla
-      semi_monthly: dos veces al mes
-      variable: variable
-      weekly: semanal
   session_timeout:
     modal:
       description: Parece no está realizando ninguna acción. Por motivos de seguridad, su sesión se cerrará, salvo que elija extender el tiempo de esta sesión.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -272,6 +272,7 @@ es:
             client_information: Información del cliente
             confirmation_code: Código de confirmación
             employment_information: Información del empleo
+            pay_date: 'Fecha de pago: %{pay_date}'
             report_details: Detalles del reporte
         share_report_button: Autorizo que se comparta mi informe con %{agency_acronym}
         table_caption_no_name: Employer %{number}

--- a/app/spec/helpers/view_helper_spec.rb
+++ b/app/spec/helpers/view_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ViewHelper, type: :helper do
-  describe '#translate_pinwheel_value' do
+  describe '#translate_aggregator_value' do
     around do |ex|
       I18n.with_locale(locale, &ex)
     end
@@ -11,22 +11,22 @@ RSpec.describe ViewHelper, type: :helper do
 
       it 'returns the translated value if translation exists' do
         I18n.backend.store_translations(:es, {
-          pinwheel: {
+          aggregator_strings: {
             namespace: {
               existing_value: 'Translated Value'
             }
           }
         })
 
-        result = helper.translate_pinwheel_value('namespace', 'existing_value')
+        result = helper.translate_aggregator_value('namespace', 'existing_value')
         expect(result).to eq('Translated Value')
       end
 
       it 'raises an error in development or test if translation is missing' do
         # Use a key that doesn't exist
         expect {
-          helper.translate_pinwheel_value('namespace', 'missing_value')
-        }.to raise_error('Missing Pinwheel translation for namespace.missing_value')
+          helper.translate_aggregator_value('namespace', 'missing_value')
+        }.to raise_error('Missing aggregator translation for namespace.missing_value')
       end
 
       it 'logs a warning and returns the original value in production if translation is missing' do
@@ -35,9 +35,9 @@ RSpec.describe ViewHelper, type: :helper do
         allow(Rails.env).to receive(:test?).and_return(false)
 
         # Expect a warning to be logged
-        expect(Rails.logger).to receive(:warn).with('Unknown Pinwheel value for namespace: missing_value')
+        expect(Rails.logger).to receive(:warn).with('Unknown aggregator value for namespace: missing_value')
 
-        result = helper.translate_pinwheel_value('namespace', 'missing_value')
+        result = helper.translate_aggregator_value('namespace', 'missing_value')
         expect(result).to eq('missing_value')
       end
     end
@@ -47,20 +47,20 @@ RSpec.describe ViewHelper, type: :helper do
 
       it 'returns the English value' do
         I18n.backend.store_translations(:en, {
-          pinwheel: {
+          aggregator_strings: {
             namespace: {
               some_value: 'Translated Value'
             }
           }
         })
 
-        result = helper.translate_pinwheel_value('namespace', 'some_value')
+        result = helper.translate_aggregator_value('namespace', 'some_value')
         expect(result).to eq('Translated Value')
       end
 
       context 'when there is no English value given' do
         it 'returns the original value regardless of translations' do
-          result = helper.translate_pinwheel_value('namespace', 'any_value')
+          result = helper.translate_aggregator_value('namespace', 'any_value')
           expect(result).to eq('any_value')
         end
       end


### PR DESCRIPTION
## [FFS-2723](https://jiraent.cms.gov/browse/FFS-2723)

## Changes
When using Argyle, the payment_details page will no longer crash in the Spanish locale.
Cleaned up our string tokens for the expectation of having multiple aggregators.

## Testing instructions
0. Switch to using Argyle (you must have argyle in your SUPPORTED_PROVIDERS list, as well as your ARGYLE_API_TOKEN_SANDBOX_ID and ARGYLE_API_TOKEN_SANDBOX_SECRET set in env.development.local)
1. Go through the cbv flow as normal
2. On the payment details page, switch to Spanish in the header
- At this point, the page should no longer crash

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
