### PR TITLE
[FFS-2750] submit to client asynchronously via solid queue

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,9 +26,6 @@ brew "graphviz"
 # used in many scripts in "infra"
 brew "jq"
 
-# queue for sidekiq jobs
-brew "redis"
-
 # ngrok local tunnel to receive webhooks
 cask "ngrok"
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ Most developers on the team code using macOS, so we recommend that platform if p
 1. Install JS dependencies
    * `nodenv rehash`
    * `npm install`
-1. Start postgres & redis:
+1. Start postgres:
    * `brew services start postgresql@12`
-   * `brew services start redis`
 1. Get development credentials from 1Password: search for "CBV .env.local secrets" and copy its ".env.local" section into a file called that in the app directory.
 1. Create database: `bin/rails db:create`
 1. Run migrations: `bin/rails db:migrate`

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -54,7 +54,7 @@ gem "device_detector"
 gem "mixpanel-ruby"
 gem "newrelic_rpm"
 
-gem "sidekiq", "~> 6.4"
+gem "solid_queue"
 
 gem "faraday", "~> 2.9.0"
 

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -450,14 +450,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    solid_queue (0.2.2)
+      rails (~> 7.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -513,6 +511,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
   x86_64-darwin-20
@@ -567,7 +566,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   selenium-webdriver
-  sidekiq (~> 6.4)
+  solid_queue
   sprockets-rails
   stackprof
   stimulus-rails

--- a/app/Procfile.dev
+++ b/app/Procfile.dev
@@ -1,5 +1,5 @@
 web: env RUBY_DEBUG_PORT=1234 RUBY_DEBUG_STOP_AT_LOAD=true RUBY_DEBUG_OPEN=true RUBY_DEBUG_HOST=0.0.0.0 bin/rails server -p 3000 -b 0.0.0.0
 js: npm run build -- --watch
 css: npm run build:css -- --watch
-worker: RUBY_DEBUG_OPEN=true bundle exec sidekiq
 ngrok: ngrok http 3000 --log stdout
+worker: bin/rails solid_queue:start

--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -58,15 +58,10 @@ class Cbv::SubmitsController < Cbv::BaseController
       @cbv_flow.update(consented_to_authorized_use_at: timestamp)
     end
 
-    if @cbv_flow.confirmation_code.blank?
-      confirmation_code = generate_confirmation_code(@cbv_flow.client_agency_id)
-      @cbv_flow.update(confirmation_code: confirmation_code)
-    end
-
-    if !current_agency.transmission_method.present?
-      Rails.logger.info("No transmission method found for client agency #{current_agency.id}")
+    if ENV["ACTIVEJOB_ENABLED"]
+      CaseWorkerTransmitterJob.perform_later(@cbv_flow.id)
     else
-      transmit_to_caseworker
+      CaseWorkerTransmitterJob.perform_now(@cbv_flow.id)
     end
 
     redirect_to next_path
@@ -77,154 +72,6 @@ class Cbv::SubmitsController < Cbv::BaseController
   def has_consent
     return true if @cbv_flow.consented_to_authorized_use_at.present?
     params[:cbv_flow] && params[:cbv_flow][:consent_to_authorized_use] == "1"
-  end
-
-  def transmit_to_caseworker
-    case current_agency.transmission_method
-    when "shared_email"
-      CaseworkerMailer.with(
-        email_address: current_agency.transmission_method_configuration.dig("email"),
-        cbv_flow: @cbv_flow,
-        aggregator_report: @aggregator_report,
-      ).summary_email.deliver_now
-      @cbv_flow.touch(:transmitted_at)
-      track_transmitted_event(@cbv_flow, @aggregator_report.paystubs)
-    when "s3"
-      config = current_agency.transmission_method_configuration
-      public_key = config["public_key"]
-
-      if public_key.blank?
-        Rails.logger.error("Public key is missing from transmission_method_configuration")
-        raise "Public key is required for S3 transmission"
-      end
-
-      time_now = Time.now
-      beginning_date = (Date.parse(@aggregator_report.from_date).strftime("%b") rescue @aggregator_report.from_date)
-      ending_date = (Date.parse(@aggregator_report.to_date).strftime("%b%Y") rescue @aggregator_report.to_date)
-      @file_name = "IncomeReport_#{@cbv_flow.cbv_applicant.agency_id_number}_" \
-        "#{beginning_date}-#{ending_date}_" \
-        "Conf#{@cbv_flow.confirmation_code}_" \
-        "#{time_now.strftime('%Y%m%d%H%M%S')}"
-
-      # Generate PDF
-      pdf_service = PdfService.new
-      @pdf_output = pdf_service.generate(
-        renderer: self,
-        template: "cbv/submits/show",
-        variables: {
-          is_caseworker: true,
-          cbv_flow: @cbv_flow,
-          aggregator_report: @aggregator_report,
-          has_consent: has_consent
-        }
-      )
-
-      # Generate CSV in-memory
-      csv_content = generate_csv
-
-      # Create tar file
-      file_data = [
-        { name: "#{@file_name}.pdf", content: @pdf_output&.content },
-        { name: "#{@file_name}.csv", content: csv_content.string }
-      ]
-      tar_tempfile = create_tar_file(file_data)
-
-      begin
-        # Gzip the tar file
-        gzipped_tempfile = gzip_file(tar_tempfile)
-
-        # Encrypt the gzipped tar file
-        tmp_encrypted_tar = gpg_encrypt_file(gzipped_tempfile.path, public_key)
-
-        if tmp_encrypted_tar.nil?
-          Rails.logger.error "Failed to encrypt file: encrypted_tempfile is nil"
-          raise "Encryption failed"
-        end
-
-        # Upload the encrypted gzipped tar file to S3
-        s3_service = S3Service.new(config.except("public_key"))
-        s3_service.upload_file(tmp_encrypted_tar.path, "outfiles/#{@file_name}.tar.gz.gpg")
-
-        @cbv_flow.touch(:transmitted_at)
-        track_transmitted_event(@cbv_flow, @aggregator_report.paystubs)
-      rescue => ex
-        Rails.logger.error "Failed to transmit to caseworker: #{ex.message}"
-        raise
-      ensure
-        tmp_encrypted_tar.close! if tmp_encrypted_tar
-      end
-    else
-      raise "Unsupported transmission method: #{current_agency.transmission_method}"
-    end
-  end
-
-  def generate_csv
-    payroll_account = PayrollAccount.find_by(cbv_flow_id: @cbv_flow.id)
-
-    data = {
-      client_id: @cbv_flow.cbv_applicant.agency_id_number,
-      first_name: @cbv_flow.cbv_applicant.first_name,
-      last_name: @cbv_flow.cbv_applicant.last_name,
-      middle_name: @cbv_flow.cbv_applicant.middle_name,
-      client_email_address: @cbv_flow.cbv_flow_invitation.email_address,
-      beacon_userid: @cbv_flow.cbv_applicant.beacon_id,
-      app_date: @cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
-      report_date_created: payroll_account.created_at.strftime("%m/%d/%Y"),
-      report_date_start: @cbv_flow.cbv_applicant.paystubs_query_begins_at.strftime("%m/%d/%Y"),
-      report_date_end: @cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
-      confirmation_code: @cbv_flow.confirmation_code,
-      consent_timestamp: @cbv_flow.consented_to_authorized_use_at.strftime("%m/%d/%Y %H:%M:%S"),
-      pdf_filename: "#{@file_name}.pdf",
-      pdf_filetype: "application/pdf",
-      pdf_filesize: @pdf_output.file_size,
-      pdf_number_of_pages: @pdf_output.page_count
-    }
-
-    create_csv(data)
-  end
-
-  def track_transmitted_event(cbv_flow, payments)
-    event_logger.track("ApplicantSharedIncomeSummary", request, {
-      timestamp: Time.now.to_i,
-      client_agency_id: cbv_flow.client_agency_id,
-      cbv_applicant_id: cbv_flow.cbv_applicant_id,
-      cbv_flow_id: cbv_flow.id,
-      invitation_id: cbv_flow.cbv_flow_invitation_id,
-      account_count: cbv_flow.payroll_accounts.count,
-      paystub_count: payments.count,
-      account_count_with_additional_information:
-        cbv_flow.additional_information.values.count { |info| info["comment"].present? },
-      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
-      locale: I18n.locale
-    })
-  rescue => ex
-    Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
-  end
-
-  def generate_confirmation_code(prefix = nil)
-    [
-      prefix.gsub("_", ""),
-      (Time.now.to_i % 36 ** 3).to_s(36).tr("OISB", "0158").rjust(3, "0"),
-      @cbv_flow.id.to_s.rjust(4, "0")
-    ].compact.join.upcase
-  end
-
-  def gzip_file(input_tempfile)
-    gzipped_tempfile = Tempfile.new(%w[gzipped .gz])
-    gzipped_tempfile.binmode
-    gzipped_path = gzipped_tempfile.path
-    raise "Failed to gzip file" if gzipped_path.nil?
-
-    Zlib::GzipWriter.open(gzipped_path) do |gz|
-      input_tempfile.binmode
-      input_tempfile.rewind
-      gz.write(input_tempfile.read)
-    end
-
-    gzipped_tempfile.rewind
-    gzipped_tempfile
-  ensure
-    input_tempfile.close unless input_tempfile.closed?
   end
 
   def track_accessed_submit_event(cbv_flow)

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -113,7 +113,6 @@ class CaseWorkerTransmitterJob < ApplicationJob
     end
   end
 
-
   def generate_csv
     payroll_account = PayrollAccount.find_by(cbv_flow_id: cbv_flow.id)
 

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -1,0 +1,196 @@
+class CaseWorkerTransmitterJob < ApplicationJob
+  include Cbv::AggregatorDataHelper
+  include GpgEncryptable
+  include TarFileCreatable
+  include CsvHelper
+
+  attr_reader :cbv_flow
+
+  queue_as :default
+
+  def perform(cbv_flow_id)
+    cbv_flow = CbvFlow.find(cbv_flow_id)
+    @cbv_flow = cbv_flow
+    current_agency = current_agency(@cbv_flow)
+
+    if cbv_flow.confirmation_code.blank?
+      confirmation_code = generate_confirmation_code(cbv_flow)
+      cbv_flow.update!(confirmation_code: confirmation_code)
+    end
+
+
+    if current_agency.transmission_method.empty?
+      Rails.logger.info("No transmission method found for client agency #{current_agency.id}")
+      return
+    end
+
+
+    aggregator_report = set_aggregator_report
+
+    transmit_to_caseworker(current_agency, aggregator_report, cbv_flow)
+  end
+
+  def agency_config
+    Rails.application.config.client_agencies
+  end
+
+  def transmit_to_caseworker(current_agency, aggregator_report, cbv_flow)
+    case current_agency.transmission_method
+    when "shared_email"
+      CaseworkerMailer.with(
+        email_address: current_agency.transmission_method_configuration.dig("email"),
+        cbv_flow: cbv_flow,
+        aggregator_report: aggregator_report,
+        ).summary_email.deliver_now
+      cbv_flow.touch(:transmitted_at)
+      track_transmitted_event(cbv_flow, aggregator_report.paystubs)
+    when "s3"
+      config = current_agency.transmission_method_configuration
+      public_key = config["public_key"]
+
+      if public_key.blank?
+        Rails.logger.error("Public key is missing from transmission_method_configuration")
+        raise "Public key is required for S3 transmission"
+      end
+
+      time_now = Time.now
+      beginning_date = (Date.parse(aggregator_report.from_date).strftime("%b") rescue aggregator_report.from_date)
+      ending_date = (Date.parse(aggregator_report.to_date).strftime("%b%Y") rescue aggregator_report.to_date)
+      @file_name = "IncomeReport_#{cbv_flow.cbv_applicant.agency_id_number}_" \
+        "#{beginning_date}-#{ending_date}_" \
+        "Conf#{cbv_flow.confirmation_code}_" \
+        "#{time_now.strftime('%Y%m%d%H%M%S')}"
+
+      # Generate PDF
+      pdf_service = PdfService.new
+      @pdf_output = pdf_service.generate(
+        renderer: Cbv::SubmitsController.new,
+        template: "cbv/submits/show",
+        variables: {
+          is_caseworker: true,
+          cbv_flow: cbv_flow,
+          aggregator_report: aggregator_report,
+          has_consent: true
+        }
+      )
+
+      # Generate CSV in-memory
+      csv_content = generate_csv
+
+      # Create tar file
+      file_data = [
+        { name: "#{@file_name}.pdf", content: @pdf_output&.content },
+        { name: "#{@file_name}.csv", content: csv_content.string }
+      ]
+      tar_tempfile = create_tar_file(file_data)
+
+      begin
+        # Gzip the tar file
+        gzipped_tempfile = gzip_file(tar_tempfile)
+
+        # Encrypt the gzipped tar file
+        tmp_encrypted_tar = gpg_encrypt_file(gzipped_tempfile.path, public_key)
+
+        if tmp_encrypted_tar.nil?
+          Rails.logger.error "Failed to encrypt file: encrypted_tempfile is nil"
+          raise "Encryption failed"
+        end
+
+        # Upload the encrypted gzipped tar file to S3
+        s3_service = S3Service.new(config.except("public_key"))
+        s3_service.upload_file(tmp_encrypted_tar.path, "outfiles/#{@file_name}.tar.gz.gpg")
+
+        cbv_flow.touch(:transmitted_at)
+        track_transmitted_event(cbv_flow, aggregator_report.paystubs)
+      rescue => ex
+        Rails.logger.error "Failed to transmit to caseworker: #{ex.message}"
+        raise
+      ensure
+        tmp_encrypted_tar.close! if tmp_encrypted_tar
+      end
+    else
+      raise "Unsupported transmission method: #{current_agency.transmission_method}"
+    end
+  end
+
+
+  def generate_csv
+    payroll_account = PayrollAccount.find_by(cbv_flow_id: cbv_flow.id)
+
+    data = {
+      client_id: cbv_flow.cbv_applicant.agency_id_number,
+      first_name: cbv_flow.cbv_applicant.first_name,
+      last_name: cbv_flow.cbv_applicant.last_name,
+      middle_name: cbv_flow.cbv_applicant.middle_name,
+      client_email_address: cbv_flow.cbv_flow_invitation.email_address,
+      beacon_userid: cbv_flow.cbv_applicant.beacon_id,
+      app_date: cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
+      report_date_created: payroll_account.created_at.strftime("%m/%d/%Y"),
+      report_date_start: cbv_flow.cbv_applicant.paystubs_query_begins_at.strftime("%m/%d/%Y"),
+      report_date_end: cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
+      confirmation_code: cbv_flow.confirmation_code,
+      consent_timestamp: cbv_flow.consented_to_authorized_use_at.strftime("%m/%d/%Y %H:%M:%S"),
+      pdf_filename: "#{@file_name}.pdf",
+      pdf_filetype: "application/pdf",
+      pdf_filesize: @pdf_output.file_size,
+      pdf_number_of_pages: @pdf_output.page_count
+    }
+
+    create_csv(data)
+  end
+
+  def track_transmitted_event(cbv_flow, payments)
+    event_logger.track("ApplicantSharedIncomeSummary", request, {
+      timestamp: Time.now.to_i,
+      client_agency_id: cbv_flow.client_agency_id,
+      cbv_applicant_id: cbv_flow.cbv_applicant_id,
+      cbv_flow_id: cbv_flow.id,
+      invitation_id: cbv_flow.cbv_flow_invitation_id,
+      account_count: cbv_flow.payroll_accounts.count,
+      paystub_count: payments.count,
+      account_count_with_additional_information:
+        cbv_flow.additional_information.values.count { |info| info["comment"].present? },
+      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
+      locale: I18n.locale
+    })
+  rescue => ex
+    Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
+  end
+
+  def generate_confirmation_code(cbv_flow)
+    prefix = cbv_flow.client_agency_id
+    [
+      prefix.gsub("_", ""),
+      (Time.now.to_i % 36 ** 3).to_s(36).tr("OISB", "0158").rjust(3, "0"),
+      cbv_flow.id.to_s.rjust(4, "0")
+    ].compact.join.upcase
+  end
+
+  def gzip_file(input_tempfile)
+    gzipped_tempfile = Tempfile.new(%w[gzipped .gz])
+    gzipped_tempfile.binmode
+    gzipped_path = gzipped_tempfile.path
+    raise "Failed to gzip file" if gzipped_path.nil?
+
+    Zlib::GzipWriter.open(gzipped_path) do |gz|
+      input_tempfile.binmode
+      input_tempfile.rewind
+      gz.write(input_tempfile.read)
+    end
+
+    gzipped_tempfile.rewind
+    gzipped_tempfile
+  ensure
+    input_tempfile.close unless input_tempfile.closed?
+  end
+
+  def pinwheel
+    environment = agency_config[@cbv_flow.client_agency_id].pinwheel_environment
+
+    Aggregators::Sdk::PinwheelService.new(environment)
+  end
+
+  def current_agency(cbv_flow)
+    agency_config[cbv_flow.client_agency_id]
+  end
+end

--- a/app/config/application.rb
+++ b/app/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 
 module IvCbvPayroll
   class Application < Rails::Application
-    config.active_job.queue_adapter = :sidekiq
+    config.active_job.queue_adapter = :solid_queue
     config.i18n.available_locales = [ :en, :es ]
     config.i18n.fallbacks = [ :en ]
     # Initialize configuration defaults for originally generated Rails version.

--- a/app/config/database.yml
+++ b/app/config/database.yml
@@ -22,38 +22,72 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
-  <<: *default
-  adapter: postgresql
-  encoding: unicode
-  database: <%= ENV.fetch("DB_NAME") { "iv_cbv_payroll_development" } %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  queue:
+    <<: *default
+    adapter: postgresql
+    encoding: unicode
+    database: <%= ENV.fetch("DB_NAME") { "iv_cbv_payroll_development" } %>
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  username: <%= ENV.fetch("DB_USERNAME") { nil } %>
+    # The specified database role being used to connect to postgres.
+    # To create additional roles in postgres see `$ createuser --help`.
+    # When left blank, postgres will use the default role. This is
+    # the same name as the operating system user running Rails.
+    username: <%= ENV.fetch("DB_USERNAME") { nil } %>
 
-  # The password associated with the postgres role (username).
-  password: <%= ENV.fetch("DB_PASSWORD") { nil } %>
+    # The password associated with the postgres role (username).
+    password: <%= ENV.fetch("DB_PASSWORD") { nil } %>
 
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  host: <%= ENV.fetch("DB_HOST") { "localhost" } %>
+    # Connect on a TCP socket. Omitted by default since the client uses a
+    # domain socket that doesn't need configuration. Windows does not have
+    # domain sockets, so uncomment these lines.
+    host: <%= ENV.fetch("DB_HOST") { "localhost" } %>
 
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
+    # The TCP port the server listens on. Defaults to 5432.
+    # If your server runs on a different port number, change accordingly.
+    #port: 5432
 
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
+    # Schema search path. The server defaults to $user,public
+    #schema_search_path: myapp,sharedapp,public
 
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+    # Minimum log levels, in increasing order:
+    #   debug5, debug4, debug3, debug2, debug1,
+    #   log, notice, warning, error, fatal, and panic
+    # Defaults to warning.
+    #min_messages: notice
+  primary:
+    <<: *default
+    adapter: postgresql
+    encoding: unicode
+    database: <%= ENV.fetch("DB_NAME") { "iv_cbv_payroll_development" } %>
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+    # The specified database role being used to connect to postgres.
+    # To create additional roles in postgres see `$ createuser --help`.
+    # When left blank, postgres will use the default role. This is
+    # the same name as the operating system user running Rails.
+    username: <%= ENV.fetch("DB_USERNAME") { nil } %>
+
+    # The password associated with the postgres role (username).
+    password: <%= ENV.fetch("DB_PASSWORD") { nil } %>
+
+    # Connect on a TCP socket. Omitted by default since the client uses a
+    # domain socket that doesn't need configuration. Windows does not have
+    # domain sockets, so uncomment these lines.
+    host: <%= ENV.fetch("DB_HOST") { "localhost" } %>
+
+    # The TCP port the server listens on. Defaults to 5432.
+    # If your server runs on a different port number, change accordingly.
+    #port: 5432
+
+    # Schema search path. The server defaults to $user,public
+    #schema_search_path: myapp,sharedapp,public
+
+    # Minimum log levels, in increasing order:
+    #   debug5, debug4, debug3, debug2, debug1,
+    #   log, notice, warning, error, fatal, and panic
+    # Defaults to warning.
+    #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -86,6 +120,15 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
+queue:
+  database: <%= ENV.fetch("DB_NAME") { nil } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("DB_USER") { nil } %>
+  password: <%= ENV.fetch("DB_PASS") { nil } %>
+  port: <%= ENV.fetch("DB_PORT") { 5432 } %>
+  host: <%= ENV.fetch("DB_HOST") { "localhost" } %>
+  aws_rds_iam_auth_token_generator: default
+
 production:
   <<: *default
   database: <%= ENV.fetch("DB_NAME") { nil } %>

--- a/app/config/environments/development.rb
+++ b/app/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
-
+  config.solid_queue.connects_to = { database: { writing: :queue } }
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -71,7 +71,6 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "iv_cbv_payroll_production"
 
   config.action_mailer.perform_caching = false

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -1,4 +1,3 @@
-require "sidekiq/web"
 
 Rails.application.routes.draw do
   devise_for :users,
@@ -9,10 +8,6 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     delete "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
-  end
-
-  if Rails.env.development?
-    mount Sidekiq::Web => "/sidekiq"
   end
 
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/, format: "html"  do

--- a/app/config/solid_queue.yml
+++ b/app/config/solid_queue.yml
@@ -1,0 +1,18 @@
+ default: &default
+   dispatchers:
+     - polling_interval: 1
+       batch_size: 500
+   workers:
+     - queues: "*"
+       threads: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+       processes: 1
+       polling_interval: 0.1
+
+ development:
+  <<: *default
+
+ test:
+  <<: *default
+
+ production:
+  <<: *default

--- a/app/db/migrate/20250415214118_create_solid_queue_tables.solid_queue.rb
+++ b/app/db/migrate/20250415214118_create_solid_queue_tables.solid_queue.rb
@@ -1,0 +1,101 @@
+# This migration comes from solid_queue (originally 20231211200639)
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false, index: true
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id, index: true
+      t.datetime :scheduled_at
+      t.datetime :finished_at, index: true
+      t.string :concurrency_key
+
+      t.timestamps
+
+      t.index [ :queue_name, :finished_at ], name: "index_solid_queue_jobs_for_filtering"
+      t.index [ :scheduled_at, :finished_at ], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.references :job, index: { unique: true }, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :scheduled_at, :priority, :job_id ], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.references :job, index: { unique: true }, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :priority, :job_id ], name: "index_solid_queue_poll_all"
+      t.index [ :queue_name, :priority, :job_id ], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.references :job, index: { unique: true }, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index [ :process_id, :job_id ]
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.references :job, index: { unique: true }, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :expires_at, :concurrency_key ], name: "index_solid_queue_blocked_executions_for_maintenance"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.references :job, index: { unique: true }, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false, index: { unique: true }
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false, index: true
+      t.bigint :supervisor_id, index: true
+
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false, index: { unique: true }
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false, index: true
+
+      t.timestamps
+
+      t.index [ :key, :value ], name: "index_solid_queue_semaphores_on_key_and_value"
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/app/db/migrate/20250415214119_add_missing_index_to_blocked_executions.solid_queue.rb
+++ b/app/db/migrate/20250415214119_add_missing_index_to_blocked_executions.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240110143450)
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index :solid_queue_blocked_executions, [ :concurrency_key, :priority, :job_id ], name: "index_solid_queue_blocked_executions_for_release"
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_10_001936) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_15_214119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -87,7 +87,102 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_10_001936) do
     t.datetime "identity_errored_at", precision: nil
     t.datetime "identity_synced_at", precision: nil
     t.string "type", default: "pinwheel", null: false
