### PR TITLE
[FFS-2750] add terraform to create solidqueue app workers

### DIFF
--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -89,6 +89,11 @@ locals {
       secret_store_name = "/service/${var.app_name}-${var.environment}/supported-providers"
     },
 
+    ACTIVEJOB_ENABLED = {
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/activejob-enabled"
+    },
+
     # Pinwheel Configuration:
     PINWHEEL_API_TOKEN_PRODUCTION = {
       manage_method     = "manual"

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -38,6 +38,104 @@ locals {
 # Service Execution
 #-------------------
 
+resource "aws_ecs_service" "solid_queue" {
+  name                   = "${var.service_name}-solid_queue"
+  cluster                = aws_ecs_cluster.cluster.arn
+  launch_type            = "FARGATE"
+  task_definition        = aws_ecs_task_definition.app.arn
+  desired_count          = var.desired_solidqueue_instance_count
+  enable_execute_command = var.enable_command_execution ? true : null
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  network_configuration {
+    assign_public_ip = false
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.app.id] # Or another SG if needed
+  }
+
+}
+
+
+
+resource "aws_ecs_task_definition" "solid_queue" {
+  family             = var.service_name
+  execution_role_arn = aws_iam_role.task_executor.arn
+  task_role_arn      = aws_iam_role.app_service.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = local.container_name,
+      image       = local.image_url,
+      memory      = var.memory,
+      cpu         = var.cpu,
+      networkMode = "awsvpc",
+      essential   = true,
+      command   = ["bin/rails", "solid_queue:start"],
+      # TODO: Reenable readonlyRootFilesystem when we can have it behave
+      # consistently in dev (demo) and production.
+      # readonlyRootFilesystem = !var.enable_command_execution,
+      readonlyRootFilesystem = false,
+
+      # Need to define all parameters in the healthCheck block even if we want
+      # to use AWS's defaults, otherwise the terraform plan will show a diff
+      # that will force a replacement of the task definition
+      healthCheck = {
+        interval = 30,
+        retries  = 3,
+        timeout  = 5,
+        command = ["CMD-SHELL",
+          "curl --fail http://localhost:${var.container_port}/health"
+        ]
+      },
+      environment = local.environment_variables,
+      secrets     = var.secrets,
+      portMappings = [
+        {
+          containerPort = var.container_port,
+          hostPort      = var.container_port,
+          protocol      = "tcp"
+        }
+      ],
+      linuxParameters = {
+        capabilities = {
+          add  = []
+          drop = ["ALL"]
+        },
+        initProcessEnabled = true
+      },
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.service_logs.name,
+          "awslogs-region"        = data.aws_region.current.name,
+          "awslogs-stream-prefix" = local.log_stream_prefix
+        }
+      },
+      mountPoints = [
+        {
+          containerPath = "/rails/tmp",
+          sourceVolume  = "${var.service_name}-tmp"
+        }
+      ]
+    }
+  ])
+
+  cpu    = var.cpu
+  memory = var.memory
+
+  volume {
+    name = "${var.service_name}-tmp"
+  }
+
+  requires_compatibilities = ["FARGATE"]
+
+  # Reference https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
+  network_mode = "awsvpc"
+}
+
 resource "aws_ecs_service" "app" {
   name                   = var.service_name
   cluster                = aws_ecs_cluster.cluster.arn

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -44,6 +44,12 @@ variable "desired_instance_count" {
   default     = 1
 }
 
+variable "desired_solidqueue_instance_count" {
+  type        = number
+  description = "Number of background instances of the task definition to place and keep running."
+  default     = 1
+}
+
 variable "domain_name" {
   type        = string
   description = "The fully qualified domain name for the application"


### PR DESCRIPTION
given we dont want them in a load balancer, it seemed copying the task definition was least worst for now.

Might be worth thinking about how to modularize the task if it needs to be modified frequently.

## Ticket

Resolves [FFS-2750](https://jiraent.cms.gov/browse/FFS-2750).


## Acceptance testing
<!-- Check one: -->
- [X ] Acceptance testing prior to merge
  * Confirm the terraform applied is spawning up the correct workers and that setting the environment variable leads to the CBV flows still performing correctly.
