### PR TITLE
FFS-2781: Fix missing "Your Information" header on /summary

### DIFF
--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -55,7 +55,7 @@
 
 <% if @cbv_flow.cbv_flow_invitation.blank? %>
 <table class="usa-table usa-table--borderless width-full margin-top-2">
-  <h3> <% t(".your_information") %></h3>
+  <h3><%= t(".your_information") %></h3>
   <div class="usa-prose">
     <p><%= t(".must_match", agency_acronym: current_agency.agency_short_name) %></p>
   </div>


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2781](https://jiraent.cms.gov/browse/FFS-2781).

## Changes
<!-- What was added, updated, or removed in this PR. -->

Before:
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/8b6f0719-fa75-4792-9558-96c121deac81" />

After:
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/f675b16e-6828-43e9-bf8d-b4e5e549a2e8" />


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This header was missing because we forgot an `=`.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