+    t.datetime "gigs_synced_at", precision: nil
     t.index ["cbv_flow_id"], name: "index_payroll_accounts_on_cbv_flow_id"
+  end
+
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -122,5 +217,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_10_001936) do
   add_foreign_key "cbv_flow_invitations", "users"
   add_foreign_key "cbv_flows", "cbv_flow_invitations"
   add_foreign_key "payroll_accounts", "cbv_flows"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "webhook_events", "payroll_accounts"
 end

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -11,10 +11,6 @@ applications:
     RAILS_SERVE_STATIC_FILES: true
     NEW_RELIC_LOG: stdout
   processes:
-  - type: worker
-    instances: ((worker_instances))
-    memory: ((worker_memory))
-    command: bundle exec sidekiq
   - type: web
     instances: ((web_instances))
     memory: ((web_memory))

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Cbv::SubmitsController do
 
   let(:cbv_flow) do
     create(:cbv_flow,
-      :invited,
-      :with_pinwheel_account,
-      with_errored_jobs: errored_jobs,
-      created_at: current_time,
-      supported_jobs: supported_jobs,
-      cbv_applicant: cbv_applicant
+           :invited,
+           :with_pinwheel_account,
+           with_errored_jobs: errored_jobs,
+           created_at: current_time,
+           supported_jobs: supported_jobs,
+           cbv_applicant: cbv_applicant
     )
   end
   let(:mock_client_agency) { instance_double(ClientAgencyConfig::ClientAgency) }
