### PR TITLE
 [FFS-2750] fix report generation worker refactor by adding additional argyle tests

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -189,6 +189,11 @@ class CaseWorkerTransmitterJob < ApplicationJob
     Aggregators::Sdk::PinwheelService.new(environment)
   end
 
+  def argyle
+    environment = agency_config[cbv_flow.client_agency_id].argyle_environment
+    Aggregators::Sdk::ArgyleService.new(environment)
+  end
+
   def current_agency(cbv_flow)
     agency_config[cbv_flow.client_agency_id]
   end

--- a/app/spec/factories/cbv_flow.rb
+++ b/app/spec/factories/cbv_flow.rb
@@ -31,6 +31,24 @@ FactoryBot.define do
       end
     end
 
+    trait :with_argyle_account do
+      transient do
+        supported_jobs { Aggregators::Webhooks::Argyle.get_supported_jobs }
+        with_errored_jobs { [] }
+      end
+
+      after(:build) do |cbv_flow, evaluator|
+        cbv_flow.payroll_accounts = [
+          create(:payroll_account,
+                 :argyle_fully_synced,
+                 with_errored_jobs: evaluator.with_errored_jobs,
+                 cbv_flow: cbv_flow,
+                 supported_jobs: evaluator.supported_jobs,
+                 )
+        ]
+      end
+    end
+
     transient do
       cbv_applicant_attributes { {} }
     end

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -51,16 +51,6 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
   context "#transmit_to_caseworker" do
     let(:supported_jobs) { %w[income paystubs employment identity] }
     let(:argyle_report) { build(:argyle_report, :with_argyle_account) }
-    let(:cbv_flow) do
-      create(:cbv_flow,
-             :invited,
-             :with_argyle_account,
-             with_errored_jobs: errored_jobs,
-             created_at: current_time,
-             supported_jobs: supported_jobs,
-             cbv_applicant: cbv_applicant
-      )
-    end
 
     before do
       cbv_flow.update(consented_to_authorized_use_at: Time.now)
@@ -71,6 +61,16 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
       let(:transmission_method_configuration) { {
         "email" => 'test@example.com'
       }}
+      let(:cbv_flow) do
+        create(:cbv_flow,
+               :invited,
+               :with_argyle_account,
+               with_errored_jobs: errored_jobs,
+               created_at: current_time,
+               supported_jobs: supported_jobs,
+               cbv_applicant: cbv_applicant
+        )
+      end
 
       before do
         allow(Aggregators::AggregatorReports::ArgyleReport).to receive(:new).and_return(argyle_report)


### PR DESCRIPTION
when pulling out the globals and moving into a worker, missed a global definition of argyle in the application controller.

added a test to help avoid this in the future.

## Acceptance testing
<!-- Check one: -->
- [ X] Acceptance testing prior to merge
  * Generate argyle report locally.