### PR TITLE
FFS-2796-1: Rename sync tracking methods in PayrollAccount

### DIFF
--- a/app/app/controllers/cbv/synchronizations_controller.rb
+++ b/app/app/controllers/cbv/synchronizations_controller.rb
@@ -7,15 +7,15 @@ class Cbv::SynchronizationsController < Cbv::BaseController
   end
 
   def update
-    if @payroll_account&.synchronization_status("accounts") == :failed
+    if @payroll_account&.job_status("accounts") == :failed
+      # argyle throws a "system_error" in the payload of "accounts.updated" webhook.
+      # The "accounts" sync status will be set to :failed in that case. The sync status will be :unsupported for pinwheel.
       render turbo_stream: turbo_stream.action(:redirect, cbv_flow_synchronization_failures_path)
     elsif @payroll_account&.has_fully_synced?
       render turbo_stream: turbo_stream.action(
         :redirect,
         cbv_flow_payment_details_path(user: { account_id: @payroll_account.pinwheel_account_id })
       )
-    # argyle throws a "system_error" in the payload of "accounts.updated" webhook.
-    # The "accounts" sync status will be set to :failed in that case. The sync status will be :unsupported for pinwheel.
     else
       render turbo_stream: turbo_stream.replace(:synchronization, partial: "status")
     end

--- a/app/app/models/cbv_flow.rb
+++ b/app/app/models/cbv_flow.rb
@@ -34,6 +34,6 @@ class CbvFlow < ApplicationRecord
   end
 
   def has_account_with_required_data?
-    payroll_accounts.any?(&:has_required_data?)
+    payroll_accounts.any?(&:necessary_jobs_succeeded?)
   end
 end

--- a/app/app/models/payroll_account.rb
+++ b/app/app/models/payroll_account.rb
@@ -12,6 +12,37 @@ class PayrollAccount < ApplicationRecord
   belongs_to :cbv_flow
   has_many :webhook_events
 
+  # Returns whether we have received all expected webhooks for the sync
+  # process, regardless of whether any of them are errors.
+  #
+  # To determine whether the sync was ultimately successful, use the value of
+  # the `synchronization_status` column (via `sync_succeeded?`).
+  def has_fully_synced?
+    raise NotImplementedError
+  end
+
+  # Returns whether the job was successful.
+  def job_succeeded?(job)
+    raise NotImplementedError
+  end
+
+  # Returns the status of the job. Valid return values are:
+  #   :unsupported - The job is not supported for this account.
+  #   :succeeded   - The job completed successfully.
+  #   :failed      - The job completed with an error.
+  #   :in_progress - The job has not yet completed.
+  def job_status(job)
+    raise NotImplementedError
+  end
+
+  # Returns whether the minimal set of webhooks succeeded.
+  #
+  # This is an early way to bail out of even fetching the report if we know the
+  # data is not going to be present.
+  def necessary_jobs_succeeded?
+    raise NotImplementedError
+  end
+
   private
 
   def find_webhook_event(event_name, event_outcome = nil)

--- a/app/app/models/payroll_account/argyle.rb
+++ b/app/app/models/payroll_account/argyle.rb
@@ -25,7 +25,7 @@ class PayrollAccount::Argyle < PayrollAccount
     supported_jobs.include?(job) && find_webhook_event(self.class.event_for_job(job), "success").present?
   end
 
-  def synchronization_status_for_accounts_job
+  def accounts_job_status
     # the argyle accounts.updated event requires special handling because it's outcome is dynamic based on its payload.
     if find_webhook_event("accounts.updated", "error").present?
       :failed
@@ -34,12 +34,12 @@ class PayrollAccount::Argyle < PayrollAccount
     end
   end
 
-  def synchronization_status(job)
+  def job_status(job)
     if supported_jobs.exclude?(job)
       :unsupported
     elsif job == "accounts"
-      synchronization_status_for_accounts_job
-    elsif job_succeeded?(job)
+      accounts_job_status
+    elsif find_webhook_event(self.class.event_for_job(job), "success").present?
       :succeeded
     elsif find_webhook_event(self.class.event_for_job(job), "success").nil? && find_webhook_event(self.class.event_for_job(job), "error").nil?
       :in_progress

--- a/app/app/models/payroll_account/argyle.rb
+++ b/app/app/models/payroll_account/argyle.rb
@@ -20,7 +20,7 @@ class PayrollAccount::Argyle < PayrollAccount
   end
 
   def job_succeeded?(job)
-    supported_jobs.include?(job) && find_webhook_event(self.class.event_for_job(job), "success").present?
+    job_status(job) == :succeeded
   end
 
   def accounts_job_status