@@ -27,12 +27,12 @@ RSpec.describe Cbv::SubmitsController do
 
   before do
     allow(mock_client_agency).to receive(:transmission_method_configuration).and_return({
-      "bucket"            => "test-bucket",
-      "region"            => "us-west-2",
-      "access_key_id"     => "SOME_ACCESS_KEY",
-      "secret_access_key" => "SOME_SECRET_ACCESS_KEY",
-      "public_key"        => @public_key
-    })
+                                                                                          "bucket" => "test-bucket",
+                                                                                          "region" => "us-west-2",
+                                                                                          "access_key_id" => "SOME_ACCESS_KEY",
+                                                                                          "secret_access_key" => "SOME_SECRET_ACCESS_KEY",
+                                                                                          "public_key" => @public_key
+                                                                                        })
 
     cbv_applicant.update(snap_application_date: current_time)
 
@@ -82,7 +82,7 @@ RSpec.describe Cbv::SubmitsController do
 
       context "when a supported job errors" do
         let(:supported_jobs) { %w[income paystubs employment] }
-        let(:errored_jobs) { [ "employment" ] }
+        let(:errored_jobs) { ["employment"] }
 
         it "renders pdf properly" do
           get :show, format: :pdf
@@ -175,7 +175,7 @@ RSpec.describe Cbv::SubmitsController do
 
     context "when a supported job errors" do
       let(:supported_jobs) { %w[income paystubs employment] }
