### PR TITLE
FFS-2729: re-link continue button to applicant info page in case they want to continue forward

### DIFF
--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -38,11 +38,7 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
   def redirect_when_info_present
     return if params[:force_show] == "true"
 
-    missing_attrs = @cbv_applicant.required_applicant_attributes.reject do |attr|
-      @cbv_applicant.send(attr).present?
-    end
-
-    redirect_to next_path if missing_attrs.empty?
+    redirect_to next_path unless @cbv_applicant.has_applicant_attribute_missing?
   end
 
   def redirect_when_in_invitation_flow

--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -47,6 +47,12 @@ class CbvApplicant < ApplicationRecord
     snap_application_date: :date
   )
 
+  def has_applicant_attribute_missing?
+    @required_applicant_attributes.any? do |attr|
+      self[attr].nil?
+    end
+  end
+
   def validate_required_applicant_attributes
     missing_attrs = @required_applicant_attributes.reject do |attr|
       self.send(attr).present?

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -66,8 +66,8 @@
     </div>
 
       <% if @has_payroll_account %>
-        <%= link_to t("cbv.employer_searches.show.review_button_text"), cbv_flow_summary_path, class: "usa-button usa-button--outline margin-top-5", data: { turbo_frame: "_top" } %>
-      <% else %>
+        <%= link_to t("cbv.employer_searches.show.review_button_text"), cbv_flow_applicant_information_path, class: "usa-button usa-button--outline margin-top-5", data: { turbo_frame: "_top" } %>
+     <% else %>
         <%= link_to t("cbv.employer_searches.show.exit_button_text", agency_short_name: current_agency.agency_short_name), current_agency.agency_contact_website, class: "usa-button usa-button--outline margin-top-5", data: { turbo_frame: "_top" } %>
       <% end %>
 

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -301,7 +301,7 @@ en:
         payroll_providers: Payroll providers
         popular_providers: Or choose from popular payroll providers or apps
         results: Results
-        review_button_text: Review my income report
+        review_button_text: Continue
         search: Search
         search_label: 'Enter the name of your current or recent employer or payroll provider:'
         select: Select
@@ -314,7 +314,7 @@ en:
           sandbox: <a href="https://example.com/contact">Go to CBV's website</a> to learn about other ways to report your income.
         to_continue_li_2: If you have other jobs to add, search for them.
         to_continue_li_3: If you have no other jobs to add here, you can exit this site.
-        to_continue_li_3_continue: If you have no other jobs to add here, continue to review your income report.
+        to_continue_li_3_continue: If you have no other jobs to add here, continue.
     entries:
       create:
         error: You must check the agreement checkbox to proceed.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -301,7 +301,7 @@ en:
         payroll_providers: Payroll providers
         popular_providers: Or choose from popular payroll providers or apps
         results: Results
-        review_button_text: Finish adding jobs
+        review_button_text: Continue
         search: Search
         search_label: 'Enter the name of your current or recent employer or payroll provider:'
         select: Select
@@ -314,7 +314,7 @@ en:
           sandbox: <a href="https://example.com/contact">Go to CBV's website</a> to learn about other ways to report your income.
         to_continue_li_2: If you have other jobs to add, search for them.
         to_continue_li_3: If you have no other jobs to add here, you can exit this site.
-        to_continue_li_3_continue: If you have no other jobs to add here, continue.
+        to_continue_li_3_continue: If you have no other jobs to add here, continue to complete your income report.
     entries:
       create:
         error: You must check the agreement checkbox to proceed.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -301,7 +301,7 @@ en:
         payroll_providers: Payroll providers
         popular_providers: Or choose from popular payroll providers or apps
         results: Results
-        review_button_text: Continue
+        review_button_text: Finish adding jobs
         search: Search
         search_label: 'Enter the name of your current or recent employer or payroll provider:'
         select: Select

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -147,7 +147,7 @@ es:
         payroll_providers: Proveedores de nómina
         popular_providers: O elija entre los proveedores o aplicaciones de nómina más populares
         results: Resultados
