### PR TITLE
FFS-2784: Update /synchronizations to only wait for a partial sync of 90 days

### DIFF
--- a/app/app/services/aggregators/sdk/argyle_service.rb
+++ b/app/app/services/aggregators/sdk/argyle_service.rb
@@ -71,11 +71,12 @@ module Aggregators::Sdk
       @http.get(build_url(WEBHOOKS_ENDPOINT)).body
     end
 
-    def create_webhook_subscription(events, url, name)
+    def create_webhook_subscription(events, url, name, config = {})
       payload = {
         events: events,
         name: name,
         url: url,
+        config: config.presence,
         secret: @webhook_secret
       }
 

--- a/app/app/services/argyle_webhooks_manager.rb
+++ b/app/app/services/argyle_webhooks_manager.rb
@@ -1,48 +1,92 @@
-# This class manages Argyle webhook subscriptions, and is intended for
-# development environment setup only
+# This class subscribes to Argyle webhooks, and is intended for regular use in
+# the development environment only.
 #
-# The webhooks will be registered in the Argyle environment listed under the
-# "sandbox" site in site-config.yml.
+# It may also be useful in demo/production when converting a client agency
+# config to run in that environment for the first time, e.g. if we just
+# configured AZ DES to use the production Argyle configuration and need to set
+# up the webhooks, we could run:
+#
+#   a = ArgyleWebhooksManager.new("az_des")
+#   a.create_subscriptions_if_necessary(ENV["DOMAIN_NAME"], "production")
+#
+# The webhooks will be registered based on the Argyle environment specified in the
+# "az_des" configuration in client-agency-config.yml.
 class ArgyleWebhooksManager
-  def initialize
-    @sandbox_config = Rails.application.config.client_agencies["sandbox"]
-    @argyle = Aggregators::Sdk::ArgyleService.new(@sandbox_config.argyle_environment)
+  def initialize(agency_id: "sandbox", logger: STDOUT)
+    @agency_config = Rails.application.config.client_agencies[agency_id]
+    @argyle = Aggregators::Sdk::ArgyleService.new(@agency_config.argyle_environment)
+    @logger = logger
   end
 
   def existing_subscriptions_with_name(name)
-    @subscriptions = @argyle.get_webhook_subscriptions["results"]
-    @subscriptions.find_all { |subscription| subscription["name"] == name }
+    existing_subscriptions.find_all { |subscription| subscription["name"] == name }
   end
 
   def remove_subscriptions(subscriptions)
     subscriptions.each do |subscription|
-      puts "  Removing existing Argyle webhook subscription (url = #{subscription["url"]})"
+      @logger.puts "  Removing existing Argyle webhook subscription (url = #{subscription["url"]})"
       @argyle.delete_webhook_subscription(subscription["id"])
     end
   end
 
-  def create_subscription_if_necessary(tunnel_url, name)
+  def create_subscriptions_if_necessary(tunnel_url, name)
+    raise "You must provide a name value!" unless name.present?
+
     receiver_url = URI.join(tunnel_url, "/webhooks/argyle/events").to_s
+
+    create_subscription(receiver_url, name, :non_partial)
+    create_subscription(receiver_url, "#{name}-partial", :partial)
+  end
+
+  private
+
+  def existing_subscriptions
+    @_existing_subscriptions ||= @argyle.get_webhook_subscriptions["results"]
+  end
+
+  def create_subscription(receiver_url, name, webhooks_type)
     subscriptions = existing_subscriptions_with_name(name)
     existing_subscription = subscriptions.find do |subscription|
-      subscription["url"] == receiver_url && subscription["events"] == Aggregators::Webhooks::Argyle.get_webhook_events
+      subscription["url"] == receiver_url &&
+        subscription["events"] == Aggregators::Webhooks::Argyle.get_webhook_events(type: webhooks_type)
     end
 
     if existing_subscription
