### PR TITLE
FFS-2798: Add terraform to support ReportMyIncome.org

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,15 @@ repos:
     entry: bin/run-linter --cd app -- npm run format:precommit
     language: node
     files: '^app/.*\.(js|ts)$'
+
+  - id: terraform_fmt
+    name: Terraform Fmt
+    entry: terraform fmt
+    language: system
+    files: 'infra/.*\.tf$'
+
+  - id: checkov
+    name: Checkov
+    entry: checkov --quiet --output sarif --framework terraform -f
+    language: system
+    files: 'infra/.*\.tf$'

--- a/Brewfile
+++ b/Brewfile
@@ -42,3 +42,4 @@ brew "gpg"
 # linters / workflow tools
 brew "pre-commit"
 brew "shellcheck"
+brew "checkov"

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -17,6 +17,10 @@ module "dev_config" {
   service_memory                 = 4096
   service_desired_instance_count = 3
 
+  # Create DNS records for these `additional_domains` in the default hosted
+  # zone (this is necessary to support CBV agency subdomains).
+  additional_domains = ["*.navapbc.cloud"]
+
   # Enable and configure identity provider.
   enable_identity_provider = local.enable_identity_provider
 

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -26,6 +26,7 @@ output "service_config" {
     memory                   = var.service_memory
     desired_instance_count   = var.service_desired_instance_count
     enable_command_execution = var.enable_command_execution
+    additional_domains       = var.additional_domains
 
     extra_environment_variables = merge(
       local.default_extra_environment_variables,

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_domains" {
+  type        = list(string)
+  description = "Any additional domains also register DNS records to point to the load balancer."
+  default     = []
+}
+
 variable "app_name" {
   type = string
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -5,7 +5,7 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   network_name                    = "prod"
-  domain_name                     = "snap-income-pilot.com"
+  domain_name                     = "reportmyincome.org"
   enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
@@ -17,6 +17,10 @@ module "prod_config" {
   service_cpu                    = 1024
   service_memory                 = 4096
   service_desired_instance_count = 3
+
+  # Create DNS records for these `additional_domains` in the default hosted
+  # zone (this is necessary to support CBV agency subdomains).
+  additional_domains = ["*.reportmyincome.org"]
 
   # Enables ECS Exec access for debugging or jump access.
   # Defaults to `false`. Uncomment the next line to enable.

--- a/infra/app/service/deprecated_domains.tf
+++ b/infra/app/service/deprecated_domains.tf
@@ -1,0 +1,53 @@
+# #############################################################################
+# This file only exists to continue supporting the deprecated domain
+# "snap-income-pilot.com" in production.
+#
+# TODO: Remove this some time after we no longer support this domain name.
+#
+# #############################################################################
+
+data "aws_route53_zone" "deprecated_snapincomepilot" {
+  count = var.environment_name == "prod" ? 1 : 0
+
+  name = "snap-income-pilot.com"
+}
+
+resource "aws_route53_record" "deprecated_snapincomepilot" {
+  # checkov:skip=CKV2_AWS_23:This deprecated DNS entry is intended to not point at a resource.
+  count = var.environment_name == "prod" ? 1 : 0
+
+  name    = "snap-income-pilot.com"
+  zone_id = data.aws_route53_zone.deprecated_snapincomepilot[count.index].id
+  type    = "A"
+  alias {
+    name                   = "reportmyincome.org"
+    zone_id                = data.aws_route53_zone.zone[0].id
+    evaluate_target_health = true
+  }
+}
+
+# #############################################################################
+# We need to add the old TLS certificate for snap-income-pilot.com (which isn't
+# managed by terraform) to the load balancer so it can serve traffic to that
+# domain.
+# #############################################################################
+data "aws_lb" "production_load_balancer" {
+  arn = "arn:aws:elasticloadbalancing:us-east-1:${data.aws_caller_identity.current.id}:loadbalancer/${module.service.load_balancer_arn_suffix}"
+}
+
+data "aws_lb_listener" "alb_listener_https" {
+  load_balancer_arn = data.aws_lb.production_load_balancer.arn
+  port              = 443
+}
+
+data "aws_acm_certificate" "deprecated_certificate" {
+  count  = var.environment_name == "prod" ? 1 : 0
+  domain = "snap-income-pilot.com"
+}
+
+resource "aws_lb_listener_certificate" "deprecated_snapincomepilot" {
+  count = var.environment_name == "prod" ? 1 : 0
+
+  listener_arn    = data.aws_lb_listener.alb_listener_https.arn
+  certificate_arn = data.aws_acm_certificate.deprecated_certificate[count.index].arn
+}

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -168,9 +168,10 @@ module "service" {
   public_subnet_ids  = data.aws_subnets.public.ids
   private_subnet_ids = data.aws_subnets.private.ids
 
-  domain_name     = local.service_config.domain_name
-  hosted_zone_id  = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
-  certificate_arn = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
+  domain_name        = local.service_config.domain_name
+  hosted_zone_id     = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
+  certificate_arn    = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
+  additional_domains = local.service_config.additional_domains
 
   cpu                      = local.service_config.cpu
   memory                   = local.service_config.memory

--- a/infra/modules/domain/certificates.tf
+++ b/infra/modules/domain/certificates.tf
@@ -30,8 +30,9 @@ locals {
 resource "aws_acm_certificate" "issued" {
   for_each = local.issued_certificate_configs
 
-  domain_name       = each.key
-  validation_method = "DNS"
+  domain_name               = each.key
+  validation_method         = "DNS"
+  subject_alternative_names = each.value.subject_alternative_names
 
   lifecycle {
     create_before_destroy = true

--- a/infra/modules/domain/variables.tf
+++ b/infra/modules/domain/variables.tf
@@ -1,8 +1,9 @@
 variable "certificate_configs" {
   type = map(object({
-    source           = string
-    private_key      = optional(string)
-    certificate_body = optional(string)
+    source                    = string
+    private_key               = optional(string)
+    certificate_body          = optional(string)
+    subject_alternative_names = optional(list(string))
   }))
   description = <<EOT
     Map from domains to certificate configuration objects for that domain.

--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -11,3 +11,18 @@ resource "aws_route53_record" "app" {
     evaluate_target_health = true
   }
 }
+
+# Register additional domains as aliases as well. These must be provided as
+# subject_alternative_names to the load balancer certificate as well.
+resource "aws_route53_record" "additional_domains" {
+  for_each = toset(var.additional_domains)
+
+  name    = each.value
+  zone_id = var.hosted_zone_id
+  type    = "A"
+  alias {
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_domains" {
+  type        = list(string)
+  description = "Any additional domains also register DNS records to point to the load balancer."
+  default     = []
+}
+
 variable "aws_services_security_group_id" {
   type        = string
   description = "Security group ID for VPC endpoints that access AWS Services"

--- a/infra/networks/deprecated_domains.tf
+++ b/infra/networks/deprecated_domains.tf
@@ -1,0 +1,38 @@
+# #############################################################################
+# This file only exists to continue supporting the deprecated domain
+# "snap-income-pilot.com" in production.
+#
+# TODO: Remove this some time after we no longer support this domain name.
+#
+# Run the following commands to move the preexisting resources into these ones:
+#   export AWS_PROFILE=prod
+#   terraform -chdir="infra/networks" init -input=false -reconfigure -backend-config="prod.s3.tfbackend"
+#   terraform -chdir="infra/networks" state mv 'module.domain.aws_acm_certificate.issued["snap-income-pilot.com"]' 'aws_acm_certificate.deprecated_certificate'
+#   terraform -chdir="infra/networks" state mv 'module.domain.aws_route53_zone.zone[0]' 'aws_route53_zone.deprecated_zone'
+#   terraform -chdir="infra/networks" state mv 'module.domain.aws_route53_record.validation["snap-income-pilot.com"]' 'aws_route53_record.deprecated_validation'
+#
+# #############################################################################
+
+resource "aws_acm_certificate" "deprecated_certificate" {
+  domain_name       = "snap-income-pilot.com"
+  key_algorithm     = "RSA_2048"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_zone" "deprecated_zone" {
+  # checkov:skip=CKV2_AWS_38:No need for DNSSEC on this deprecated zone.
+  # checkov:skip=CKV2_AWS_39:No need to manage DNS query logging on this deprecated zone.
+  name = "snap-income-pilot.com"
+}
+
+resource "aws_route53_record" "deprecated_validation" {
+  name    = "_68adda3cfec681d22de0bf4e66e946f8.snap-income-pilot.com"
+  records = ["_3a86b1ee62e6e99d96fa7ebf4af0dab5.sdgjtdhdhz.acm-validations.aws."]
+  ttl     = 60
+  type    = "CNAME"
+  zone_id = aws_route53_zone.deprecated_zone.id
+}

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -10,7 +10,8 @@ locals {
 
         certificate_configs = {
           "verify-demo.navapbc.cloud" = {
-            source = "issued"
+            source                    = "issued"
+            subject_alternative_names = ["*.navapbc.cloud"]
           }
           # Example certificate configuration for a certificate that is managed by the project
           # "sub.domain.com" = {
@@ -30,17 +31,17 @@ locals {
       single_nat_gateway = true
     }
 
-    staging = {
-      account_name               = "staging"
-      database_subnet_group_name = "staging"
+    # staging = {
+    #   account_name               = "staging"
+    #   database_subnet_group_name = "staging"
 
-      domain_config = {
-        manage_dns  = true
-        hosted_zone = "hosted.zone.for.staging.network.com"
+    #   domain_config = {
+    #     manage_dns  = true
+    #     hosted_zone = "hosted.zone.for.staging.network.com"
 
-        certificate_configs = {}
-      }
-    }
+    #     certificate_configs = {}
+    #   }
+    # }
 
     prod = {
       account_name               = "nava-ffs-prod"
@@ -48,11 +49,12 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "snap-income-pilot.com"
+        hosted_zone = "reportmyincome.org"
 
         certificate_configs = {
-          "snap-income-pilot.com" = {
-            source = "issued"
+          "reportmyincome.org" = {
+            source                    = "issued"
+            subject_alternative_names = ["*.reportmyincome.org"]
           }
         }
       }


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2798](https://jiraent.cms.gov/browse/FFS-2798).


## Changes
<!-- What was added, updated, or removed in this PR. -->

To support this new domain, this commit adds terraform to:
1. Replace the old domain (snap-income-pilot.com) with the new domain.
2. We intend to use the new domain name with subdomains for
   white-labeling. This commit adds an `additional_domains`
   configuration variable that gets passed into the service module in
   order to create the DNS records for the wildcard domain.
3. The wildcard domain will also need to be added to the TLS
   certificate. This commit adds a new `subject_alternative_names`
   configuration item to the `certificate_configs` variable that allows
   for specifying additional hosts that should also be included in the
   TLS certificate.

Finally, to remain backwards-compatible (at least temporarily) with
snap-income-pilot.com, this commit:

1. Adds a "deprecated_domains.tf" file in the services and network
   modules which are containers to hold the old resources for
   snap-income-pilot.com, to still be used by the ALB managed by the
   service module. We will have to perform some terraform state surgery
   to move the old TLS certificate (for snap-income-pilot.com) from
   terraform, so terraform doesn't clean it up while provisioning the
   ReportMyIncome.org resources.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This is probably intertwined with deploying Multi-Aggregator to production, as
there are shared terraform issues that we need to resolve before the terraform
will be able to create the resources in this PR.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
