### PR TITLE
 FFS-2754: finish extracting out maybe later

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -78,8 +78,6 @@ gem "pdf-reader", "~> 2.12.0"
 gem "net-imap", "0.4.20"  # Fixing GHSA-j3g3-5qv5-52m
 gem "cgi", ">= 0.4.2"     # Fixing GHSA-mhwm-jh88-3gjf
 
-gem "maybe_later"
-
 group :development, :test do
   gem "brakeman", "~> 5.2"
   gem "bundler-audit", "~> 0.9"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -246,9 +246,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    maybe_later (0.0.4)
-      concurrent-ruby (~> 1.1.9)
-      railties (>= 6.0.0)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
@@ -558,7 +555,6 @@ DEPENDENCIES
   i18n-tasks (~> 1.0)
   jbuilder
   jsbundling-rails
-  maybe_later
   mission_control-jobs
   mixpanel-ruby
   net-imap (= 0.4.20)

--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -64,12 +64,7 @@ class Cbv::SubmitsController < Cbv::BaseController
       @cbv_flow.update!(confirmation_code: confirmation_code)
     end
 
-    if ENV["ACTIVEJOB_ENABLED"] == "true"
-      CaseWorkerTransmitterJob.perform_later(@cbv_flow.id)
-    else
-      CaseWorkerTransmitterJob.perform_now(@cbv_flow.id)
-    end
-
+    CaseWorkerTransmitterJob.perform_later(@cbv_flow.id)
     redirect_to next_path
   end
 

--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -8,13 +8,7 @@ class GenericEventTracker
     else
       request_data = nil
     end
-    if ENV["ACTIVEJOB_ENABLED"] == "true"
-      EventTrackingJob.perform_later(event_type, request_data, merged_attributes)
-    else
-      MaybeLater.run do
-        EventTrackingJob.perform_now(event_type, request_data, merged_attributes)
-      end
-    end
+    EventTrackingJob.perform_later(event_type, request_data, merged_attributes)
   end
 
   private

--- a/app/lib/new_relic_event_tracker.rb
+++ b/app/lib/new_relic_event_tracker.rb
@@ -30,7 +30,6 @@ class NewRelicEventTracker
     # Map to the old NewRelic event name if present, otherwise just send NewRelic the event_type name
     newrelic_event_type = NEWRELIC_EVENT_MAP[event_type] || event_type
 
-    # MaybeLater tries to run this code after the request has finished
     start_time = Time.now
     Rails.logger.info "  Sending NewRelic event #{newrelic_event_type} with attributes: #{attributes}"
     NewRelic::Agent.record_custom_event(newrelic_event_type, attributes)

--- a/app/spec/controllers/api/argyle_controller_spec.rb
+++ b/app/spec/controllers/api/argyle_controller_spec.rb
@@ -28,19 +28,7 @@ RSpec.describe Api::ArgyleController do
       end
 
       it "tracks a Mixpanel event" do
-        expect_any_instance_of(MixpanelEventTracker)
-          .to receive(:track)
-          .with("ApplicantBeganLinkingEmployer", anything, hash_including(
-            cbv_flow_id: cbv_flow.id,
-            invitation_id: cbv_flow.cbv_flow_invitation_id,
-          ))
-        post :create
-      end
-
-      it "tracks a NewRelic event" do
-        expect_any_instance_of(NewRelicEventTracker)
-          .to receive(:track)
-          .with("ApplicantBeganLinkingEmployer", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantBeganLinkingEmployer", anything, hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
           ))

--- a/app/spec/controllers/api/pinwheel_controller_spec.rb
+++ b/app/spec/controllers/api/pinwheel_controller_spec.rb
@@ -24,20 +24,7 @@ RSpec.describe Api::PinwheelController do
     end
 
     it "tracks a Mixpanel event" do
