### PR TITLE
[FFS-2739] when the poller is firing to collect information, dont fire a pageview event

### DIFF
--- a/app/app/controllers/cbv/synchronizations_controller.rb
+++ b/app/app/controllers/cbv/synchronizations_controller.rb
@@ -1,6 +1,7 @@
 class Cbv::SynchronizationsController < Cbv::BaseController
   before_action :set_pinwheel_account, only: %i[show update]
   before_action :redirect_if_sync_finished, only: %i[show]
+  skip_before_action :capture_page_view, only: %i[update]
 
   def show
   end

--- a/app/spec/controllers/cbv/synchronizations_controller_spec.rb
+++ b/app/spec/controllers/cbv/synchronizations_controller_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Cbv::SynchronizationsController do
       expect(response.body).to include("turbo-stream action=\"redirect\"")
     end
 
+    it "does not fire tracking event if its for the polling purposes" do
+      expect_any_instance_of(GenericEventTracker).not_to receive(:track)
+
+      patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
+    end
+
     context "when the paystubs synchronization fails" do
       let(:errored_jobs) { [ "paystubs" ] }
 


### PR DESCRIPTION
we only want to track the initial hitting of the page (which is done via the show action) when we're waiting for the webhooks to sync, rather than collect the poller as well.


## Ticket

Resolves [FFS-2739](https://jiraent.cms.gov/browse/FFS-2739).


## Changes

Ensures tracking not applied when firing the update event, because that is polled for and therefore adds noise.

## Acceptance testing

- [ X] Acceptance testing prior to merge
  * You can test this by confirming that the PageView events only fire once when you hit the synchronizations page.
