### PR TITLE
FFS-2675: Remove artificial delay from ArgyleModalAdapter

### DIFF
--- a/app/app/controllers/cbv/synchronizations_controller.rb
+++ b/app/app/controllers/cbv/synchronizations_controller.rb
@@ -3,12 +3,22 @@ class Cbv::SynchronizationsController < Cbv::BaseController
   before_action :redirect_if_sync_finished, only: %i[show]
   skip_before_action :capture_page_view, only: %i[update]
 
+  MAX_POLLS = 60 # poll for 2 mins
+
   def show
+    session[:poll_count] = 0
   end
 
   def update
-    if @payroll_account.nil?
+    if session[:poll_count] >= MAX_POLLS
       render turbo_stream: turbo_stream.action(:redirect, cbv_flow_synchronization_failures_path)
+      return
+    end
+
+    session[:poll_count] += 1
+
+    if @payroll_account.nil?
+      render turbo_stream: turbo_stream.replace(:synchronization, partial: "status")
     elsif @payroll_account.has_fully_synced?
       render turbo_stream: turbo_stream.action(
         :redirect,
@@ -22,9 +32,7 @@ class Cbv::SynchronizationsController < Cbv::BaseController
   private
 
   def redirect_if_sync_finished
-    if @payroll_account.nil?
-      redirect_to cbv_flow_synchronization_failures_path
-    elsif @payroll_account.has_fully_synced?
+    if @payroll_account&.has_fully_synced?
       redirect_to cbv_flow_payment_details_path(user: { account_id: @payroll_account.pinwheel_account_id })
     end
   end

--- a/app/app/controllers/cbv/synchronizations_controller.rb
+++ b/app/app/controllers/cbv/synchronizations_controller.rb
@@ -3,22 +3,10 @@ class Cbv::SynchronizationsController < Cbv::BaseController
   before_action :redirect_if_sync_finished, only: %i[show]
   skip_before_action :capture_page_view, only: %i[update]
 
-  MAX_POLLS = 60 # poll for 2 mins
-
   def show
-    session[:poll_count] = 0
   end
 
   def update
-    session[:poll_count] ||= 0
-
-    if session[:poll_count] >= MAX_POLLS
-      render turbo_stream: turbo_stream.action(:redirect, cbv_flow_synchronization_failures_path)
-      return
-    end
-
-    session[:poll_count] += 1
-
     if @payroll_account&.has_fully_synced?
       render turbo_stream: turbo_stream.action(
         :redirect,

--- a/app/app/controllers/cbv/synchronizations_controller.rb
+++ b/app/app/controllers/cbv/synchronizations_controller.rb
@@ -10,6 +10,8 @@ class Cbv::SynchronizationsController < Cbv::BaseController
   end
 
   def update
+    session[:poll_count] ||= 0
+
     if session[:poll_count] >= MAX_POLLS
       render turbo_stream: turbo_stream.action(:redirect, cbv_flow_synchronization_failures_path)
       return
@@ -17,9 +19,7 @@ class Cbv::SynchronizationsController < Cbv::BaseController
 
     session[:poll_count] += 1
 
-    if @payroll_account.nil?
-      render turbo_stream: turbo_stream.replace(:synchronization, partial: "status")
-    elsif @payroll_account.has_fully_synced?
+    if @payroll_account&.has_fully_synced?
       render turbo_stream: turbo_stream.action(
         :redirect,
         cbv_flow_payment_details_path(user: { account_id: @payroll_account.pinwheel_account_id })

--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -147,11 +147,7 @@ export default class ArgyleModalAdapter extends ModalAdapter {
     })
 
     if (this.successCallback) {
-      setTimeout(() => {
-        // TODO[FFS-2675]: Remove this artifical delay. It current exists to
-        // allow time for Argyle to send us the `accounts.connected` webhook.
-        this.successCallback(eventPayload.accountId)
-      }, 1000)
+      this.successCallback(eventPayload.accountId)
     }
   }
 

--- a/app/spec/controllers/cbv/synchronizations_controller_spec.rb
+++ b/app/spec/controllers/cbv/synchronizations_controller_spec.rb
@@ -4,32 +4,72 @@ RSpec.describe Cbv::SynchronizationsController do
   render_views
 
   let(:cbv_flow) { create(:cbv_flow, :invited) }
-
   let(:errored_jobs) { [] }
   let(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, with_errored_jobs: errored_jobs, cbv_flow: cbv_flow) }