-      let(:errored_jobs) { [ "employment" ] }
+      let(:errored_jobs) { ["employment"] }
 
       it "renders pdf properly" do
         get :show, format: :pdf
@@ -197,184 +197,47 @@ RSpec.describe Cbv::SubmitsController do
       allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
     end
 
-    context "without consent" do
-      it "redirects back with an alert" do
-        patch :update
-        expect(response).to redirect_to(cbv_flow_submit_path)
-        expect(flash[:alert]).to be_present
-        expect(flash[:alert]).to eq("Please check the legal agreement box to share your report.")
+    describe "with activejob enabled" do
+      around do |example|
+        ClimateControl.modify ACTIVEJOB_ENABLED: 'true' do
+          example.run
+        end
       end
-    end
-
-    context "with consent" do
-      it "generates a new confirmation code" do
-        expect(cbv_flow.confirmation_code).to be_nil
-        patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
-        cbv_flow.reload
-        expect(cbv_flow.confirmation_code).to start_with("SANDBOX")
-      end
-
-      it "removes underscores from the agency name" do
-        cbv_flow.update(client_agency_id: "az_des")
-        expect(cbv_flow.confirmation_code).to be_nil
-        patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
-        cbv_flow.reload
-        expect(cbv_flow.confirmation_code).to start_with("AZDES")
-      end
-    end
-
-    context "when confirmation_code already exists" do
-      let(:existing_confirmation_code) { "SANDBOX000" }
-
-      before do
-        cbv_flow.update(confirmation_code: existing_confirmation_code)
-      end
-
-      it "does not override the existing confirmation code" do
-        expect(cbv_flow.reload.confirmation_code).to eq(existing_confirmation_code)
-        expect { patch :update }.not_to change { cbv_flow.reload.confirmation_code }
-      end
-    end
-
-    context "when sending an email to the caseworker" do
-      before do
-        cbv_flow.update(consented_to_authorized_use_at: Time.now)
-        sign_in ma_user
-        allow(mock_client_agency).to receive(:transmission_method).and_return('s3')
-        allow(mock_client_agency).to receive(:id).and_return('ma')
-        pinwheel_stub_request_end_user_accounts_response
-        pinwheel_stub_request_end_user_paystubs_response
-        allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
-      end
-
-      it "sends the email" do
-        expect do
+      context "without consent" do
+        it "redirects back with an alert" do
+          expect(CaseWorkerTransmitterJob).not_to receive(:perform_later)
           patch :update
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
-
-        email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to eq("Income Verification Report ABC1234 has been received")
+          expect(response).to redirect_to(cbv_flow_submit_path)
+          expect(flash[:alert]).to be_present
+          expect(flash[:alert]).to eq("Please check the legal agreement box to share your report.")
+        end
       end
 