-      expect_any_instance_of(MixpanelEventTracker)
-        .to receive(:track)
-        .with("ApplicantBeganLinkingEmployer", anything, hash_including(
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id,
-          response_type: "employer",
-        ))
-      post :create_token, params: valid_params
-    end
-
-    it "tracks a NewRelic event" do
-      expect_any_instance_of(NewRelicEventTracker)
-        .to receive(:track)
-        .with("ApplicantBeganLinkingEmployer", anything, hash_including(
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantBeganLinkingEmployer", anything, hash_including(
           cbv_flow_id: cbv_flow.id,
           invitation_id: cbv_flow.cbv_flow_invitation_id,
           response_type: "employer",

--- a/app/spec/controllers/api/user_events_controller_spec.rb
+++ b/app/spec/controllers/api/user_events_controller_spec.rb
@@ -32,18 +32,10 @@ RSpec.describe Api::UserEventsController, type: :controller do
       end
 
       it "tracks an event with Mixpanel" do
-        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("ApplicantOpenedHelpModal", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantOpenedHelpModal", anything, hash_including(
           timestamp: be_a(Integer),
           source: "banner",
           cbv_flow_id: cbv_flow.id
-        ))
-        post :user_action, params: valid_params
-      end
-
-      it "tracks an event with NewRelic" do
-        expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("ApplicantOpenedHelpModal", anything, hash_including(
-          timestamp: be_a(Integer),
-          source: "banner"
         ))
         post :user_action, params: valid_params
       end
@@ -102,21 +94,7 @@ RSpec.describe Api::UserEventsController, type: :controller do
         end
 
         it "tracks an event with Mixpanel (with selected_tab = platform)" do
-          expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
-            timestamp: be_a(Integer),
-            cbv_flow_id: cbv_flow.id,
-            invitation_id: cbv_flow.cbv_flow_invitation_id,
-            item_type: "platform",
-            item_id: "123",
-            item_name: "Test Payroll Provider",
-            is_default_option: "true",
-            locale: "en"
-          ))
-          post :user_action, params: valid_params
-        end
-
-        it "tracks an event with NewRelic (with selected_tab = platform)" do
-          expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
+          expect(EventTrackingJob).to receive(:perform_later).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
             timestamp: be_a(Integer),
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
@@ -142,21 +120,7 @@ RSpec.describe Api::UserEventsController, type: :controller do
         end
 
         it "tracks an event with Mixpanel (with selected_tab = employer)" do