-      puts "  Existing Argyle webhook subscription found in Argyle #{@sandbox_config.argyle_environment}: #{existing_subscription["url"]}"
+      @logger.puts "  Existing Argyle webhook subscription found in Argyle #{@agency_config.argyle_environment}: #{existing_subscription["url"]}"
       remove_subscriptions(subscriptions.excluding(existing_subscription))
 
       existing_subscription["id"]
     else
       remove_subscriptions(subscriptions)
 
-      puts "  Registering Argyle webhooks for Ngrok tunnel in Argyle #{@sandbox_config.argyle_environment}..."
-      response = @argyle.create_webhook_subscription(Aggregators::Webhooks::Argyle.get_webhook_events, receiver_url, name)
+      @logger.puts "  Registering Argyle webhooks for Ngrok tunnel in Argyle #{@agency_config.argyle_environment}..."
+      response = @argyle.create_webhook_subscription(
+        Aggregators::Webhooks::Argyle.get_webhook_events(type: webhooks_type),
+        receiver_url,
+        name,
+        webhook_subscription_config(webhooks_type)
+      )
       new_webhook_subscription_id = response["id"]
-      puts "  ✅ Set up Argyle webhook: #{new_webhook_subscription_id}"
-      puts " Argyle webhook url: #{receiver_url}"
+      @logger.puts "  ✅ Set up Argyle webhook: #{new_webhook_subscription_id}"
+      @logger.puts " Argyle webhook url: #{receiver_url}"
 
       new_webhook_subscription_id
     end
+  end
+
+  def webhook_subscription_config(webhooks_type)
+    return nil if webhooks_type == :non_partial
+
+    # Configure the `paystubs.partially_synced` and `gigs.partially_synced`
+    # webhooks to trigger early based on the largest value of pay_income_days.
+    #
+    # We may want to eventually create webhook subscriptions for every value of
+    # pay_income_days, so that agencies with shorter amounts of required data
+    # can benefit from a quicker sync.
+    largest_pay_income_days = Rails.application.config.client_agencies.client_agency_ids.map do |agency_id|
+      Rails.application.config.client_agencies[agency_id].pay_income_days
+    end.compact.max
+
+    { days_synced: largest_pay_income_days }
   end
 end

--- a/app/config/initializers/ngrok_development.rb
+++ b/app/config/initializers/ngrok_development.rb
@@ -21,7 +21,7 @@ Rails.application.config.to_prepare do
       if ProviderSearchService::SUPPORTED_PROVIDERS.include?(:argyle)
         # Argyle webhooks setup
         argyle_webhooks = ArgyleWebhooksManager.new
-        argyle_webhooks.create_subscription_if_necessary(tunnel_url, subscription_name)
+        argyle_webhooks.create_subscriptions_if_necessary(tunnel_url, subscription_name)
       end
     rescue => ex
       Rails.application.config.webhooks_initialization_error = ex.message

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
         process_webhook("users.fully_synced")
         expect(payroll_account.webhook_events.count).to eq(3)
 
-        process_webhook("gigs.fully_synced")
+        process_webhook("gigs.partially_synced")
         expect(payroll_account.webhook_events.count).to eq(4)
 
-        process_webhook("paystubs.fully_synced")
+        process_webhook("paystubs.partially_synced")
         expect(payroll_account.webhook_events.count).to eq(5)
 
         # expect the PayrollAccount to be fully synced
@@ -147,7 +147,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
         process_webhook("accounts.connected")
         process_webhook("identities.added")
         process_webhook("users.fully_synced")
-        process_webhook("gigs.fully_synced")
+        process_webhook("gigs.partially_synced")
 
         expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
           expect(event_name).to eq("ApplicantFinishedArgyleSync")
@@ -208,19 +208,19 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
           )
         end
 
-        process_webhook("paystubs.fully_synced")
+        process_webhook("paystubs.partially_synced")
       end
 
       it 'tracks an ApplicantReportMetUsefulRequirements event' do
         process_webhook("accounts.connected")
         process_webhook("identities.added")
         process_webhook("users.fully_synced")