-        review_button_text: Revisar mi informe de ingresos
+        review_button_text: Terminar de agregar trabajos
         search: Buscar
         search_label: 'Ingrese el nombre de su empleador actual o reciente o su proveedor de nómina:'
         select: Seleccione
@@ -160,7 +160,7 @@ es:
           sandbox: <a href="https://example.com/contact">Vaya al sitio web del CBV</a> para informarse de otras formas de notificar sus ingresos.
         to_continue_li_2: Si tiene otros trabajos que añadir, búsquelos.
         to_continue_li_3: Si no tiene otros trabajos que añadir aquí, puede salir de este sitio.
-        to_continue_li_3_continue: Si no tiene otros trabajos que añadir aquí, continúe a revisar su informe de ingresos.
+        to_continue_li_3_continue: Si no tiene otros trabajos que añadir aquí, continúe.
     entries:
       create:
         error: Debe marcar la casilla de «acuerdo» para proceder.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -147,7 +147,7 @@ es:
         payroll_providers: Proveedores de nómina
         popular_providers: O elija entre los proveedores o aplicaciones de nómina más populares
         results: Resultados
-        review_button_text: Terminar de agregar trabajos
+        review_button_text: Continuar
         search: Buscar
         search_label: 'Ingrese el nombre de su empleador actual o reciente o su proveedor de nómina:'
         select: Seleccione
@@ -160,7 +160,7 @@ es:
           sandbox: <a href="https://example.com/contact">Vaya al sitio web del CBV</a> para informarse de otras formas de notificar sus ingresos.
         to_continue_li_2: Si tiene otros trabajos que añadir, búsquelos.
         to_continue_li_3: Si no tiene otros trabajos que añadir aquí, puede salir de este sitio.
-        to_continue_li_3_continue: Si no tiene otros trabajos que añadir aquí, continúe.
+        to_continue_li_3_continue: Si no tiene otros trabajos que añadir aquí, continúe a revisar su informe de ingresos.
     entries:
       create:
         error: Debe marcar la casilla de «acuerdo» para proceder.

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -106,8 +106,9 @@ RSpec.describe Cbv::EmployerSearchesController do
           create(:payroll_account, cbv_flow_id: cbv_flow.id)
           get :show, params: { query: "no_results" }
           expect(response).to be_successful
-          expect(response.body).to include("continue to review your income report")
-          expect(response.body).to include("Review my income report")
+          expect(response.body).to include("If you have no other jobs to add here, continue")
+          expect(response.body).to include("Continue")
+          expect(response.body).to include(cbv_flow_applicant_information_path)
         end
       end
 

--- a/app/spec/models/cbv_applicant_spec.rb
+++ b/app/spec/models/cbv_applicant_spec.rb
@@ -9,6 +9,27 @@ RSpec.describe CbvApplicant, type: :model do
     end
   end
 
+  describe "#has_applicant_attribute_missing?" do
+    before do
+      allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
+        { first_name: "required" }
+      )
+    end
+
+    let(:cbv_applicant) { create(:cbv_applicant, first_name: nil) }
+    it "returns true if a field missing" do
+      cbv_applicant.set_applicant_attributes
+      expect(cbv_applicant.required_applicant_attributes).to be_present
+      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(true)
+    end
+
+    it "returns false if a field not missing" do
+      cbv_applicant.set_applicant_attributes
+      cbv_applicant.first_name = "Dean Venture"
+      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(false)
+    end
+  end
+
   describe "validations" do
     let(:valid_attributes) { attributes_for(:cbv_applicant, :nyc) }
 


### PR DESCRIPTION
Changes
Links the next link on the missing results page such that it would proceed to the application information page, which they will need to fill out if in the LA flow. The application controller already checks if it is unnecessary to be there, so won't hurt non-LA flows while avoiding too much spreading logic.

Context for reviewers
In the future, there might be need for different action text. For now, a talk with design says they're ok with this language for now.

Testing instructions
  * With an LA applicant, get one payroll account added, then search and fail to find a second payroll account. Click the button--> direct to the applicant information page.

## Acceptance testing
<!-- Check one: -->

- [ X] Acceptance testing prior to merge
  * With an LA applicant, get one payroll account added, then search and fail to find a second payroll account. Click the button--> direct to the applicant information page.