### PR TITLE
FFS-2779: Event isn't logged when switching languages

### DIFF
--- a/app/app/controllers/api/user_events_controller.rb
+++ b/app/app/controllers/api/user_events_controller.rb
@@ -30,6 +30,7 @@ class Api::UserEventsController < ApplicationController
     ApplicantEncounteredArgyleInvalidAuthLoginError
     ApplicantEncounteredArgyleMfaCanceledLoginError
     ApplicantUpdatedArgyleSearchTerm
+    UserManuallySwitchedLanguage
   ]
 
   # Maps aggregator event names (keys) to new Mixpanel event names (values) we're using
@@ -72,6 +73,7 @@ class Api::UserEventsController < ApplicationController
 
     event_attributes = user_action_params[:attributes].merge(base_attributes)
     event_name = user_action_params[:event_name]
+
     if EVENT_NAMES.include?(event_name)
       # Map to the new Mixpanel event name if present, otherwise just send NewRelic the Pinwheel name
       mixpanel_event_type = MIXPANEL_EVENT_MAP[event_name] || event_name

--- a/app/app/controllers/api/user_events_controller.rb
+++ b/app/app/controllers/api/user_events_controller.rb
@@ -30,7 +30,7 @@ class Api::UserEventsController < ApplicationController
     ApplicantEncounteredArgyleInvalidAuthLoginError
     ApplicantEncounteredArgyleMfaCanceledLoginError
     ApplicantUpdatedArgyleSearchTerm
-    UserManuallySwitchedLanguage
+    ApplicantManuallySwitchedLanguage
   ]
 
   # Maps aggregator event names (keys) to new Mixpanel event names (values) we're using
@@ -52,7 +52,8 @@ class Api::UserEventsController < ApplicationController
     "ArgyleCloseModal" => "ApplicantClosedArgyleModal",
     "ArgyleError" => "ApplicantEncounteredArgyleError",
     "ArgyleTokenExpired" => "ApplicantEncounteredArgyleTokenExpired",
-    "ModalAdapterError" => "ApplicantEncounteredModalAdapterError"
+    "ModalAdapterError" => "ApplicantEncounteredModalAdapterError",
+    "ApplicantManuallySwitchedLanguage" => "UserManuallySwitchedLanguage"
   }
 
   def user_action

--- a/app/app/helpers/view_helper.rb
+++ b/app/app/helpers/view_helper.rb
@@ -4,7 +4,7 @@ module ViewHelper
   def switch_locale_link(locale)
     new_locale = locale == I18n.default_locale ? nil : locale
     path = url_for(request.params.merge(locale: new_locale))
-    link_to t("shared.languages.#{locale}"), path, class: "usa-nav__link", data: { "turbo-prefetch": false }
+    link_to t("shared.languages.#{locale}"), path, class: "usa-nav__link", data: { "turbo-prefetch": false, "action": "click->language#switchLocale", "locale": locale }
   end
 
   def format_parsed_date(date, format = :default)

--- a/app/app/javascript/controllers/index.js
+++ b/app/app/javascript/controllers/index.js
@@ -4,11 +4,13 @@ import CbvEmployerSearch from "./cbv/employer_search"
 import CbvSessionsTimeoutController from "./cbv/sessions_controller.js"
 import HelpController from "./help"
 import PollingController from "./polling_controller.js"
+import LanguageController from "./language_controller.js"
 
 application.register("cbv-employer-search", CbvEmployerSearch)
 application.register("polling", PollingController)
 application.register("session", CbvSessionsTimeoutController)
 application.register("help", HelpController)
