### PR TITLE
FFS-2550: Calculate gig work hours using /shifts Pinwheel endpoint

### DIFF
--- a/app/app/services/aggregators/aggregator_reports/pinwheel_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/pinwheel_report.rb
@@ -14,11 +14,17 @@ module Aggregators::AggregatorReports
       @employments.append(fetch_employment(account_id: account.pinwheel_account_id))
       @incomes.append(fetch_income(account_id: account.pinwheel_account_id))
       @paystubs.append(*fetch_paystubs(account_id: account.pinwheel_account_id))
+      @gigs.append(*fetch_gigs(account_id: account.pinwheel_account_id))
     end
 
     def fetch_paystubs(account_id:)
       json = @pinwheel_service.fetch_paystubs_api(account_id: account_id, from_pay_date: @from_date, to_pay_date: @to_date)
       json["data"].map { |paystub_json| Aggregators::ResponseObjects::Paystub.from_pinwheel(paystub_json) }
+    end
+
+    def fetch_gigs(account_id:)
+      gigs_json = @pinwheel_service.fetch_shifts_api(account_id: account_id)
+      gigs_json["data"].map { |gig_json| Aggregators::ResponseObjects::Gig.from_pinwheel(gig_json) }
     end
 
     def fetch_employment(account_id:)

--- a/app/app/services/aggregators/format_methods/pinwheel.rb
+++ b/app/app/services/aggregators/format_methods/pinwheel.rb
@@ -25,4 +25,8 @@ module Aggregators::FormatMethods::Pinwheel
       .group_by { |e| e["category"] }
       .transform_values { |earnings| earnings.sum { |e| e["hours"] } }
   end
+
+  def self.total_earnings_amount(earnings)
+    earnings.sum { |earning| earning["amount"] }
+  end
 end

--- a/app/app/services/aggregators/response_objects/gig.rb
+++ b/app/app/services/aggregators/response_objects/gig.rb
@@ -25,5 +25,19 @@ module Aggregators::ResponseObjects
         compensation_unit: response_body["income"]["currency"]
       )
     end
+
+    def self.from_pinwheel(response_body)
+      new(
+        account_id: response_body["account_id"],
+        gig_type: response_body["type"],
+        gig_status: nil, # pinwheel shifts don't have status
+        hours: Aggregators::FormatMethods::Pinwheel.hours(response_body["earnings"]),
+        start_date: response_body["start_date"],
+        end_date: response_body["end_date"],
+        compensation_category: response_body["earnings"].first["category"],
+        compensation_amount: response_body["earnings"].first["amount"], # Pinwheel already provides amounts in cents
+        compensation_unit: response_body["currency"]
+      )
+    end
   end
 end

--- a/app/app/services/aggregators/response_objects/gig.rb
+++ b/app/app/services/aggregators/response_objects/gig.rb
@@ -35,7 +35,7 @@ module Aggregators::ResponseObjects
         start_date: response_body["start_date"],
         end_date: response_body["end_date"],
         compensation_category: response_body["earnings"].first["category"],
-        compensation_amount: response_body["earnings"].first["amount"], # Pinwheel already provides amounts in cents
+        compensation_amount: Aggregators::FormatMethods::Pinwheel.total_earnings_amount(response_body["earnings"]),
         compensation_unit: response_body["currency"]
       )
     end

--- a/app/app/services/aggregators/sdk/pinwheel_service.rb
+++ b/app/app/services/aggregators/sdk/pinwheel_service.rb
@@ -70,6 +70,10 @@ module Aggregators::Sdk
       @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/paystubs"), params).body
     end
 
+    def fetch_shifts_api(account_id:)
+      @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/shifts")).body
+    end
+
     def fetch_employment_api(account_id:)
       @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/employment")).body
     end
@@ -80,10 +84,6 @@ module Aggregators::Sdk
 
     def fetch_income_api(account_id:)
       @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/income")).body
-    end
-
-    def fetch_shifts_api(account_id:)
-      @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/shifts")).body
     end
 
     def fetch_platform(platform_id:)

--- a/app/app/services/aggregators/sdk/pinwheel_service.rb
+++ b/app/app/services/aggregators/sdk/pinwheel_service.rb
@@ -82,6 +82,10 @@ module Aggregators::Sdk
       @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/income")).body
     end
 
