### PR TITLE
Fix translate_aggregator_value to handle `nil` value

### DIFF
--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -37,6 +37,8 @@ module ViewHelper
   end
 
   def translate_aggregator_value(namespace, value)
+    return unless value.present?
+
     i18n_key = "aggregator_strings.#{namespace}.#{value}"
 
     # convert the key to snake_case, replacing hyphens with underscores

--- a/app/spec/helpers/view_helper_spec.rb
+++ b/app/spec/helpers/view_helper_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ViewHelper, type: :helper do
     context 'when locale is not :es' do
       let(:locale) { :en }
 
-      it 'returns the English value' do
+      before do
         I18n.backend.store_translations(:en, {
           aggregator_strings: {
             namespace: {
@@ -53,9 +53,18 @@ RSpec.describe ViewHelper, type: :helper do
             }
           }
         })
+      end
 
+      it 'returns the English value' do
         result = helper.translate_aggregator_value('namespace', 'some_value')
         expect(result).to eq('Translated Value')
+      end
+
+      context 'when the value is nil' do
+        it 'returns nil' do
+          result = helper.translate_aggregator_value('namespace', nil)
+          expect(result).to be_nil
+        end
       end
 
       context 'when there is no English value given' do


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - Tiny bugfix needed for #560.


## Changes
<!-- What was added, updated, or removed in this PR. -->


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This was breaking by returning a hash when value was nil, because it
would look for a key like "aggregator_reports.employment_statuses.",
which I18n would happily resolve to:

```
{:employed=>"employed", :inactive=>"inactive", :terminated=>"terminated"}
```

This behavior seems incorrect, so we should ensure that a nil value in
results in a nil value out.



## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