-          expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
-            timestamp: be_a(Integer),
-            cbv_flow_id: cbv_flow.id,
-            invitation_id: cbv_flow.cbv_flow_invitation_id,
-            item_type: "employer",
-            item_id: "123",
-            item_name: "Test Employer",
-            is_default_option: "true",
-            locale: "en"
-          ))
-          post :user_action, params: valid_params
-        end
-
-        it "tracks an event with NewRelic (with selected_tab = employer)" do
-          expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
+          expect(EventTrackingJob).to receive(:perform_later).with("ApplicantSelectedEmployerOrPlatformItem", anything, hash_including(
             timestamp: be_a(Integer),
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
@@ -183,21 +147,7 @@ RSpec.describe Api::UserEventsController, type: :controller do
       end
 
       it "tracks an event with Mixpanel" do
-        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("ApplicantViewedPinwheelLoginPage", anything, hash_including(
-          timestamp: be_a(Integer),
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id,
-          locale: "en",
-          screen_name: "LOGIN",
-          employer_name: "Bob's Burgers",
-          platform_name: "Test Payroll Platform Name"
-        ))
-        post :user_action, params: valid_params
-      end
-
-      # We detect the new name for these events in NewRelic because we change the name from within the :track method
-      it "tracks an event with NewRelic" do
-        expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("ApplicantViewedPinwheelLoginPage", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedPinwheelLoginPage", anything, hash_including(
           timestamp: be_a(Integer),
           cbv_flow_id: cbv_flow.id,
           invitation_id: cbv_flow.cbv_flow_invitation_id,
@@ -219,17 +169,7 @@ RSpec.describe Api::UserEventsController, type: :controller do
       end
 
       it "tracks an event with Mixpanel" do
-        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("UserManuallySwitchedLanguage", anything, hash_including(
-          timestamp: be_a(Integer),
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id,
-          locale: "es"
-        ))
-        post :user_action, params: valid_params
-      end
-
-      it "tracks an event with NewRelic" do
-        expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("UserManuallySwitchedLanguage", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("UserManuallySwitchedLanguage", anything, hash_including(
           timestamp: be_a(Integer),
           cbv_flow_id: cbv_flow.id,
           invitation_id: cbv_flow.cbv_flow_invitation_id,

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -2,16 +2,6 @@ require "rails_helper"
 
 RSpec.describe Cbv::PaymentDetailsController do
   include PinwheelApiHelper
-  include ArgyleApiHelper
-  let(:mixpanel_event_stub) { instance_double(MixpanelEventTracker) }
-  let(:newrelic_event_stub) { instance_double(NewRelicEventTracker) }
-
-  before do
-    allow(MixpanelEventTracker).to receive(:new).and_return(mixpanel_event_stub)
-    allow(NewRelicEventTracker).to receive(:new).and_return(newrelic_event_stub)
-    allow(newrelic_event_stub).to receive(:track)
-    allow(mixpanel_event_stub).to receive(:track)
-  end
 
   describe "#show" do
     render_views
@@ -60,9 +50,8 @@ RSpec.describe Cbv::PaymentDetailsController do
       end
 
       it "tracks events" do
-        expect(mixpanel_event_stub)
-          .to receive(:track)
-          .with("ApplicantViewedPaymentDetails", anything, hash_including(
+        allow(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedPaymentDetails", anything, hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             pinwheel_account_id: payroll_account.id,
@@ -71,18 +60,6 @@ RSpec.describe Cbv::PaymentDetailsController do
             has_paystubs_data: true,
             has_income_data: true
           ))
-
-        expect(newrelic_event_stub)
-         .to receive(:track)
-         .with("ApplicantViewedPaymentDetails", anything, hash_including(
-           cbv_flow_id: cbv_flow.id,
-           invitation_id: cbv_flow.cbv_flow_invitation_id,
-           pinwheel_account_id: payroll_account.id,
-           payments_length: 1,
-           has_employment_data: true,
-           has_paystubs_data: true,
-           has_income_data: true
-         ))
 
         get :show, params: { user: { account_id: account_id } }
       end
@@ -368,17 +345,9 @@ RSpec.describe Cbv::PaymentDetailsController do
     end
 
     it "tracks events" do
-      expect(mixpanel_event_stub)
-        .to receive(:track)
-        .with("ApplicantSavedPaymentDetails", anything, hash_including(
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id,
-          additional_information_length: comment.length
-        ))
+      allow(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
 
-      expect(newrelic_event_stub)
-        .to receive(:track)
-        .with("ApplicantSavedPaymentDetails", anything, hash_including(
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantSavedPaymentDetails", anything, hash_including(
           cbv_flow_id: cbv_flow.id,
           invitation_id: cbv_flow.cbv_flow_invitation_id,
           additional_information_length: comment.length

--- a/app/spec/controllers/cbv/payment_details_controller_spec.rb
+++ b/app/spec/controllers/cbv/payment_details_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Cbv::PaymentDetailsController do
   include PinwheelApiHelper
+  include ArgyleApiHelper
 
   describe "#show" do
     render_views

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -327,40 +327,19 @@ RSpec.describe Cbv::SubmitsController do
       allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
     end
 
-    describe "with activejob enabled" do
-      around do |example|
-        ClimateControl.modify ACTIVEJOB_ENABLED: 'true' do
-          example.run
-        end
-      end
-      context "without consent" do
-        it "redirects back with an alert" do
-          expect(CaseWorkerTransmitterJob).not_to receive(:perform_later)
-          patch :update
-          expect(response).to redirect_to(cbv_flow_submit_path)
-          expect(flash[:alert]).to be_present
-          expect(flash[:alert]).to eq("Please check the legal agreement box to share your report.")
-        end
-      end
-
-      context "with consent" do
-        it "queues a job and redirects to success screen" do
-          expect(CaseWorkerTransmitterJob).to receive(:perform_later).with(cbv_flow.id)
-          patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
-          expect(response).to redirect_to({ controller: :successes, action: :show })
-        end
+    context "without consent" do
+      it "redirects back with an alert" do
+        expect(CaseWorkerTransmitterJob).not_to receive(:perform_later)
+        patch :update
+        expect(response).to redirect_to(cbv_flow_submit_path)
+        expect(flash[:alert]).to be_present
+        expect(flash[:alert]).to eq("Please check the legal agreement box to share your report.")
       end
     end
 
-    describe "with activejob disabled" do
-      around do |example|
-        ClimateControl.modify ACTIVEJOB_ENABLED: nil do
-          example.run
-        end
-      end
-
-      it "runs the task immediately with consent" do
-        expect(CaseWorkerTransmitterJob).to receive(:perform_now)
+    context "with consent" do
+      it "queues a job and redirects to success screen" do
+        expect(CaseWorkerTransmitterJob).to receive(:perform_later).with(cbv_flow.id)
         patch :update, params: { cbv_flow: { consent_to_authorized_use: "1" } }
         expect(response).to redirect_to({ controller: :successes, action: :show })
       end

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -116,16 +116,9 @@ RSpec.describe Cbv::SummariesController do
     end
 
     it "tracks events" do
-      expect(mixpanel_event_stub)
-        .to receive(:track)
-        .with("ApplicantAccessedIncomeSummary", anything, hash_including(
-          cbv_flow_id: cbv_flow.id,
-          invitation_id: cbv_flow.cbv_flow_invitation_id
-        ))
+      allow(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
 
-      expect(newrelic_event_stub)
-        .to receive(:track)
-        .with("ApplicantAccessedIncomeSummary", anything, hash_including(
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantAccessedIncomeSummary", anything, hash_including(
           cbv_flow_id: cbv_flow.id,
           invitation_id: cbv_flow.cbv_flow_invitation_id
         ))

--- a/app/spec/controllers/help_controller_spec.rb
+++ b/app/spec/controllers/help_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe HelpController, type: :controller do
         valid_params[:client_agency_id] = cbv_flow.client_agency_id
       end
 
-      it "tracks events with both trackers" do
+      it "tracks events for help topic" do
         expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedHelpTopic", anything, hash_including(
             cbv_applicant_id: cbv_flow.cbv_applicant_id,
             cbv_flow_id: cbv_flow.id,

--- a/app/spec/controllers/help_controller_spec.rb
+++ b/app/spec/controllers/help_controller_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe HelpController, type: :controller do
       }
     end
 
-    let(:mixpanel_event_stub) { instance_double(MixpanelEventTracker) }
-    let(:newrelic_event_stub) { instance_double(NewRelicEventTracker) }
-
-    before do
-      allow(MixpanelEventTracker).to receive(:new).and_return(mixpanel_event_stub)
-      allow(NewRelicEventTracker).to receive(:new).and_return(newrelic_event_stub)
-      allow(newrelic_event_stub).to receive(:track)
-      allow(mixpanel_event_stub).to receive(:track)
-    end
-
     context "with a valid CBV flow" do
       let(:cbv_flow) { create(:cbv_flow, :invited) }
 
@@ -28,29 +18,9 @@ RSpec.describe HelpController, type: :controller do
       end
 
       it "tracks events with both trackers" do
-        expect(mixpanel_event_stub)
-          .to receive(:track)
-          .with("ApplicantViewedHelpTopic", anything, hash_including(
-            browser: nil,
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedHelpTopic", anything, hash_including(
             cbv_applicant_id: cbv_flow.cbv_applicant_id,
             cbv_flow_id: cbv_flow.id,
-            device_name: nil,
-            device_type: nil,
-            ip: "0.0.0.0",
-            locale: I18n.locale,
-            client_agency_id: cbv_flow.client_agency_id,
-            topic: "employer",
-            user_agent: "Rails Testing"
-          ))
-
-        expect(newrelic_event_stub)
-          .to receive(:track)
-          .with("ApplicantViewedHelpTopic", anything, hash_including(
-            browser: nil,
-            cbv_applicant_id: cbv_flow.cbv_applicant_id,
-            cbv_flow_id: cbv_flow.id,
-            device_name: nil,
-            device_type: nil,
             ip: "0.0.0.0",
             locale: I18n.locale,
             client_agency_id: cbv_flow.client_agency_id,
@@ -71,14 +41,7 @@ RSpec.describe HelpController, type: :controller do
 
     context "without a CBV flow" do
       it "still renders the template and tracks events" do
-        expect(mixpanel_event_stub)
-          .to receive(:track)
-          .with("ApplicantViewedHelpTopic", anything, hash_including(
-            browser: nil,
-            cbv_applicant_id: nil,
-            cbv_flow_id: nil,
-            device_name: nil,
-            device_type: nil,
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedHelpTopic", anything, hash_including(
             ip: "0.0.0.0",
             locale: I18n.locale,
             client_agency_id: "sandbox",

--- a/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/app/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -36,12 +36,7 @@ RSpec.describe Users::OmniauthCallbacksController do
       end
 
       it "tracks events" do
-        expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("CaseworkerLogin", anything, hash_including(
-          client_agency_id: "ma",
-          user_id: be_a(Integer)
-        ))
-
-        expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("CaseworkerLogin", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("CaseworkerLogin", anything, hash_including(
           client_agency_id: "ma",
           user_id: be_a(Integer)
         ))

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -44,15 +44,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
       end
 
       it "creates a PinwheelAccount object and logs events" do
-        expect_any_instance_of(MixpanelEventTracker).to receive(:track)
-          .with("ApplicantCreatedPinwheelAccount", anything, hash_including(
-            cbv_flow_id: cbv_flow.id,
-            invitation_id: cbv_flow.cbv_flow_invitation_id,
-            platform_name: "acme"
-          ))
-
-        expect_any_instance_of(NewRelicEventTracker).to receive(:track)
-          .with("ApplicantCreatedPinwheelAccount", anything, hash_including(
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantCreatedPinwheelAccount", anything, hash_including(
             cbv_flow_id: cbv_flow.id,
             invitation_id: cbv_flow.cbv_flow_invitation_id,
             platform_name: "acme"

--- a/app/spec/jobs/event_tracking_job_spec.rb
+++ b/app/spec/jobs/event_tracking_job_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe EventTrackingJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "when a request exists" do
+    it "passes the right data to mixpanel and newrelic" do
+      request_data = {
+        remote_ip: "0.0.0.0",
+        headers: {
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        }
+      }
+
+      expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("MyAwesomeClick", anything, { browser: "Chrome", device_name: nil, device_type: "desktop" })
+      expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("MyAwesomeClick", anything, { browser: "Chrome", device_name: nil, device_type: "desktop" })
+      described_class.perform_now("MyAwesomeClick", request_data, {})
+    end
+  end
+
+  context "when a request is missing" do
+    it "passes the right data to mixpanel and newrelic" do
+      expect_any_instance_of(MixpanelEventTracker).to receive(:track).with("MyAwesomeClick", anything, { my: "attribute" })
+      expect_any_instance_of(NewRelicEventTracker).to receive(:track).with("MyAwesomeClick", anything, { my: "attribute" })
+      described_class.perform_now("MyAwesomeClick", nil, { my: "attribute" })
+    end
+  end
 end

--- a/app/spec/lib/mixpanel_event_tracker_spec.rb
+++ b/app/spec/lib/mixpanel_event_tracker_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe MixpanelEventTracker do
     let(:tracker) { described_class.for_request(nil) }
 
     before do
-      # Make MaybeLater execute immediately instead of after the request, which doesn't exist
-      allow(MaybeLater).to receive(:run) do |&block|
-        block.call
-      end
-
       # Since we're stubbing this in spec_helper, make our tests in this file call original as well
       allow_any_instance_of(MixpanelEventTracker).to receive(:track).and_call_original
     end

--- a/app/spec/lib/new_relic_event_tracker_spec.rb
+++ b/app/spec/lib/new_relic_event_tracker_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe NewRelicEventTracker do
     let(:tracker) { described_class.for_request(nil) }
 
     before do
-      # Make MaybeLater execute immediately instead of after the request, which doesn't exist
-      allow(MaybeLater).to receive(:run) do |&block|
-        block.call
-      end
-
       # Since we're stubbing this in spec_helper, make our tests in this file call original as well
       allow_any_instance_of(NewRelicEventTracker).to receive(:track).and_call_original
     end

--- a/app/spec/mailers/weekly_report_mailer_spec.rb
+++ b/app/spec/mailers/weekly_report_mailer_spec.rb
@@ -56,15 +56,7 @@ RSpec.describe WeeklyReportMailer, type: :mailer do
   end
 
   it "tracks events" do
-    expect_any_instance_of(MixpanelEventTracker).to receive(:track)
-      .with("EmailSent", anything, hash_including(
-        mailer: "WeeklyReportMailer",
-        action: "report_email",
-        message_id: be_a(String)
-      ))
-
-    expect_any_instance_of(NewRelicEventTracker).to receive(:track)
-      .with("EmailSent", anything, hash_including(
+    expect(EventTrackingJob).to receive(:perform_later).with("EmailSent", anything, hash_including(
         mailer: "WeeklyReportMailer",
         action: "report_email",
         message_id: be_a(String)

--- a/app/spec/rails_helper.rb
+++ b/app/spec/rails_helper.rb
@@ -12,10 +12,6 @@ require "view_component/system_test_helpers"
 require "capybara/rspec"
 Capybara.default_driver = Capybara.javascript_driver
 
-MaybeLater.config do |config|
-  config.invoke_even_if_server_is_unsupported = true
-  config.inline_by_default = true
-end
 
 Rails.application.load_tasks
 
@@ -53,17 +49,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.before(:each, type: :controller) do
-    allow(MaybeLater).to receive(:run) do |&block|
-      block.call
-    end
-  end
-
-  config.before(:each, type: :mailer) do
-    allow(MaybeLater).to receive(:run) do |&block|
-      block.call
-    end
-  end
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Finish
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2754](https://jiraent.cms.gov/browse/FFS-2754).


## Changes
this removes the usage of the environment variable for job enqueueing, which enables us to remove maybe later.

## Context for reviewers
this favors unit testing that event job tracking fires successfully as one set of tests, and the integration tests now don't check newrelic/mixpanel in favor of checking that the async job was fired.

To fix in a followup PR maybe: right now, if the job fails because it needed to connect to mixpanel or newrelic, the job will fail and retry the whole re-sync. at some point might be worth having a job fire off jobs? (mixpanel and newrelic seperately) [or rip out the newrelic events]

## Acceptance testing
- [ X] Acceptance testing prior to merge
 * go through the flow, make sure mixpanel events are still firing
