### PR TITLE
[FFS-2662] fix sandbox via introducing something for it to validate

### DIFF
--- a/app/app/models/cbv_applicant/sandbox.rb
+++ b/app/app/models/cbv_applicant/sandbox.rb
@@ -1,2 +1,7 @@
 class CbvApplicant::Sandbox < CbvApplicant
+  VALID_ATTRIBUTES = %i[
+    first_name
+    middle_name
+    last_name
+  ]
 end

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -9,6 +9,10 @@ class ClientAgencyConfig
       .to_h
   end
 
+  def self.client_agencies
+    Rails.application.config.client_agencies
+  end
+
   def client_agency_ids
     @client_agencies.keys
   end

--- a/app/spec/models/cbv_applicant/az_des_spec.rb
+++ b/app/spec/models/cbv_applicant/az_des_spec.rb
@@ -4,8 +4,6 @@ require_relative "../cbv_applicant_spec.rb"
 RSpec.describe CbvApplicant::AzDes, type: :model do
   let(:az_attributes) { attributes_for(:cbv_applicant, :az_des) }
 
-  it_behaves_like "a CbvApplicant subclass", "az_des"
-
   context "user input is invalid" do
     it "requires case_number" do
       applicant = CbvApplicant.new(az_attributes.without(:case_number))

--- a/app/spec/models/cbv_applicant/ma_spec.rb
+++ b/app/spec/models/cbv_applicant/ma_spec.rb
@@ -4,8 +4,6 @@ require_relative "../cbv_applicant_spec.rb"
 RSpec.describe CbvApplicant::Ma, type: :model do
   let(:ma_attributes) { attributes_for(:cbv_applicant, :ma) }
 
-  it_behaves_like "a CbvApplicant subclass", "ma"
-
   context "user input is invalid" do
     it "requires agency_id_number" do
       applicant = CbvApplicant.new(ma_attributes.without(:agency_id_number))

--- a/app/spec/models/cbv_applicant/nyc_spec.rb
+++ b/app/spec/models/cbv_applicant/nyc_spec.rb
@@ -4,8 +4,6 @@ require_relative "../cbv_applicant_spec.rb"
 RSpec.describe CbvApplicant::Nyc, type: :model do
   let(:nyc_attributes) { attributes_for(:cbv_applicant, :nyc) }
 
-  it_behaves_like "a CbvApplicant subclass", "nyc"
-
   context "user input is valid" do
     it "formats a 9-character case number with leading zeros" do
       applicant = CbvApplicant.new(nyc_attributes.merge(case_number: '12345678A'))

--- a/app/spec/models/cbv_applicant_spec.rb
+++ b/app/spec/models/cbv_applicant_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
-RSpec.shared_examples "a CbvApplicant subclass" do |agency_id|
-  it "has a list of VALID_ATTRIBUTES" do
-    expect(CbvApplicant.valid_attributes_for_agency(agency_id)).to be_present
-  end
-end
-
 RSpec.describe CbvApplicant, type: :model do
+  describe "all valid types of agencies" do
+    ClientAgencyConfig.client_agencies.client_agency_ids.each do |client_agency_id|
+      it "has a list of VALID_ATTRIBUTES for #{client_agency_id}" do
+        expect(CbvApplicant.valid_attributes_for_agency(client_agency_id)).to be_present
+      end
+    end
+  end
+
   describe "validations" do
     let(:valid_attributes) { attributes_for(:cbv_applicant, :nyc) }
 


### PR DESCRIPTION
i also like the spirit of the shared example test, but think a more direct call of the configuration drives which tests are required

<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves ability to do sandbox invitations.

## Changes
Fix sandbox invitation flow to be runnable again.

Restructures the tests so this will be less likely to happen in the future.

## Acceptance testing

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ X] Acceptance testing prior to merge
  * Can attempt a sandbox invite.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