+  let(:nonexistent_id) { "nonexistent-id" }
 
   before do
     session[:cbv_flow_id] = cbv_flow.id
   end
 
+  describe "#show" do
+    it "redirects to payment details when account exists" do
+      get :show, params: { user: { account_id: payroll_account.pinwheel_account_id } }
+
+      expect(response).to redirect_to(cbv_flow_payment_details_path(user: { account_id: payroll_account.pinwheel_account_id }))
+    end
+
+    it "renders the page when account doesn't exist" do
+      get :show, params: { user: { account_id: nonexistent_id } }
+
+      expect(response).to be_successful
+      expect(response).to render_template(:show)
+    end
+
+    it "resets poll count" do
+      get :show, params: { user: { account_id: nonexistent_id } }
+
+      expect(session[:poll_count]).to eq(0)
+    end
+  end
+
   describe "#update" do
-    it "redirects to the payment details page" do
+    it "redirects to payment details when account exists" do
       patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
 
       expect(response.body).to include("cbv/payment_details")
       expect(response.body).to include("turbo-stream action=\"redirect\"")
     end
 
-    it "does not fire tracking event if its for the polling purposes" do
+    it "continues polling when account doesn't exist" do
+      patch :update, params: { user: { account_id: nonexistent_id } }
+
+      expect(response.body).to include("turbo-frame id=\"synchronization\"")
+    end
+
+    it "doesn't fire tracking events" do
       expect_any_instance_of(GenericEventTracker).not_to receive(:track)
 
       patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
     end
 
+    it "increments poll count" do
+      patch :update, params: { user: { account_id: nonexistent_id } }
+
+      expect(session[:poll_count]).to eq(1)
+    end
+
+    it "redirects to failures after max polls" do
+      session[:poll_count] = Cbv::SynchronizationsController::MAX_POLLS
+      patch :update, params: { user: { account_id: nonexistent_id } }
+
+      expect(response.body).to include("synchronization_failures")
+    end
+
     context "when the paystubs synchronization fails" do
       let(:errored_jobs) { [ "paystubs" ] }
 
-      it "redirects to the payment details page" do
+      it "redirects to payment details" do
         patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
 
         expect(response.body).to include("cbv/payment_details")

--- a/app/spec/controllers/cbv/synchronizations_controller_spec.rb
+++ b/app/spec/controllers/cbv/synchronizations_controller_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Cbv::SynchronizationsController do
       expect(response).to be_successful
       expect(response).to render_template(:show)
     end
-
-    it "resets poll count" do
-      get :show, params: { user: { account_id: nonexistent_id } }
-
-      expect(session[:poll_count]).to eq(0)
-    end
   end
 
   describe "#update" do
@@ -51,19 +45,6 @@ RSpec.describe Cbv::SynchronizationsController do
       expect_any_instance_of(GenericEventTracker).not_to receive(:track)
 
       patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
-    end
-
-    it "increments poll count" do
-      patch :update, params: { user: { account_id: nonexistent_id } }
-
-      expect(session[:poll_count]).to eq(1)
-    end
-
-    it "redirects to failures after max polls" do
-      session[:poll_count] = Cbv::SynchronizationsController::MAX_POLLS
-      patch :update, params: { user: { account_id: nonexistent_id } }
-
-      expect(response.body).to include("synchronization_failures")
     end
 
     context "when the paystubs synchronization fails" do

--- a/app/spec/controllers/cbv/synchronizations_controller_spec.rb
+++ b/app/spec/controllers/cbv/synchronizations_controller_spec.rb
@@ -13,59 +13,53 @@ RSpec.describe Cbv::SynchronizationsController do
   end
 
   describe "#show" do
-    it "redirects to the payment details page" do
-      get :show, params: { user: { account_id: payroll_account.pinwheel_account_id } }
+    context "when account exists" do
+      it "redirects to the payment details page" do
+        get :show, params: { user: { account_id: payroll_account.pinwheel_account_id } }
 
-      expect(response).to redirect_to(cbv_flow_payment_details_path(user: { account_id: payroll_account.pinwheel_account_id }))
+        expect(response).to redirect_to(cbv_flow_payment_details_path(user: { account_id: payroll_account.pinwheel_account_id }))
+      end
     end
 
-    it "renders the page when account doesn't exist" do
-      get :show, params: { user: { account_id: nonexistent_id } }
+    context "when account doesn't exist" do
+      it "renders the page" do
+        get :show, params: { user: { account_id: nonexistent_id } }
 
