### PR TITLE
 FFS-2750: add ability to see the dashboard across environments

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -29,3 +29,6 @@ NYC_HRA_EMAIL=test@email.com
 # we've seen minor visual discrepancies in the page headers/footers across
 # different versions of wkhtmltopdf.)
 USE_SYSTEM_WKHTMLTOPDF=false
+
+MISSION_CONTROL_USER=user
+MISSION_CONTROL_PASSWORD=password

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -55,6 +55,9 @@ gem "mixpanel-ruby"
 gem "newrelic_rpm"
 
 gem "solid_queue"
+# dashboard to manage solid queue
+gem "mission_control-jobs"
+
 
 gem "faraday", "~> 2.9.0"
 
@@ -91,7 +94,6 @@ group :development, :test do
   gem "rubocop-rails-omakase"
   gem "selenium-webdriver"
   gem "timecop"
-  gem "mission_control-jobs"
 end
 
 group :development do

--- a/app/config/environment.rb
+++ b/app/config/environment.rb
@@ -1,5 +1,15 @@
 # Load the Rails application.
 require_relative "application"
 
+
 # Initialize the Rails application.
 Rails.application.initialize!
+
+Rails.application.config.after_initialize do
+  # Your code here
+  # You can call services, start background tasks, preload data, etc.
+  # if the password is not defined, Mission Control will 401
+  # TODO once we're on rails credentials, remove this and replace with rails creds
+  MissionControl::Jobs.http_basic_auth_user = ENV["MISSION_CONTROL_USER"]
+  MissionControl::Jobs.http_basic_auth_password = ENV["MISSION_CONTROL_PASSWORD"]
+end

--- a/app/config/environment.rb
+++ b/app/config/environment.rb
@@ -4,12 +4,3 @@ require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!
-
-Rails.application.config.after_initialize do
-  # Your code here
-  # You can call services, start background tasks, preload data, etc.
-  # if the password is not defined, Mission Control will 401
-  # TODO once we're on rails credentials, remove this and replace with rails creds
-  MissionControl::Jobs.http_basic_auth_user = ENV["MISSION_CONTROL_USER"]
-  MissionControl::Jobs.http_basic_auth_password = ENV["MISSION_CONTROL_PASSWORD"]
-end

--- a/app/config/environments/development.rb
+++ b/app/config/environments/development.rb
@@ -11,8 +11,6 @@ Rails.application.configure do
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-  config.mission_control.jobs.http_basic_auth_enabled = false
-
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/app/config/initializers/mission_control.rb
+++ b/app/config/initializers/mission_control.rb
@@ -1,0 +1,6 @@
+Rails.application.config.after_initialize do
+  # if the password is not defined, Mission Control will 401
+  # TODO once we're on rails credentials, remove this and replace with rails creds
+  MissionControl::Jobs.http_basic_auth_user = ENV["MISSION_CONTROL_USER"]
+  MissionControl::Jobs.http_basic_auth_password = ENV["MISSION_CONTROL_PASSWORD"]
+end

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -82,9 +82,7 @@ Rails.application.routes.draw do
     end
   end
 
-  if Rails.env.development?
-    mount MissionControl::Jobs::Engine, at: "/jobs"
-  end
+  mount MissionControl::Jobs::Engine, at: "/jobs"
 
   match "/404", to: "pages#error_404", via: :all
   match "/500", to: "pages#error_500", via: :all

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -35,6 +35,14 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/rails-master-key"
     },
+    MISSION_CONTROL_USER = {
+     manage_method     = "manual"
+     secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-user"
+    },
+    MISSION_CONTROL_PASSWORD = {
+     manage_method     = "manual"
+     secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-password"
+    },
     SLACK_TEST_EMAIL = {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/slack-test-email"

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -36,12 +36,12 @@ locals {
       secret_store_name = "/service/${var.app_name}-${var.environment}/rails-master-key"
     },
     MISSION_CONTROL_USER = {
-     manage_method     = "manual"
-     secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-user"
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-user"
     },
     MISSION_CONTROL_PASSWORD = {
-     manage_method     = "manual"
-     secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-password"
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/mission-control-password"
     },
     SLACK_TEST_EMAIL = {
       manage_method     = "manual"


### PR DESCRIPTION
by default, the jobs dashboard engine we use leverages rails credentials. This trick lets us hook into the configuration directly instead so we can inject environment variables, since I don't think we have time right now to refactor into rails creds.



## Acceptance testing
<!-- Check one: -->

- [ X] Acceptance testing prior to merge
set MISSION_CONTROL_USER and MISSION_CONTROL_PASSWORD environment variables
run locally (bin/start_dev)
visit localhost:3000/jobs, putting in user/password you defined earlier.
if the page loads with a job dashboard, success!