-      it "stores the current time as transmitted_at" do
-        expect { patch :update }
-          .to change { cbv_flow.reload.transmitted_at }
-                .from(nil)
-                .to(within(5.second).of(Time.now))
+      context "with consent" do
+
+        it "queues a job and redirects to success screen" do
+          expect(CaseWorkerTransmitterJob).to receive(:perform_later).with(cbv_flow.id)
+          patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
+          expect(response).to redirect_to({ controller: :successes, action: :show })
+        end
+
+      end
+    end
+
+    describe "with activejob disabled" do
+      around do |example|
+        ClimateControl.modify ACTIVEJOB_ENABLED: nil do
+          example.run
+        end
       end
 
-      it "redirects to success screen" do
-        patch :update
+      it "runs the task immediately with consent" do
+        expect(CaseWorkerTransmitterJob).to receive(:perform_now)
+        patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
         expect(response).to redirect_to({ controller: :successes, action: :show })
       end
+
     end
 
-    context "#transmit_to_caseworker" do
-      before do
-        cbv_flow.update(consented_to_authorized_use_at: Time.now)
-
-        # Set up the mock_client_agency behavior
-        allow(mock_client_agency).to receive(:transmission_method_configuration).and_return({
-         "bucket"            => "test-bucket",
-         "region"            => "us-west-2",
-         "access_key_id"     => "SOME_ACCESS_KEY",
-         "secret_access_key" => "SOME_SECRET_ACCESS_KEY",
-         "public_key"        => @public_key
-         })
-      end
-
-      context "when transmission method is shared_email" do
-        before do
-          sign_in nyc_user
-          allow(mock_client_agency).to receive(:transmission_method).and_return('shared_email')
-          allow(mock_client_agency).to receive(:transmission_method_configuration).and_return({
-             "email" => 'test@example.com'
-          })
-          allow(controller).to receive(:current_agency).and_return(mock_client_agency)
-          allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
-        end
-
-        it "sends an email to the caseworker and updates transmitted_at" do
-          expect {
-            patch :update
-          }.to change { ActionMailer::Base.deliveries.count }.by(1)
-            .and change { cbv_flow.reload.transmitted_at }.from(nil)
-
-          email = ActionMailer::Base.deliveries.last
-          expect(email.to).to include('test@example.com')
-          expect(email.subject).to include("Income Verification Report")
-          expect(email.body.encoded).to include(cbv_flow.cbv_applicant.case_number)
-        end
-
-        # Note that we are not testing events here because doing so requires use of expect_any_instance_of,
-        # which does not play nice since there are multiple instances of the event logger.
-      end
-
-      context "when transmission method is s3" do
-        let(:user) { create(:user, email: "test@test.com") }
-        let(:s3_service_double) { instance_double(S3Service) }
-        # let(:pinwheel_service_double) { instance_double(Aggregators::Sdk::PinwheelService) }
-        before do
-          sign_in user
-          allow(S3Service).to receive(:new).and_return(s3_service_double)
-          allow(s3_service_double).to receive(:upload_file)
-          allow(mock_client_agency).to receive_messages(
-            id: 'ma',
-            transmission_method: 's3',
-            transmission_method_configuration: {
-              "bucket"     => "test-bucket",
-              "public_key" => @public_key
-            }
-          )
-
-          allow(controller).to receive(:current_agency).and_return(mock_client_agency)
-
-          # Stub pinwheel_for method to return our double
-          pinwheel_stub_request_end_user_accounts_response
-          pinwheel_stub_request_end_user_paystubs_response
-          pinwheel_stub_request_employment_info_response
-          pinwheel_stub_request_income_metadata_response
-          pinwheel_stub_request_identity_response
-        end
-
-        it "generates, gzips, encrypts, and uploads PDF and CSV files to S3" do
-          agency_id_number = cbv_applicant.agency_id_number
-          beacon_id = cbv_applicant.beacon_id
-
-          expect(s3_service_double).to receive(:upload_file).once do |file_path, file_name|
-            expect(file_path).to end_with('.gpg')
-            expect(file_name).to start_with("outfiles/IncomeReport_#{cbv_applicant.agency_id_number}_")
-            expect(file_name).to end_with('.tar.gz.gpg')
-            expect(File.exist?(file_path)).to be true
-          end
-
-          expect(CSV).to receive(:generate).and_wrap_original do |original_method, *args, &block|
-            csv_content = original_method.call(*args, &block)
-            csv_rows = CSV.parse(csv_content, headers: true)
-            expect(csv_rows[0]["client_id"]).to eq(agency_id_number)
-            csv_content
-          end
-
-          cbv_flow.update(client_agency_id: "ma")
-          cbv_applicant.update(client_agency_id: "ma")
-          cbv_applicant.update(beacon_id: beacon_id)
-          cbv_applicant.update(agency_id_number: agency_id_number)
-
-          patch :update
-        end
-
-        it "handles errors during file processing and upload" do
-          cbv_flow.update(client_agency_id: 'ma')
-          allow_any_instance_of(GpgEncryptable).to receive(:gpg_encrypt_file).and_raise(StandardError, "Encryption failed")
-
-          expect {
-            patch :update
-          }.to raise_error(StandardError, "Encryption failed")
-
-          expect(s3_service_double).not_to have_received(:upload_file)
-          expect(cbv_flow.reload.transmitted_at).to be_nil
-        end
-      end
-    end
   end
 end

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Cbv::SubmitsController do
 
       context "when a supported job errors" do
         let(:supported_jobs) { %w[income paystubs employment] }