-      expect(response).to be_successful
-      expect(response).to render_template(:show)
+        expect(response).to be_successful
+        expect(response).to render_template(:show)
+      end
     end
   end
 
   describe "#update" do
-    it "redirects to the payment details page" do
-      patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
-
-      expect(response.body).to include("cbv/payment_details")
-      expect(response.body).to include("turbo-stream action=\"redirect\"")
-    end
-
     it "does not fire tracking event if its for the polling purposes" do
       expect_any_instance_of(GenericEventTracker).not_to receive(:track)
 
       patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
     end
 
-    it "continues polling when account doesn't exist" do
-      patch :update, params: { user: { account_id: nonexistent_id } }
+    context "when account exists and is fully synced" do
+      it "redirects to the payment details page" do
+        patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
 
-      expect(response.body).to include("turbo-frame id=\"synchronization\"")
+        expect(response.body).to include("cbv/payment_details")
+        expect(response.body).to include("turbo-stream action=\"redirect\"")
+      end
     end
 
-    it "continues polling when account exists but is not fully synced" do
-      allow_any_instance_of(PayrollAccount::Pinwheel).to receive(:has_fully_synced?).and_return(false)
+    context "when account exists but is not fully synced" do
+      before do
+        allow_any_instance_of(PayrollAccount::Pinwheel).to receive(:has_fully_synced?).and_return(false)
+      end
 
-      patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
+      it "continues polling" do
+        patch :update, params: { user: { account_id: payroll_account.pinwheel_account_id } }
 
-      expect(response.body).to include("turbo-frame id=\"synchronization\"")
+        expect(response.body).to include("turbo-frame id=\"synchronization\"")
+      end
     end
 
-    it "renders partial and continues polling when payroll_account is nil" do
-      controller.instance_variable_set(:@payroll_account, nil)
-
-      patch :update, params: { user: { account_id: nonexistent_id } }
-
-      expect(response.body).to include("turbo-frame id=\"synchronization\"")
-      expect(response.body).not_to include("synchronization_failures")
-      expect(response).to render_template(partial: "_status")
-    end
-
-    context "when the paystubs synchronization fails" do
+    context "when account exists but paystubs synchronization fails" do
       let(:errored_jobs) { [ "paystubs" ] }
 
       it "redirects to the payment details page" do
@@ -73,6 +67,28 @@ RSpec.describe Cbv::SynchronizationsController do
 
         expect(response.body).to include("cbv/payment_details")
         expect(response.body).to include("turbo-stream action=\"redirect\"")
+      end
+    end
+
+    context "when account doesn't exist" do
+      it "continues polling" do
+        patch :update, params: { user: { account_id: nonexistent_id } }
+
+        expect(response.body).to include("turbo-frame id=\"synchronization\"")
+      end
+    end
+
+    context "when payroll_account is nil" do
+      before do
+        controller.instance_variable_set(:@payroll_account, nil)
+      end
+
+      it "renders partial and continues polling" do
+        patch :update, params: { user: { account_id: nonexistent_id } }
+
+        expect(response.body).to include("turbo-frame id=\"synchronization\"")
+        expect(response.body).not_to include("synchronization_failures")
+        expect(response).to render_template(partial: "_status")
       end
     end
   end

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -76,7 +76,6 @@ describe("ArgyleModalAdapter", () => {
     })
     it("triggers the modal adapter onSuccess callback", async () => {
       await triggers.triggerAccountConnected()
-      vi.advanceTimersByTime(1000) // TODO[FFS-2675]: Remove this timer advancement
       expect(modalAdapterArgs.onSuccess).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Ticket

Resolves [FFS-2675](https://jiraent.cms.gov/browse/FFS-2675).


## Changes
- Fixed race condition in synchronization handling
- Simplify controller logic
- Set controller render partial with nil payroll accounts
- Testing

## Context for reviewers
Users would get redirected to `/synchronization_failures` when `payroll_account` was `nil`, and we added a small timeout to alleviate it, but it wasn't enough and was brittle.

It was decided that we would handle redirecting to `/synchronization_failures` after a certain amount of polling or inability to retrieve data from webhook in a follow up ticket. 

## Testing
Proceed through flow to synchronizations page as usual, observing that although the timeout is gone, synchronizations page is rendered not failures.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