-        process_webhook("gigs.fully_synced")
+        process_webhook("gigs.partially_synced")
 
         expect(fake_event_logger).to receive(:track)
            .with("ApplicantReportMetUsefulRequirements", anything, anything).exactly(1).times
 
-        process_webhook("paystubs.fully_synced")
+        process_webhook("paystubs.partially_synced")
       end
     end
   end

--- a/app/spec/factories/webhook_request.rb
+++ b/app/spec/factories/webhook_request.rb
@@ -52,6 +52,19 @@ FactoryBot.define do
                 }
               }
             }
+          when "paystubs.partially_synced"
+            {
+              "event" => evaluator.event_type,
+              "name" => evaluator.user,
+              "data" => {
+                "account" => evaluator.argyle_account_id,
+                "user" => evaluator.argyle_user_id,
+                "available_from" => 30.days.ago.iso8601,
+                "available_to" => 1.day.ago.iso8601,
+                "available_count" => 16,
+                "days_synced" => 30
+              }
+            }
           when "paystubs.fully_synced"
             {
               "event" => evaluator.event_type,
@@ -62,6 +75,20 @@ FactoryBot.define do
                 "available_from" => 3.years.ago.iso8601,
                 "available_to" => 1.year.from_now.iso8601,
                 "available_count" => 153
+              }
+            }
+          when "gigs.partially_synced"
+            {
+              "event" => evaluator.event_type,
+              "name" => evaluator.user,
+              "data" => {
+                "account" => evaluator.argyle_account_id,
+                "user" => evaluator.argyle_user_id,
+                "item_id" => "item_000041078",
+                "available_from" => 30.days.ago.iso8601,
+                "available_to" => 1.days.ago.iso8601,
+                "available_count" => 16,
+                "days_synced" => 30
               }
             }
           when "gigs.fully_synced"
@@ -76,6 +103,8 @@ FactoryBot.define do
                 "available_count" => 2503
               }
             }
+          else
+            raise "No webhook request factory defined for type = #{evaluator.event_type}"
           end
 
         # Generate Argyle signature using the service

--- a/app/spec/models/payroll_account/argyle_spec.rb
+++ b/app/spec/models/payroll_account/argyle_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe PayrollAccount::Argyle, type: :model do
     describe '#has_required_data?' do
       it 'returns true when paystubs succeeded' do
         account = create(:payroll_account, :argyle, cbv_flow: cbv_flow)
-        create(:webhook_event, payroll_account: account, event_name: 'paystubs.fully_synced', event_outcome: 'success')
+        create(:webhook_event, payroll_account: account, event_name: 'paystubs.partially_synced', event_outcome: 'success')
 
         expect(account.has_required_data?).to be true
       end
 
       it 'returns true when gigs succeeded' do
         account = create(:payroll_account, :argyle, cbv_flow: cbv_flow)
-        create(:webhook_event, payroll_account: account, event_name: 'gigs.fully_synced', event_outcome: 'success')
+        create(:webhook_event, payroll_account: account, event_name: 'gigs.partially_synced', event_outcome: 'success')
 
         expect(account.has_required_data?).to be true
       end

--- a/app/spec/services/aggregators/sdk/argyle_service_spec.rb
+++ b/app/spec/services/aggregators/sdk/argyle_service_spec.rb
@@ -267,6 +267,7 @@ RSpec.describe Aggregators::Sdk::ArgyleService, type: :service do
         events: events,
         name: name,
         url: url,
+        config: nil,
         secret: webhook_secret
       }
     end

--- a/app/spec/services/aggregators/webhooks/argyle_spec.rb
+++ b/app/spec/services/aggregators/webhooks/argyle_spec.rb
@@ -13,8 +13,35 @@ RSpec.describe Aggregators::Webhooks::Argyle, type: :service do
   end
 
   describe '.get_webhook_events' do
