### PR TITLE
FFS-2753: Update /employer_search precedence logic

### DIFF
--- a/app/app/services/aggregators/sdk/argyle_service.rb
+++ b/app/app/services/aggregators/sdk/argyle_service.rb
@@ -85,8 +85,8 @@ module Aggregators::Sdk
 
     # Fetch all Argyle items
     # https://docs.argyle.com/api-reference/items#list
-    def items(query = nil)
-      @http.get(build_url(ITEMS_ENDPOINT), { q: query }).body
+    def items(query = nil, status = %w[healthy issues])
+      @http.get(build_url(ITEMS_ENDPOINT), { q: query, status: status }).body
     end
 
     # https://docs.argyle.com/api-reference/users#retrieve

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -20,7 +20,7 @@ class ProviderSearchService
     if @providers.include?(:pinwheel) && (results.length == 0 || !any_exact_matches?(results, query))
       pinwheel_service = Aggregators::Sdk::PinwheelService.new(@client_agency_config.pinwheel_environment)
 
-      pinwheel_results = pinwheel_service.fetch_items(q: query)["data"].map do |result|
+      pinwheel_results = pinwheel_service.fetch_items(q: query, supported_jobs: %w[paystubs])["data"].map do |result|
         Aggregators::ResponseObjects::SearchResult.from_pinwheel(result)
       end
 

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -1,22 +1,32 @@
 class ProviderSearchService
   SUPPORTED_PROVIDERS = (ENV["SUPPORTED_PROVIDERS"] || "pinwheel")&.split(",")&.map(&:to_sym)
 
-  def initialize(client_agency_id)
+  def initialize(client_agency_id, providers: SUPPORTED_PROVIDERS)
     @client_agency_config = site_config[client_agency_id]
+    @providers = providers
   end
 
   def search(query = "")
     results = []
-    if SUPPORTED_PROVIDERS.include?(:argyle)
-      results = Aggregators::Sdk::ArgyleService.new(@client_agency_config.argyle_environment).items(query)["results"].map do |result|
+
+    if @providers.include?(:argyle)
+      argyle_service = Aggregators::Sdk::ArgyleService.new(@client_agency_config.argyle_environment)
+
+      results = argyle_service.items(query)["results"].map do |result|
         Aggregators::ResponseObjects::SearchResult.from_argyle(result)
       end
     end
 
-    if results.length == 0 && SUPPORTED_PROVIDERS.include?(:pinwheel)
-      results = Aggregators::Sdk::PinwheelService.new(@client_agency_config.pinwheel_environment).fetch_items(q: query)["data"].map do |result|
+    if @providers.include?(:pinwheel) && (results.length == 0 || !any_exact_matches?(results, query))
+      pinwheel_service = Aggregators::Sdk::PinwheelService.new(@client_agency_config.pinwheel_environment)
+
+      pinwheel_results = pinwheel_service.fetch_items(q: query)["data"].map do |result|
         Aggregators::ResponseObjects::SearchResult.from_pinwheel(result)
       end
+
+      # Use Pinwheel's results if there aren't any results from Argyle, or
+      # there is an exact match from Pinwheel.
+      results = pinwheel_results if results.length == 0 || any_exact_matches?(pinwheel_results, query)
     end
 
     results
@@ -26,9 +36,9 @@ class ProviderSearchService
   def top_aggregator_options(type)
     case type
     when "payroll"
-      Aggregators::ResponseObjects::SearchResult.from_aggregator_options(TOP_PROVIDERS, SUPPORTED_PROVIDERS)
+      Aggregators::ResponseObjects::SearchResult.from_aggregator_options(TOP_PROVIDERS, @providers)
     when "employer"
-      Aggregators::ResponseObjects::SearchResult.from_aggregator_options(TOP_EMPLOYERS, SUPPORTED_PROVIDERS)
+      Aggregators::ResponseObjects::SearchResult.from_aggregator_options(TOP_EMPLOYERS, @providers)
     end
   end
 
@@ -36,6 +46,15 @@ class ProviderSearchService
 
   def site_config
     Rails.application.config.client_agencies
+  end
+
+  def any_exact_matches?(results, original_query)
+    results.any? { |result| normalize_name(result.name) == normalize_name(original_query) }
+  end
+
+  def normalize_name(name)
+    # "Wal-Mart, LLC" => "walmartllc"
+    name.downcase.gsub(/[^0-9a-z]+/, "")
   end
 
   # TODO: move these to a config file - see FFS-2661

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe Cbv::EmployerSearchesController do
             cbv_applicant_id: cbv_flow.cbv_applicant_id,
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
-            num_results: 1,
+            num_results: 2,
             has_payroll_account: false,