+    def fetch_shifts_api(account_id:)
+      @http.get(build_url("#{ACCOUNTS_ENDPOINT}/#{account_id}/shifts")).body
+    end
+
     def fetch_platform(platform_id:)
       @http.get(build_url("#{PLATFORMS_ENDPOINT}/#{platform_id}")).body
     end

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Cbv::SummariesController do
       pinwheel_stub_request_employment_info_response unless errored_jobs.include?("employment")
       pinwheel_stub_request_income_metadata_response if supported_jobs.include?("income")
       pinwheel_stub_request_identity_response
+      pinwheel_stub_request_shifts_response
     end
 
     context "when rendering views" do

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
           pinwheel_stub_request_income_metadata_response
           pinwheel_stub_request_end_user_multiple_paystubs_response
           pinwheel_stub_request_employment_info_response
+          pinwheel_stub_request_shifts_response
 
           allow(controller).to receive(:event_logger).and_return(event_logger)
         end

--- a/app/spec/services/aggregators/aggregator_reports/pinwheel_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/pinwheel_report_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Aggregators::AggregatorReports::PinwheelReport, type: :service do
   let(:incomes_json) { pinwheel_load_relative_json_file('request_income_metadata_response.json') }
   let(:employments_json) { pinwheel_load_relative_json_file('request_employment_info_response.json') }
   let(:paystubs_json) { pinwheel_load_relative_json_file('request_end_user_paystubs_response.json') }
+  let(:shifts_json) { pinwheel_load_relative_json_file('request_end_user_shifts_response.json') }
 
   let(:empty_pinwheel_result) { { "result" => [] } }
 
@@ -26,6 +27,7 @@ RSpec.describe Aggregators::AggregatorReports::PinwheelReport, type: :service do
     allow(pinwheel_service).to receive(:fetch_income_api).with(account_id: account).and_return(incomes_json)
     allow(pinwheel_service).to receive(:fetch_employment_api).with(account_id: account).and_return(incomes_json)
     allow(pinwheel_service).to receive(:fetch_paystubs_api).with(account_id: account, from_pay_date: from_date, to_pay_date: to_date).and_return(paystubs_json)
+    allow(pinwheel_service).to receive(:fetch_shifts_api).with(account_id: account).and_return(shifts_json)
   end
 
   describe '#fetch' do
@@ -35,6 +37,7 @@ RSpec.describe Aggregators::AggregatorReports::PinwheelReport, type: :service do
       expect(pinwheel_service).to have_received(:fetch_paystubs_api).with(account_id: account, from_pay_date: from_date, to_pay_date: to_date).exactly(3).times
       expect(pinwheel_service).to have_received(:fetch_employment_api).with(account_id: account).exactly(3).times
       expect(pinwheel_service).to have_received(:fetch_income_api).with(account_id: account).exactly(3).times
+      expect(pinwheel_service).to have_received(:fetch_shifts_api).with(account_id: account).exactly(3).times
     end
 
     it 'transforms all response objects correctly' do
@@ -43,6 +46,7 @@ RSpec.describe Aggregators::AggregatorReports::PinwheelReport, type: :service do
       expect(report.instance_variable_get(:@employments)).to all(be_an(Aggregators::ResponseObjects::Employment))
       expect(report.instance_variable_get(:@incomes)).to all(be_an(Aggregators::ResponseObjects::Income))
       expect(report.instance_variable_get(:@paystubs)).to all(be_an(Aggregators::ResponseObjects::Paystub))
+      expect(report.instance_variable_get(:@gigs)).to all(be_an(Aggregators::ResponseObjects::Gig))
     end
 
     it 'sets @has_fetched to true on success' do

--- a/app/spec/services/aggregators/format_methods/pinwheel_spec.rb
+++ b/app/spec/services/aggregators/format_methods/pinwheel_spec.rb
@@ -63,4 +63,26 @@ RSpec.describe Aggregators::FormatMethods::Pinwheel do
       expect(described_class.hours_by_earning_category(earnings)).to eq({})
     end
   end
+
+  describe '.total_earnings_amount' do
+    it 'sums amounts across all earnings' do
+      earnings = [
+        { "category" => "hourly", "amount" => 4000 },
+        { "category" => "overtime", "amount" => 1500 },
+        { "category" => "bonus", "amount" => 2000 }
+      ]
+      expect(described_class.total_earnings_amount(earnings)).to eq(7500)
+    end
+
+    it 'returns 0 if there are no earnings' do
+      expect(described_class.total_earnings_amount([])).to eq(0)
+    end
+
+    it 'properly handles a single earning' do
+      earnings = [
+        { "category" => "hourly", "amount" => 4000 }
+      ]
+      expect(described_class.total_earnings_amount(earnings)).to eq(4000)
+    end
+  end
 end

