### PR TITLE
FFS-2724: Use custom argyle flowId to allow multiple employers

### DIFF
--- a/app/app/controllers/api/argyle_controller.rb
+++ b/app/app/controllers/api/argyle_controller.rb
@@ -25,7 +25,14 @@ class Api::ArgyleController < ApplicationController
                    response["user_token"]
                  end
 
-    render json: { status: :ok, user: { user_token: user_token }, isSandbox: is_sandbox_environment }
+    render json: {
+      status: :ok,
+      isSandbox: is_sandbox_environment,
+      flowId: Aggregators::Sdk::ArgyleService::FLOW_ID,
+      user: {
+        user_token: user_token
+      }
+    }
   end
 
   def track_event

--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -18,9 +18,10 @@ export default class ArgyleModalAdapter extends ModalAdapter {
         locale,
       })
 
-      const { user, isSandbox } = await fetchArgyleToken()
+      const { user, isSandbox, flowId } = await fetchArgyleToken()
       return Argyle.create({
         userToken: user.user_token,
+        flowId: flowId,
         items: [this.requestData.id],
         onAccountConnected: this.onSuccess.bind(this),
         onTokenExpired: this.onTokenExpired.bind(this),

--- a/app/app/javascript/types/Argyle.d.ts
+++ b/app/app/javascript/types/Argyle.d.ts
@@ -6,6 +6,8 @@ type LinkError = {
 }
 
 type ArgyleInitializationParams = {
+  // See: https://docs.argyle.com/link/initialization
+  flowId: string
   userToken: string
   items: string[]
   onAccountConnected?: (payload: ArgyleAccountData) => void

--- a/app/app/services/aggregators/sdk/argyle_service.rb
+++ b/app/app/services/aggregators/sdk/argyle_service.rb
@@ -21,6 +21,9 @@ module Aggregators::Sdk
       }
     }
 
+    # See: https://console.argyle.com/flows
+    FLOW_ID = "BXSHLUUJ"
+
     ITEMS_ENDPOINT = "items"
     PAYSTUBS_ENDPOINT = "paystubs"
     IDENTITIES_ENDPOINT = "identities"

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Cbv::PaymentDetailsController do
       pinwheel_stub_request_end_user_paystubs_response
       pinwheel_stub_request_income_metadata_response if supported_jobs.include?("income")
       pinwheel_stub_request_employment_info_response
+      pinwheel_stub_request_shifts_response
     end
 
     context "when pinwheel values are present" do

--- a/app/spec/support/pinwheel_api_helper.rb
+++ b/app/spec/support/pinwheel_api_helper.rb
@@ -130,15 +130,6 @@ module PinwheelApiHelper
       )
   end
 
-  def pinwheel_stub_request_end_user_shifts_response
-    stub_request(:get, %r{#{Aggregators::Sdk::PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/shifts})
-      .to_return(
-        status: 200,
-        body: pinwheel_load_relative_json_file('request_end_user_shifts_response.json').to_json,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' }
-      )
-  end
-
   def pinwheel_stub_request_shifts_response
     stub_request(:get, %r{#{Aggregators::Sdk::PinwheelService::ACCOUNTS_ENDPOINT}/[0-9a-fA-F\-]{36}/shifts})
       .to_return(


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2724](https://jiraent.cms.gov/browse/FFS-2724).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2724: Use custom argyle flowId to allow multiple employers**
> Argyle was restricting users to only linking one account because any
> subsequent accounts would open an uncloseable "Your Connections" screen
> before allowing future subsequent account linking.

> This page can be disabled in Argyle settings by defining a custom
> "flow". We just have to pass this ID into the modal initialization.

> Tested locally and it worked like a charm.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