-            pinwheel_result_count: 1,
+            pinwheel_result_count: 2,
             argyle_result_count: 0
             ))
         get :show, params: { query: "results" }
@@ -155,9 +155,9 @@ RSpec.describe Cbv::EmployerSearchesController do
             cbv_applicant_id: cbv_flow.cbv_applicant_id,
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
-            num_results: 1,
+            num_results: 2,
             has_payroll_account: false,
-            pinwheel_result_count: 1,
+            pinwheel_result_count: 2,
             argyle_result_count: 0
             ))
         get :show, params: { query: "results" }

--- a/app/spec/services/provider_search_service_spec.rb
+++ b/app/spec/services/provider_search_service_spec.rb
@@ -3,38 +3,73 @@ require 'rails_helper'
 RSpec.describe ProviderSearchService, type: :service do
   include PinwheelApiHelper
   include ArgyleApiHelper
-  let(:service) { ProviderSearchService.new("sandbox") }
+  let(:service) { ProviderSearchService.new("sandbox", providers: providers) }
+  let(:providers) { %i[pinwheel argyle] }
 
   describe "#search" do
-    around do |ex|
-      stub_environment_variable("SUPPORTED_PROVIDERS", "pinwheel", &ex)
-    end
-
     before do
       pinwheel_stub_request_items_response
       argyle_stub_request_items_response("bob")
     end
 
-    it "returns results from all enabled providers" do
-      results = service.search("test")
-      expect(results.length).to eq(1)
-    end
-
     it "returns results with correct structure" do
-      stub_const("ProviderSearchService::SUPPORTED_PROVIDERS", [ :pinwheel ])
       results = service.search("test")
       result = results.first
 
       expect(result).to have_attributes(
-        provider_name: :pinwheel,
+        provider_name: :argyle,
         provider_options: have_attributes(response_type: a_kind_of(String), provider_id: a_kind_of(String)),
         name: a_kind_of(String),
         logo_url: a_kind_of(String)
       )
     end
 
-    it 'returns argyle results only when both argyle and pinwheel are present' do
-      stub_const("ProviderSearchService::SUPPORTED_PROVIDERS", [ :argyle, :pinwheel ])
+    context "when there is no exact match for the query in Argyle" do
+      let(:query) do
+        # This value is not exactly present in either the Argyle nor Pinwheel
+        # request stubs.
+        "Some Other Company, LLC"
+      end
+
+      it "defaults to Argyle results if there are no Pinwheel exact matches" do
+        results = service.search(query)
+        expect(results.count { |r| r.provider_name == :pinwheel }).to eq(0)
+        expect(results.count { |r| r.provider_name == :argyle }).to eq(10)
+      end
+
+      context "when there *is* an exact match in Pinwheel" do
+        let(:query) do
+          # This value *is* exactly present in the Pinwheel request stub, but
+          # not Argyle's.
+          "Acme Payroll"
+        end
+
+        it "uses Pinwheel results" do
+          results = service.search(query)
+          expect(results.count { |r| r.provider_name == :pinwheel }).to eq(2)
+          expect(results.count { |r| r.provider_name == :argyle }).to eq(0)
+        end
+      end
+    end
+
+    context "when there is an exact match in Argyle" do
+      let(:query) do
+        # This value is exactly present *Argyle's* request stub, but not
+        # Pinwheel's.
+        "Amazon Flex"
+      end
+
+      it "does not try to query Pinwheel" do
+        expect_any_instance_of(Aggregators::Sdk::PinwheelService)
+          .not_to receive(:fetch_items)
+
+        results = service.search(query)
+        expect(results.count { |r| r.provider_name == :pinwheel }).to eq(0)
+        expect(results.count { |r| r.provider_name == :argyle }).to eq(10)
+      end
+    end
+
+    it 'prefers argyle results when both are present' do
       results = service.search("test")
 
       pinwheel_results = results.count { |item| item.provider_name == :pinwheel }
@@ -42,15 +77,43 @@ RSpec.describe ProviderSearchService, type: :service do
       expect(pinwheel_results).to eq 0
       expect(argyle_results).to eq 10
     end
+
+    context "when only pinwheel is enabled" do
+      let(:providers) { %i[pinwheel] }
+
+      it "returns results from pinwheel" do
+        results = service.search("test")
+        expect(results.length).to eq(2)
+      end
+    end
+
+    context "when only argyle is enabled" do
+      let(:providers) { %i[argyle] }
+
+      it "returns results from argyle" do
+        results = service.search("test")
+        expect(results.length).to eq(10)
+      end
+    end
   end
 
   # # TODO: These test would be more effective once the top providers are being loaded from config so we could create
   # # a config that sets up specific test cases around having pinwheel/argyle/both ids
   describe '#top_aggregator_options' do