--- a/app/spec/services/aggregators/response_objects/gig_spec.rb
+++ b/app/spec/services/aggregators/response_objects/gig_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Aggregators::ResponseObjects::Gig do
         start_date: gig_data["start_date"],
         end_date: gig_data["end_date"],
         hours: PinwheelFormatter.hours(gig_data["earnings"]),
-        compensation_amount: gig_data["earnings"].first["amount"],
+        compensation_amount: PinwheelFormatter.total_earnings_amount(gig_data["earnings"]),
         compensation_unit: gig_data["currency"],
         gig_status: nil
       )

--- a/app/spec/services/aggregators/response_objects/gig_spec.rb
+++ b/app/spec/services/aggregators/response_objects/gig_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Aggregators::ResponseObjects::Gig do
+  include PinwheelApiHelper
+  include ArgyleApiHelper
+
+  PinwheelFormatter = Aggregators::FormatMethods::Pinwheel
+  ArgyleFormatter = Aggregators::FormatMethods::Argyle
+
+  describe '.from_pinwheel' do
+    let(:response_body) { pinwheel_load_relative_json_file('request_end_user_shifts_response.json') }
+    let(:gig_data) { response_body["data"].first }
+
+    it 'creates a Gig from a Pinwheel shift' do
+      gig = described_class.from_pinwheel(gig_data)
+
+      expect(gig).to have_attributes(
+        account_id: gig_data["account_id"],
+        gig_type: gig_data["type"],
+        start_date: gig_data["start_date"],
+        end_date: gig_data["end_date"],
+        hours: PinwheelFormatter.hours(gig_data["earnings"]),
+        compensation_amount: gig_data["earnings"].first["amount"],
+        compensation_unit: gig_data["currency"],
+        gig_status: nil
+      )
+    end
+  end
+
+  describe '.from_argyle' do
+    let(:argyle_json) { argyle_load_relative_json_file('bob', 'request_gigs.json') }
+    let(:gig_data) { argyle_json["results"].find { |g| g["duration"] } }
+
+    it 'creates a Gig from an Argyle gig' do
+      gig = described_class.from_argyle(gig_data)
+
+      expect(gig).to have_attributes(
+        account_id: gig_data["account"],
+        gig_type: gig_data["type"],
+        start_date: ArgyleFormatter.format_date(gig_data["start_datetime"]),
+        end_date: ArgyleFormatter.format_date(gig_data["end_datetime"]),
+        hours: ArgyleFormatter.seconds_to_hours(gig_data["duration"]),
+        compensation_amount: ArgyleFormatter.format_currency(gig_data["income"]["pay"]),
+        compensation_unit: gig_data["income"]["currency"],
+        gig_status: gig_data["status"]
+      )
+    end
+  end
+end

--- a/app/spec/services/aggregators/sdk/pinwheel_service_spec.rb
+++ b/app/spec/services/aggregators/sdk/pinwheel_service_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Aggregators::Sdk::PinwheelService, type: :service do
     let(:account_id) { SecureRandom.uuid }
 
     before do
-      pinwheel_stub_request_end_user_shifts_response
+      pinwheel_stub_request_shifts_response
     end
 
     it "returns shifts data for the specified account" do

--- a/app/spec/services/aggregators/sdk/pinwheel_service_spec.rb
+++ b/app/spec/services/aggregators/sdk/pinwheel_service_spec.rb
@@ -173,4 +173,18 @@ RSpec.describe Aggregators::Sdk::PinwheelService, type: :service do
       end
     end
   end
+
+  describe "#fetch_shifts_api" do
+    let(:account_id) { SecureRandom.uuid }
+
+    before do
+      pinwheel_stub_request_end_user_shifts_response
+    end
+
+    it "returns shifts data for the specified account" do
+      response = service.fetch_shifts_api(account_id: account_id)
+
+      expect(response['data'].first['type']).to eq('shift')
+    end
+  end
 end