@@ -39,10 +39,10 @@ class PayrollAccount::Argyle < PayrollAccount
       accounts_job_status
     elsif find_webhook_event(self.class.event_for_job(job), "success").present?
       :succeeded
-    elsif find_webhook_event(self.class.event_for_job(job), "success").nil? && find_webhook_event(self.class.event_for_job(job), "error").nil?
-      :in_progress
     elsif find_webhook_event(self.class.event_for_job(job), "error").present?
       :failed
+    else
+      :in_progress
     end
   end
 

--- a/app/app/models/payroll_account/argyle.rb
+++ b/app/app/models/payroll_account/argyle.rb
@@ -7,8 +7,6 @@ class PayrollAccount::Argyle < PayrollAccount
     SQL
   end
 
-  # Jobs are used to map real-time Argyle data retrieval with the synchronizations page indicators
-  # We can assume that when the paystubs are fully synced, the employment and paystubs are also fully synced
   def has_fully_synced?
     supported_jobs.all? do |job|
       supported_jobs.exclude?(job) || find_webhook_event(self.class.event_for_job(job)).present?

--- a/app/app/models/payroll_account/argyle.rb
+++ b/app/app/models/payroll_account/argyle.rb
@@ -48,8 +48,8 @@ class PayrollAccount::Argyle < PayrollAccount
     end
   end
 
-  def has_required_data?
-    job_succeeded?("paystubs") || job_succeeded?("gigs")
+  def necessary_jobs_succeeded?
+    job_succeeded?("accounts") && (job_succeeded?("paystubs") || job_succeeded?("gigs"))
   end
 
   def self.event_for_job(job)

--- a/app/app/models/payroll_account/pinwheel.rb
+++ b/app/app/models/payroll_account/pinwheel.rb
@@ -25,7 +25,7 @@ class PayrollAccount::Pinwheel < PayrollAccount
     supported_jobs.include?(job) && find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :success).present?
   end
 
-  def synchronization_status(job)
+  def job_status(job)
     if supported_jobs.exclude?(job)
       :unsupported
     elsif job_succeeded?(job)

--- a/app/app/models/payroll_account/pinwheel.rb
+++ b/app/app/models/payroll_account/pinwheel.rb
@@ -37,7 +37,7 @@ class PayrollAccount::Pinwheel < PayrollAccount
     end
   end
 
-  def has_required_data?
+  def necessary_jobs_succeeded?
     job_succeeded?("paystubs")
   end
 end

--- a/app/app/models/payroll_account/pinwheel.rb
+++ b/app/app/models/payroll_account/pinwheel.rb
@@ -22,18 +22,18 @@ class PayrollAccount::Pinwheel < PayrollAccount
   end
 
   def job_succeeded?(job)
-    supported_jobs.include?(job) && find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :success).present?
+    job_status(job) == :succeeded
   end
 
   def job_status(job)
     if supported_jobs.exclude?(job)
       :unsupported
-    elsif job_succeeded?(job)
+    elsif find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :success).present?
       :succeeded
-    elsif find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :success).nil? && find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :error).nil?
-      :in_progress
     elsif find_webhook_event(JOBS_TO_WEBHOOK_EVENTS[job], :error).present?
       :failed
+    else
+      :in_progress
     end
   end
 

--- a/app/app/views/cbv/synchronizations/_indicators.html.erb
+++ b/app/app/views/cbv/synchronizations/_indicators.html.erb
@@ -2,21 +2,21 @@
   <div
     class="tablet:grid-col-2 grid-col-fill"
   >
-    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".income"), status: coalesce_to_completed(payroll_account.synchronization_status("income")) } %>
+    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".income"), status: coalesce_to_completed(payroll_account.job_status("income")) } %>
   </div>
   <div
     class="tablet:grid-col-2 grid-col-fill"
   >
-    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".employment"), status: coalesce_to_completed(payroll_account.synchronization_status("employment")) } %>
+    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".employment"), status: coalesce_to_completed(payroll_account.job_status("employment")) } %>
   </div>
   <div
     class="tablet:grid-col-2 grid-col-fill"
   >
-    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".paystubs"), status: payroll_account.synchronization_status("paystubs") } %>
+    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".paystubs"), status: payroll_account.job_status("paystubs") } %>
   </div>
   <div
     class="tablet:grid-col-2 grid-col-fill"
   >
-    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".identity"), status: coalesce_to_completed(payroll_account.synchronization_status("identity")) } %>
+    <%= render partial: "cbv/synchronizations/indicator", locals: { label: t(".identity"), status: coalesce_to_completed(payroll_account.job_status("identity")) } %>
   </div>
 </div>

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -239,14 +239,15 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
 
         expect(payroll_account.identity_errored_at).to be_nil
 