+    it 'returns items for argyle (when both are configured)' do
+      results = service.top_aggregator_options("payroll")
+      first_result = results.first
+
+      expect(first_result).to have_attributes(
+        provider_name: :argyle,
+        provider_options: have_attributes(response_type: a_kind_of(String), provider_id: a_kind_of(String)),
+        name: a_kind_of(String),
+        logo_url: a_kind_of(String)
+      )
+    end
+
     context "when only pinwheel is enabled" do
-      before do
-        stub_const("ProviderSearchService::SUPPORTED_PROVIDERS", [ :pinwheel ])
-      end
+      let(:providers) { %i[pinwheel] }
 
       it 'returns properly formatted top payroll providers' do
         results = service.top_aggregator_options("payroll")
@@ -92,29 +155,9 @@ RSpec.describe ProviderSearchService, type: :service do
     end
 
     context "when only argyle is enabled" do
-      before do
-        stub_const("ProviderSearchService::SUPPORTED_PROVIDERS", [ :argyle ])
-      end
+      let(:providers) { %i[argyle] }
 
       it 'returns argyle payroll providers when argyle is configured' do
-        results = service.top_aggregator_options("payroll")
-        first_result = results.first
-
-        expect(first_result).to have_attributes(
-          provider_name: :argyle,
-          provider_options: have_attributes(response_type: a_kind_of(String), provider_id: a_kind_of(String)),
-          name: a_kind_of(String),
-          logo_url: a_kind_of(String)
-        )
-      end
-    end
-
-    context "when both pinwheel and argyle are enabled" do
-      before do
-        stub_const("ProviderSearchService::SUPPORTED_PROVIDERS", [ :argyle, :pinwheel ])
-      end
-
-      it 'returns argyle id and provider name when both are configured and there are two ids' do
         results = service.top_aggregator_options("payroll")
         first_result = results.first
 

--- a/app/spec/support/fixtures/argyle/bob/request_items.json
+++ b/app/spec/support/fixtures/argyle/bob/request_items.json
@@ -4,7 +4,7 @@
     "results": [
         {
             "id": "item_000248659",
-            "name": "Amazon",
+            "name": "Lumon",
             "kind": "employer",
             "known_limitations": null,
             "status": "healthy",

--- a/app/spec/support/fixtures/pinwheel/request_items_response.json
+++ b/app/spec/support/fixtures/pinwheel/request_items_response.json
@@ -28,7 +28,7 @@
       "max_percentage": 99,
       "min_amount": 1,
       "min_percentage": 1,
-      "name": "Acme Corporation",
+      "name": "Lumon",
       "percentage_supported": false,
       "response_type": "employer",
       "supported_jobs": [

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -10,16 +10,7 @@ module PinwheelApiHelper
     stub_request(:get, /#{Aggregators::Sdk::PinwheelService::ITEMS_ENDPOINT}/)
       .to_return(
         status: 200,
-        body: {
-          data: [
-            {
-              id: "12345",
-              name: "Some Employer Name",
-              logo_url: "https://example.com/logo.jpg",
-              response_type: "employer"
-            }
-          ]
-        }.to_json,
+        body: pinwheel_load_relative_json_file('request_items_response.json').to_json,
         headers: { content_type: 'application/json;charset=UTF-8' }
       )
   end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2753](https://jiraent.cms.gov/browse/FFS-2753).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Update /employer_search precedence logic**
> Upon further discussion of requirements with Eryn, we want to update the
> precedence logic to be:

> 1. Search Argyle. If any result is an exact match (after basic string
>    normalization), then stop and show all Argyle results. If no exact
>    match, then
> 2. Search Pinwheel. If any result is an exact match (after basic string
>    normalization), then stop and show all Pinwheel results. If no exact
>    match, then
> 3. Show Argyle results, if any. If none, then
> 4. Show Pinwheel results.

> This commit implements that and refactors the tests a bit to be able to
> operate without stubbing the constant.

**Update Argyle search params to exclude unavailable results**
> [Argyle's API docs][1] say that some search results may be returned that
> have status = "unavailable". These cannot be linked, therefore let's
> hide them from search results and hope our fallback-to-pinwheel logic
> will fulfill the user need in linking these employers.

> [1]: https://docs.argyle.com/api-reference/items#object-status


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