-    it 'returns array of supported webhook events' do
-      expect(described_class.get_webhook_events).to eq(described_class::SUBSCRIBED_WEBHOOK_EVENTS.keys)
+    let(:expected_non_partial_events) do
+      %w[
+        identities.added
+        accounts.connected
+        users.fully_synced
+        paystubs.fully_synced
+        gigs.fully_synced
+      ]
+    end
+
+    let(:expected_partial_events) do
+      %w[
+        paystubs.partially_synced
+        gigs.partially_synced
+      ]
+    end
+
+    it 'returns array of non-partial webhook events by default' do
+      expect(described_class.get_webhook_events).to match_array(expected_non_partial_events)
+    end
+
+    it 'returns array of partial webhook events with type = :partial' do
+      expect(described_class.get_webhook_events(type: :partial)).to match_array(expected_partial_events)
+    end
+
+    it 'returns array of all webhook events with type = :all' do
+      expect(described_class.get_webhook_events(type: :all)).to match_array(
+        expected_non_partial_events + expected_partial_events
+      )
     end
   end
 

--- a/app/spec/services/argyle_webhooks_manager_spec.rb
+++ b/app/spec/services/argyle_webhooks_manager_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
 
   let(:ngrok_url) { 'https://ngrok-url.com' }
   let(:webhook_name) { 'test_webhook' }
+  let(:test_logger) { StringIO.new }
   let(:all_webhook_subscriptions) do
     argyle_load_relative_json_file('', 'response_get_webhook_subscriptions.json')['results']
   end
@@ -15,13 +16,14 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
   let(:argyle_webhooks_manager) do
     # Allow the test to use our mocked ArgyleService
     allow(Aggregators::Sdk::ArgyleService).to receive(:new).and_return(argyle_service)
-    described_class.new
+    described_class.new(logger: test_logger)
   end
   let(:create_webhook_subscription_response) { argyle_load_relative_json_file('', 'response_create_webhook_subscription.json') }
   # Define sandbox_config as a let variable for easier access in tests
   let(:sandbox_config) { double("SandboxConfig", argyle_environment: "sandbox") }
   # Define the webhook events
-  let(:webhook_events) { Aggregators::Webhooks::Argyle.get_webhook_events }
+  let(:non_partial_webhook_events) { Aggregators::Webhooks::Argyle.get_webhook_events(type: :non_partial) }
+  let(:partial_webhook_events) { Aggregators::Webhooks::Argyle.get_webhook_events(type: :partial) }
 
   before do
     # use our stubbed data for the response
@@ -66,7 +68,7 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
     end
   end
 
-  describe '#create_subscription_if_necessary' do
+  describe '#create_subscriptions_if_necessary' do
     context 'when the subscription does not exist' do
       it 'creates a new subscription when there is no matching subscription' do
         receiver_url = URI.join(ngrok_url, "/webhooks/argyle/events").to_s
@@ -78,6 +80,8 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
         )
 
         allow(argyle_webhooks_manager).to receive(:existing_subscriptions_with_name)
+          .and_return([])
+        allow(argyle_webhooks_manager).to receive(:existing_subscriptions_with_name)
           .with(webhook_name)
           .and_return([ existing_sub ])
 
@@ -85,18 +89,26 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
           existing_sub["id"]
         )
 
-        expect(STDOUT).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = https://different-url.ngrok.io/webhooks/argyle/events)")
-        expect(STDOUT).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...")
-        expect(STDOUT).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}")
-        expect(STDOUT).to receive(:puts).with(" Argyle webhook url: #{receiver_url}")
+        expect(test_logger).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = https://different-url.ngrok.io/webhooks/argyle/events)")
+        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...").twice
+        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}").twice
+        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}").twice
 
         expect(argyle_service).to receive(:create_webhook_subscription).with(
-          webhook_events,
+          non_partial_webhook_events,
           receiver_url,
-          webhook_name
+          webhook_name,
+          nil
         ).and_return(create_webhook_subscription_response)
 