-        expect(fake_event_logger).to receive(:track)
-                                       .with("ApplicantEncounteredArgyleAccountSystemError", anything, anything).exactly(1).times
+        expect(fake_event_logger)
+          .to receive(:track)
+          .with("ApplicantEncounteredArgyleAccountSystemError", anything, anything).exactly(1).times
 
         process_webhook("accounts.updated", variant: :system_error)
         payroll_account.reload.webhook_events.reload
 
         expect(payroll_account.webhook_events.count).to eq(5)
-        expect(payroll_account.synchronization_status("accounts")).to equal(:failed)
+        expect(payroll_account.job_status("accounts")).to equal(:failed)
         expect(payroll_account.has_fully_synced?).to be_falsey
       end
     end

--- a/app/spec/models/payroll_account/argyle_spec.rb
+++ b/app/spec/models/payroll_account/argyle_spec.rb
@@ -21,23 +21,33 @@ RSpec.describe PayrollAccount::Argyle, type: :model do
       end
     end
 
-    describe '#has_required_data?' do
+    describe '#necessary_jobs_succeeded?' do
+      let(:account) { create(:payroll_account, :argyle, cbv_flow: cbv_flow) }
+
       it 'returns true when paystubs succeeded' do
-        account = create(:payroll_account, :argyle, cbv_flow: cbv_flow)
         create(:webhook_event, payroll_account: account, event_name: 'paystubs.partially_synced', event_outcome: 'success')
 
-        expect(account.has_required_data?).to be true
+        expect(account.necessary_jobs_succeeded?).to be true
       end
 
       it 'returns true when gigs succeeded' do
-        account = create(:payroll_account, :argyle, cbv_flow: cbv_flow)
         create(:webhook_event, payroll_account: account, event_name: 'gigs.partially_synced', event_outcome: 'success')
 
-        expect(account.has_required_data?).to be true
+        expect(account.necessary_jobs_succeeded?).to be true
       end
 
       it 'returns false when neither paystubs nor gigs succeeded' do
-        expect(payroll_account.has_required_data?).to be false
+        expect(payroll_account.necessary_jobs_succeeded?).to be false
+      end
+
+      context "when the accounts job fails" do
+        before do
+          create(:webhook_event, payroll_account: account, event_name: "accounts.updated", event_outcome: "error")
+        end
+
+        it "returns false" do
+          expect(payroll_account.necessary_jobs_succeeded?).to be false
+        end
       end
     end
   end

--- a/app/spec/models/payroll_account/pinwheel_spec.rb
+++ b/app/spec/models/payroll_account/pinwheel_spec.rb
@@ -94,14 +94,14 @@ RSpec.describe PayrollAccount::Pinwheel, type: :model do
     end
   end
 
-  describe "#synchronization_status" do
+  describe "#job_status" do
     context "when the job's status is succeeded" do
       before do
         create_webhook_events
       end
 
       it "returns succeeded" do
-        expect(payroll_account.synchronization_status('income')).to eq(:succeeded)
+        expect(payroll_account.job_status('income')).to eq(:succeeded)
       end
     end
 
@@ -111,13 +111,13 @@ RSpec.describe PayrollAccount::Pinwheel, type: :model do
       end
 
       it "returns failed" do
-        expect(payroll_account.synchronization_status('income')).to eq(:failed)
+        expect(payroll_account.job_status('income')).to eq(:failed)
       end
     end
 
     context "when the job has no events (either successful or errored)" do
       it "returns in_progress" do
-        expect(payroll_account.synchronization_status('income')).to eq(:in_progress)
+        expect(payroll_account.job_status('income')).to eq(:in_progress)
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe PayrollAccount::Pinwheel, type: :model do
       let(:supported_jobs) { super() - [ "income" ] }
 
       it "returns unsupported" do
-        expect(payroll_account.synchronization_status('income')).to eq(:unsupported)
+        expect(payroll_account.job_status('income')).to eq(:unsupported)
       end
     end
   end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

First half of [FFS-2796](https://jiraent.cms.gov/browse/FFS-2796). This is the refactoring part of the branch, upon which the actual fix is implemented.


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Rename existing synchronization_status -> job_status**
> This is in preparation for adding a `synchronization_status` field
> to the PayrollAccount itself, which tracks the overall synchronization
> status (not just for a single job).

**Rename `#has_required_data?` -> `#necessary_jobs_succeeded?`**
> This name better reflects that the logic does not actually depend on the
> data that's present.

**Improve documentation of PayrollAccount base class**

**Rewrite #job_succeeded? to defer to #job_status(job)**
> Just some logic simplifications in these methods.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