--- a/app/spec/support/fixtures/pinwheel/request_end_user_shifts_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_end_user_shifts_response.json
@@ -1,0 +1,84 @@
+{
+  "meta": {
+    "refreshed_at": "2025-03-07T23:30:41.014197+00:00",
+    "count": 3,
+    "next_cursor": "gAAAAABn80ZBxHqxlzGpo3vPbMLJkvlEG3lXBPgDy31NrTi8kCD0i2X="
+  },
+  "data": [
+    {
+      "id": "01dd74ac-5468-43b1-9a3e-78a3be41163d",
+      "created_at": "2025-03-07T23:30:39.424285+00:00",
+      "account_id": "725fad62-1caa-4613-9acc-5bda99e5b8a3",
+      "start_date": "2025-03-07",
+      "end_date": "2025-03-07",
+      "type": "shift",
+      "timezone": "America/New_York",
+      "timestamps": [
+        {
+          "from": "2025-03-07T09:00:00-05:00",
+          "to": "2025-03-07T17:00:00-05:00"
+        }
+      ],
+      "currency": "USD",
+      "earnings": [
+        {
+          "name": "Sandbox Test Earning",
+          "category": "hourly",
+          "amount": 15000,
+          "rate": 1000,
+          "hours": 15.0
+        }
+      ]
+    },
+    {
+      "id": "094c5c5d-9442-404a-a87f-98f683096b41",
+      "created_at": "2025-03-07T23:30:39.424285+00:00",
+      "account_id": "725fad62-1caa-4613-9acc-5bda99e5b8a3",
+      "start_date": "2025-03-06",
+      "end_date": "2025-03-06",
+      "type": "shift",
+      "timezone": "America/New_York",
+      "timestamps": [
+        {
+          "from": "2025-03-06T09:00:00-05:00",
+          "to": "2025-03-06T17:00:00-05:00"
+        }
+      ],
+      "currency": "USD",
+      "earnings": [
+        {
+          "name": "Sandbox Test Earning",
+          "category": "hourly",
+          "amount": 15000,
+          "rate": 1000,
+          "hours": 15.0
+        }
+      ]
+    },
+    {
+      "id": "e527779c-5490-4435-8ac8-9b7f9e1cc108",
+      "created_at": "2025-03-07T23:30:39.424285+00:00",
+      "account_id": "725fad62-1caa-4613-9acc-5bda99e5b8a3",
+      "start_date": "2025-03-05",
+      "end_date": "2025-03-05",
+      "type": "shift",
+      "timezone": "America/New_York",
+      "timestamps": [
+        {
+          "from": "2025-03-05T09:00:00-05:00",
+          "to": "2025-03-05T17:00:00-05:00"
+        }
+      ],
+      "currency": "USD",
+      "earnings": [
+        {
+          "name": "Sandbox Test Earning",
+          "category": "hourly",
+          "amount": 15000,
+          "rate": 1000,
+          "hours": 15.0
+        }
+      ]
+    }
+  ]
+}

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -139,6 +139,15 @@ module PinwheelApiHelper
       )
   end
 
+  def pinwheel_stub_request_end_user_shifts_response
+    stub_request(:get, %r{#{Aggregators::Sdk::PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/shifts})
+      .to_return(
+        status: 200,
+        body: load_relative_json_file('request_end_user_shifts_response.json').to_json,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' }
+      )
+  end
+
   def pinwheel_load_relative_file(filename)
     File.read(File.join(
       File.dirname(__FILE__),

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -143,7 +143,16 @@ module PinwheelApiHelper
     stub_request(:get, %r{#{Aggregators::Sdk::PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/shifts})
       .to_return(
         status: 200,
-        body: load_relative_json_file('request_end_user_shifts_response.json').to_json,
+        body: pinwheel_load_relative_json_file('request_end_user_shifts_response.json').to_json,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' }
+      )
+  end
+
+  def pinwheel_stub_request_shifts_response
+    stub_request(:get, %r{#{Aggregators::Sdk::PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/shifts})
+      .to_return(
+        status: 200,
+        body: pinwheel_load_relative_json_file('request_end_user_shifts_response.json').to_json,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' }
       )
   end


### PR DESCRIPTION
## Ticket

Resolves [FFS-2550](https://jiraent.cms.gov/browse/FFS-2550).


## Changes
- Fetch shifts data from Pinwheel
- Pinwheel integrated into the Gig `ResponseObject` struct
- Append gigs to Pinwheel report
- Test coverage for gigs, Pinwheel report and service with fixture

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