-        result = argyle_webhooks_manager.create_subscription_if_necessary(ngrok_url, webhook_name)
+        expect(argyle_service).to receive(:create_webhook_subscription).with(
+          partial_webhook_events,
+          receiver_url,
+          webhook_name + "-partial",
+          { days_synced: 90 }
+        ).and_return(create_webhook_subscription_response)
+
+        result = argyle_webhooks_manager.create_subscriptions_if_necessary(ngrok_url, webhook_name)
         expect(result).to eq(create_webhook_subscription_response["id"])
       end
 
@@ -107,29 +119,36 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
           "id" => "matching-subscription-id",
           "name" => webhook_name,
           "url" => receiver_url,
-          "events" => webhook_events
+          "events" => non_partial_webhook_events
         }
 
         other_sub = {
           "id" => "other-subscription-id",
           "name" => webhook_name,
           "url" => "https://old-url.ngrok.io/webhooks/argyle/events",
-          "events" => webhook_events
+          "events" => non_partial_webhook_events
         }
 
+        allow(argyle_webhooks_manager).to receive(:existing_subscriptions_with_name)
+          .and_return([])
         allow(argyle_webhooks_manager).to receive(:existing_subscriptions_with_name)
           .with(webhook_name)
           .and_return([ matching_sub, other_sub ])
 
-        expect(STDOUT).to receive(:puts).with("  Existing Argyle webhook subscription found in Argyle sandbox: #{receiver_url}")
-        expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([ other_sub ]).and_call_original
-        expect(STDOUT).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = #{other_sub["url"]})")
+        expect(test_logger).to receive(:puts).with("  Existing Argyle webhook subscription found in Argyle sandbox: #{receiver_url}")
+        expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([ other_sub ]).and_call_original # non-partial
+        expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([]).and_call_original # no subscriptions for partial webhooks
+        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...")
+        expect(test_logger).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = #{other_sub["url"]})")
+        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}")
+        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}")
         expect(argyle_service).to receive(:delete_webhook_subscription).with(other_sub["id"])
         # Should NOT create a new subscription since we're reusing existing
-        expect(argyle_service).not_to receive(:create_webhook_subscription)
+        expect(argyle_service).not_to receive(:create_webhook_subscription).with(array_including("paystubs.fully_synced"), anything, anything, anything)
+        # But it will create a subscription for the partially synced webhooks, since we didn't set it up earlier in the test
+        expect(argyle_service).to receive(:create_webhook_subscription).with(array_including("paystubs.partially_synced"), anything, anything, anything)
 
-        result = argyle_webhooks_manager.create_subscription_if_necessary(ngrok_url, webhook_name)
-        expect(result).to eq(matching_sub["id"])
+        argyle_webhooks_manager.create_subscriptions_if_necessary(ngrok_url, webhook_name)
       end
     end
   end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2784](https://jiraent.cms.gov/browse/FFS-2784).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Allow passing in `config` when creating Argyle webhook subscriber**
> The config hash is useful for providing the `days_synced` argument to be
> able to register partially-synced events. This will be useful later for
> us for real. For now, this was just a testing thing that helped me out.

**Wait for Argyle `partially_synced` events (rather than `fully_synced`)**
> The Argyle sync anecdotally takes a very long time, and especially for
> gig accounts that have been open for a while (even if there isn't
> activity going back very far). We want to take advantage of Argyle's
> `paystubs.partially_synced` and `gigs.partially_synced` to allow the
> user to proceed to the /payment-details page even if the account may
> still technically be syncing in the background.

> This raises some complexity: the `partially_synced` webhooks must be
> registered with a "config" parameter specifying the definition of
> "partial" - i.e. `{ "days_synced": 90 }` for the partially_synced
> webhook to trigger after >= 90 days have synced.

> So, we need to update the ArgyleWebhooksManager to manage *two* webhook
> subscriptions now - a "partial" webhook for these new events, and a
> "non-partial" webhook for the others.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