-        let(:errored_jobs) { ["employment"] }
+        let(:errored_jobs) { [ "employment" ] }
 
         it "renders pdf properly" do
           get :show, format: :pdf
@@ -175,7 +175,7 @@ RSpec.describe Cbv::SubmitsController do
 
     context "when a supported job errors" do
       let(:supported_jobs) { %w[income paystubs employment] }
-      let(:errored_jobs) { ["employment"] }
+      let(:errored_jobs) { [ "employment" ] }
 
       it "renders pdf properly" do
         get :show, format: :pdf
@@ -214,13 +214,11 @@ RSpec.describe Cbv::SubmitsController do
       end
 
       context "with consent" do
-
         it "queues a job and redirects to success screen" do
           expect(CaseWorkerTransmitterJob).to receive(:perform_later).with(cbv_flow.id)
           patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
           expect(response).to redirect_to({ controller: :successes, action: :show })
         end
-
       end
     end
 
@@ -236,8 +234,6 @@ RSpec.describe Cbv::SubmitsController do
         patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
         expect(response).to redirect_to({ controller: :successes, action: :show })
       end
-
     end
-
   end
 end

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
     end
 
     context "when transmission method is shared_email" do
-      let(:transmission_method) { "shared_email"}
+      let(:transmission_method) { "shared_email" }
       let(:transmission_method_configuration) { {
         "email" => 'test@example.com'
       }}