+application.register("language", LanguageController)
 
 Turbo.StreamActions.redirect = function () {
   Turbo.visit(this.target)

--- a/app/app/javascript/controllers/language_controller.js
+++ b/app/app/javascript/controllers/language_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+import { trackUserAction } from "../utilities/api"
+
+// Handles tracking language switching events
+export default class extends Controller {
+  switchLocale(event) {
+    const locale = event.currentTarget.dataset.locale
+    const previousLocale = document.documentElement.lang
+
+    trackUserAction("UserManuallySwitchedLanguage", {
+      locale: locale,
+      previous_locale: previousLocale,
+      current_locale: previousLocale,
+    })
+  }
+}

--- a/app/app/javascript/controllers/language_controller.js
+++ b/app/app/javascript/controllers/language_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   switchLocale(event) {
     const locale = event.currentTarget.dataset.locale
 
-    trackUserAction("UserManuallySwitchedLanguage", {
+    trackUserAction("ApplicantManuallySwitchedLanguage", {
       locale: locale,
     })
   }

--- a/app/app/javascript/controllers/language_controller.js
+++ b/app/app/javascript/controllers/language_controller.js
@@ -5,12 +5,9 @@ import { trackUserAction } from "../utilities/api"
 export default class extends Controller {
   switchLocale(event) {
     const locale = event.currentTarget.dataset.locale
-    const previousLocale = document.documentElement.lang
 
     trackUserAction("UserManuallySwitchedLanguage", {
       locale: locale,
-      previous_locale: previousLocale,
-      current_locale: previousLocale,
     })
   }
 }

--- a/app/app/views/application/_header.html.erb
+++ b/app/app/views/application/_header.html.erb
@@ -6,7 +6,7 @@
     </div>
   </header>
 <% end %>
-<header class="usa-header usa-header--basic" aria-label="<%= t("shared.header.aria_label") %>">
+<header class="usa-header usa-header--basic" aria-label="<%= t("shared.header.aria_label") %>" data-controller="language">
   <div class="usa-nav-container">
     <div class="usa-navbar">
       <div class="usa-logo">

--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -11,7 +11,7 @@ class GenericEventTracker
         ip: request.remote_ip,
         cbv_flow_id: request.session[:cbv_flow_id],
         client_agency_id: url_params["client_agency_id"],
-        locale: url_params["locale"],
+        locale: url_params["locale"] || I18n.locale.to_s,
         user_agent: request.headers["User-Agent"]
       }
     end

--- a/app/spec/controllers/api/user_events_controller_spec.rb
+++ b/app/spec/controllers/api/user_events_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Api::UserEventsController, type: :controller do
     end
 
     context "when tracking a UserManuallySwitchedLanguage event" do
-      let(:event_name) { "UserManuallySwitchedLanguage" }
+      let(:event_name) { "ApplicantManuallySwitchedLanguage" }
       let(:event_attributes) do
         {
           locale: "es"

--- a/app/spec/controllers/api/user_events_controller_spec.rb
+++ b/app/spec/controllers/api/user_events_controller_spec.rb
@@ -209,5 +209,34 @@ RSpec.describe Api::UserEventsController, type: :controller do
         post :user_action, params: valid_params
       end
     end
+
+    context "when tracking a UserManuallySwitchedLanguage event" do
+      let(:event_name) { "UserManuallySwitchedLanguage" }
+      let(:event_attributes) do
+        {
+          locale: "es"
+        }
+      end
+
+      it "tracks an event with Mixpanel" do
+        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("UserManuallySwitchedLanguage", anything, hash_including(
+          timestamp: be_a(Integer),
+          cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          locale: "es"
+        ))
+        post :user_action, params: valid_params
+      end
+
+      it "tracks an event with NewRelic" do
+        expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("UserManuallySwitchedLanguage", anything, hash_including(
+          timestamp: be_a(Integer),
+          cbv_flow_id: cbv_flow.id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          locale: "es"
+        ))
+        post :user_action, params: valid_params
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves [FFS-2779](https://jiraent.cms.gov/browse/FFS-2779).


## Changes
**Adds:**
- Stimulus controller for language
- Mixpanel tracking when users switch languages in the header 
- Locale in all Mixpanel events, even without locale in url
- Events testing

**Testing:**
- Visit CBV entry
- Swap between Spanish and English
- Verify "UserManuallySwitchedLanguage" appears in log stream 
- Check all Mixpanel events have proper locale

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
**Before**
  <img width="1503" alt="Screenshot 2025-04-18 at 2 07 25 PM" src="https://github.com/user-attachments/assets/e11276f3-db22-4600-9fff-c91f7dc1d2ec" />
**After**
<img width="1509" alt="Screenshot 2025-04-18 at 2 08 30 PM" src="https://github.com/user-attachments/assets/1e4b4252-8c45-41e3-97ae-ee9f3ca2f4fa" />

<img width="1494" alt="Screenshot 2025-04-18 at 2 04 32 PM" src="https://github.com/user-attachments/assets/2dd4480e-3a51-4a3c-a0a7-97381a0e3e92" />