@@ -99,9 +99,9 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
     context "when transmission method is s3" do
       let(:user) { create(:user, email: "test@test.com") }
       let(:s3_service_double) { instance_double(S3Service) }
-      let(:transmission_method) { "s3"}
-      let(:mocked_client_id) { "ma"}
-      let(:transmission_method_configuration) {{
+      let(:transmission_method) { "s3" }
+      let(:mocked_client_id) { "ma" }
+      let(:transmission_method_configuration) { {
         "bucket"     => "test-bucket",
         "public_key" => @public_key
       }}

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+require 'csv'
+RSpec.describe CaseWorkerTransmitterJob, type: :job do
+  include PinwheelApiHelper
+  include_context "gpg_setup"
+  let(:mock_client_agency) { instance_double(ClientAgencyConfig::ClientAgency) }
+
+
+  let(:cbv_applicant) { create(:cbv_applicant, created_at: current_time, case_number: "ABC1234") }
+  let(:supported_jobs) { %w[income paystubs employment identity] }
+  let(:errored_jobs) { [] }
+  let(:current_time) { Date.parse('2024-06-18') }
+  let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
+
+  let(:cbv_flow) do
+    create(:cbv_flow,
+           :invited,
+           :with_pinwheel_account,
+           with_errored_jobs: errored_jobs,
+           created_at: current_time,
+           supported_jobs: supported_jobs,
+           cbv_applicant: cbv_applicant
+    )
+  end
+
+  let(:transmission_method) {
+    raise "define this transmission method in your spec"
+  }
+  let(:transmission_method_configuration) {
+    {}
+  }
+
+  let(:mocked_client_id) {
+    "sandbox"
+  }
+
+  before do
+    pinwheel_stub_request_end_user_accounts_response
+    pinwheel_stub_request_end_user_paystubs_response
+    pinwheel_stub_request_employment_info_response
+    pinwheel_stub_request_income_metadata_response
+    pinwheel_stub_request_identity_response
+    allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
+
+    allow_any_instance_of(described_class).to receive(:current_agency).and_return(mock_client_agency)
+    allow(mock_client_agency).to receive(:id).and_return(mocked_client_id)
+    allow(mock_client_agency).to receive(:transmission_method).and_return(transmission_method)
+    allow(mock_client_agency).to receive(:transmission_method_configuration).and_return(transmission_method_configuration)
+  end
+
+  context "#transmit_to_caseworker" do
+    before do
+      cbv_flow.update(consented_to_authorized_use_at: Time.now)
+    end
+
+    context "when transmission method is shared_email" do
+      let(:transmission_method) { "shared_email"}
+      let(:transmission_method_configuration) { {
+        "email" => 'test@example.com'
+      }}
+
+      it "generates a new confirmation code" do
+        expect { described_class.new.perform(cbv_flow.id) }.to change { cbv_flow.reload.confirmation_code }.to start_with("SANDBOX")
+      end
+
+      it "removes underscores from the agency name" do
+        cbv_flow.update!(client_agency_id: "az_des")
+        expect { described_class.new.perform(cbv_flow.id) }.to change { cbv_flow.reload.confirmation_code }.to(start_with("AZDES"))
+      end
+
+      context "when confirmation_code already exists" do
+        let(:existing_confirmation_code) { "SANDBOX000" }
+
+        before do
+          cbv_flow.update(confirmation_code: existing_confirmation_code)
+        end
+
+        it "does not override the existing confirmation code" do
+          expect { described_class.new.perform(cbv_flow.id) }.not_to change { cbv_flow.reload.client_agency_id }
+        end
+      end
+
+      it "sends an email to the caseworker and updates transmitted_at" do
+        expect {
+          described_class.new.perform(cbv_flow.id)
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+                                                           .and change { cbv_flow.reload.transmitted_at }.from(nil)
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email.to).to include('test@example.com')
+        expect(email.subject).to include("Income Verification Report")
+        expect(email.body.encoded).to include(cbv_flow.cbv_applicant.case_number)
+      end
+
+      # Note that we are not testing events here because doing so requires use of expect_any_instance_of,
+      # which does not play nice since there are multiple instances of the event logger.
+    end
+
+    context "when transmission method is s3" do
+      let(:user) { create(:user, email: "test@test.com") }
+      let(:s3_service_double) { instance_double(S3Service) }
+      let(:transmission_method) { "s3"}
+      let(:mocked_client_id) { "ma"}
+      let(:transmission_method_configuration) {{
+        "bucket"     => "test-bucket",
+        "public_key" => @public_key
+      }}
+      # let(:pinwheel_service_double) { instance_double(Aggregators::Sdk::PinwheelService) }
+      before do
+        allow(S3Service).to receive(:new).and_return(s3_service_double)
+        allow(s3_service_double).to receive(:upload_file)
+      end
+
+      it "generates, gzips, encrypts, and uploads PDF and CSV files to S3" do
+        agency_id_number = cbv_applicant.agency_id_number
+        beacon_id = cbv_applicant.beacon_id
+
+        expect(s3_service_double).to receive(:upload_file).once do |file_path, file_name|
+          expect(file_path).to end_with('.gpg')
+          expect(file_name).to start_with("outfiles/IncomeReport_#{cbv_applicant.agency_id_number}_")
+          expect(file_name).to end_with('.tar.gz.gpg')
+          expect(File.exist?(file_path)).to be true
+        end
+
+        expect(CSV).to receive(:generate).and_wrap_original do |original_method, *args, &block|
+          csv_content = original_method.call(*args, &block)
+          csv_rows = CSV.parse(csv_content, headers: true)
+          expect(csv_rows[0]["client_id"]).to eq(agency_id_number)
+          csv_content
+        end
+
+        cbv_flow.update(client_agency_id: "ma")
+        cbv_applicant.update(client_agency_id: "ma")
+        cbv_applicant.update(beacon_id: beacon_id)
+        cbv_applicant.update(agency_id_number: agency_id_number)
+
+        described_class.new.perform(cbv_flow.id)
+      end
+
+      it "handles errors during file processing and upload" do
+        cbv_flow.update(client_agency_id: 'ma')
+        allow_any_instance_of(GpgEncryptable).to receive(:gpg_encrypt_file).and_raise(StandardError, "Encryption failed")
+
+        expect {
+          described_class.new.perform(cbv_flow.id)
+        }.to raise_error(StandardError, "Encryption failed")
+
+        expect(s3_service_double).not_to have_received(:upload_file)
+        expect(cbv_flow.reload.transmitted_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION


Resolves [FFS-2750](https://jiraent.cms.gov/browse/FFS-2750).


## Changes

 This removes sidekiq, which was kinda the active job setup kinda not, in favor of keeping everything in database via solid queue.
 Extracts out most of the work done by the submits controller into a contained class. Did some refactoring of the tests while I was at it,
 but there are some extra test cases to add in a follow up PR.

 There are two choices that I think need to be made as a team, with some tradeoffs in what that entails.

 Tradeoff 1: do we like the Procfile suggests run the puma server seperately or jointly with the job manager?

 In the default gem configuration, it suggests we can add a plugin to Puma that would allow idle servers to pick off jobs off the queue. Personally not a fan of that which is why I went for seperate servers in dev, but worth a discussion. (not a fan due to the 12 factor willies that gives to have the background processes hog front end user servers potentially.)

Conclusion:
After discussion with Tom, we think, especially due to the PDF generation jobs being memory intensive, it's safer if we have separate Rails containers for the job servers. Will be doing a followup PR to enable this for demo and production.

 Tradeoff 2: do we do as they suggest and put in a seperate server configuration for production, or have them combined?
 Interestingly, they do suggest that the database be a seperate process by default-- 'Running Solid Queue in a separate database is recommended'. Given the autoscaling nature of our DB and small size I could see an argument for and against choosing to do so--> wanting to leave that up to the team before making a call.

Conclusion; 
After discussion with Tom, we decided that given our job size spawning will be pretty deliberate and small, and the nature of the Postgres autoscaling, that we're safe with keeping them in the same database for now. We can revisit this later if the scale and nature of the jobs we enqueue changes.

## Acceptance testing

- [ X ] Acceptance testing prior to merge
  * Turn ACTIVEJOB_ENABLED to true
  * Go through the flow and generate a pdf
  * See the pdf is sent to the client
