### PR TITLE
FFS-2800: Allow multiple webhook events to indicate success

### DIFF
--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -77,9 +77,10 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
     end
   end
 
-  describe 'Argyle webhooks' do
+  describe 'when receiving webhooks for a full Argyle sync' do
     let(:cbv_flow) { create(:cbv_flow, argyle_user_id: "abc-def-ghi") }
     let(:argyle_account_id) { 'argyle_account_id' }
+    let(:fake_event_logger) { instance_double(GenericEventTracker) }
 
     # Instead of using "shared_examples_for" we're relying on a test helper method
     # since we cannot use "shared_examples_for" within the "it" test scope
@@ -102,156 +103,152 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
       expect(webhook_event.payroll_account.pinwheel_account_id).to eq(payroll_account.pinwheel_account_id)
     end
 
-    context 'PayrollAccount::Argyle model flow' do
-      let(:fake_event_logger) { instance_double(GenericEventTracker) }
+    before do
+      allow_any_instance_of(Aggregators::Sdk::ArgyleService)
+        .to receive(:fetch_identities_api)
+        .and_return(argyle_load_relative_json_file("sarah", "request_identity.json"))
+      allow_any_instance_of(Aggregators::Sdk::ArgyleService)
+        .to receive(:fetch_paystubs_api)
+        .and_return(argyle_load_relative_json_file("sarah", "request_paystubs.json"))
+      allow_any_instance_of(Aggregators::Sdk::ArgyleService)
+        .to receive(:fetch_gigs_api)
+        .and_return(argyle_load_relative_json_file("bob", "request_gigs.json"))
+      allow(controller).to receive(:event_logger).and_return(fake_event_logger)
+      allow(fake_event_logger).to receive(:track)
+    end
 
-      before do
-        allow_any_instance_of(Aggregators::Sdk::ArgyleService)
-          .to receive(:fetch_identities_api)
-          .and_return(argyle_load_relative_json_file("sarah", "request_identity.json"))
-        allow_any_instance_of(Aggregators::Sdk::ArgyleService)
-          .to receive(:fetch_paystubs_api)
-          .and_return(argyle_load_relative_json_file("sarah", "request_paystubs.json"))
-        allow_any_instance_of(Aggregators::Sdk::ArgyleService)
-          .to receive(:fetch_gigs_api)
-          .and_return(argyle_load_relative_json_file("bob", "request_gigs.json"))
-        allow(controller).to receive(:event_logger).and_return(fake_event_logger)
-        allow(fake_event_logger).to receive(:track)
-      end
-
-      it 'sequentially tests account synchronization flow' do
-        # Test each webhook in sequence
-        expect do
-          process_webhook("accounts.connected")
-        end.to change(PayrollAccount, :count).by(1)
-
-        payroll_account = PayrollAccount.last
-        expect(payroll_account.sync_in_progress?).to eq(true)
-
-        process_webhook("identities.added")
-        expect(payroll_account.webhook_events.count).to eq(2)
-
-        process_webhook("users.fully_synced")
-        expect(payroll_account.webhook_events.count).to eq(3)
-
-        process_webhook("gigs.partially_synced")
-        expect(payroll_account.webhook_events.count).to eq(4)
-
-        process_webhook("paystubs.partially_synced")
-        expect(payroll_account.webhook_events.count).to eq(5)
-
-        # expect the PayrollAccount to be fully synced
-        expect(payroll_account.has_fully_synced?).to be_truthy
-        expect(payroll_account.reload.sync_succeeded?).to eq(true)
-      end
-
-      it 'tracks an ApplicantFinishedArgyleSync event' do
+    it "results in a fully synced payroll account" do
+      # Test each webhook in sequence
+      expect do
         process_webhook("accounts.connected")
-        process_webhook("identities.added")
-        process_webhook("users.fully_synced")
-        process_webhook("gigs.partially_synced")
+      end.to change(PayrollAccount, :count).by(1)
 
-        expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
-          expect(event_name).to eq("ApplicantFinishedArgyleSync")
-          expect(attributes).to include(
-            cbv_flow_id: cbv_flow.id,
-            cbv_applicant_id: cbv_flow.cbv_applicant_id,
-            invitation_id: cbv_flow.cbv_flow_invitation_id,
-            sync_duration_seconds: be_a(Numeric),
+      payroll_account = PayrollAccount.last
+      expect(payroll_account.sync_in_progress?).to eq(true)
 
-            # Identity fields
-            identity_success: true,
-            identity_supported: true,
-            identity_count: 1,
-            identity_full_name_present: true,
-            identity_full_name_length: 15,
-            identity_date_of_birth_present: true,
-            identity_ssn_present: true,
-            identity_emails_count: 1,
-            identity_phone_numbers_count: 1,
+      process_webhook("identities.added")
+      expect(payroll_account.webhook_events.count).to eq(2)
 
-            # Income fields
-            income_success: true,
-            income_supported: true,
-            income_compensation_amount_present: true,
-            income_compensation_unit_present: true,
-            income_pay_frequency_present: true,
+      process_webhook("users.fully_synced")
+      expect(payroll_account.webhook_events.count).to eq(3)
 
-            # Paystubs fields
-            paystubs_success: true,
-            paystubs_supported: true,
-            paystubs_count: 10,
-            paystubs_deductions_count: 16,
-            paystubs_hours_by_earning_category_count: 10,
-            paystubs_hours_present: true,
-            paystubs_earnings_count: 33,
-            paystubs_earnings_with_hours_count: 10,
-            paystubs_earnings_type_base_count: 10,
-            paystubs_earnings_type_bonus_count: 10,
-            paystubs_earnings_type_overtime_count: 5,
-            paystubs_earnings_type_commission_count: 8,
+      process_webhook("gigs.partially_synced")
+      expect(payroll_account.webhook_events.count).to eq(4)
 
-            # Employment fields
-            employment_success: true,
-            employment_supported: true,
-            employment_status: "employed",
-            employment_type: "w2",
-            employment_employer_name: "Whole Foods",
-            employment_employer_address_present: true,
-            employment_employer_phone_number_present: true,
-            employment_start_date: "2022-08-08",
-            employment_termination_date: nil,
-            employment_type_w2_count: 1,
-            employment_type_gig_count: 0,
+      process_webhook("paystubs.partially_synced")
+      expect(payroll_account.webhook_events.count).to eq(5)
 
-            # Gigs fields
-            gigs_success: true,
-            gigs_supported: true
-          )
-        end
+      # expect the PayrollAccount to be fully synced
+      expect(payroll_account.has_fully_synced?).to be_truthy
+      expect(payroll_account.reload.sync_succeeded?).to eq(true)
+    end
 
-        process_webhook("paystubs.partially_synced")
+    it 'tracks an ApplicantFinishedArgyleSync event' do
+      process_webhook("accounts.connected")
+      process_webhook("identities.added")
+      process_webhook("users.fully_synced")
+      process_webhook("gigs.partially_synced")
+
+      expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
+        expect(event_name).to eq("ApplicantFinishedArgyleSync")
+        expect(attributes).to include(
+          cbv_flow_id: cbv_flow.id,
+          cbv_applicant_id: cbv_flow.cbv_applicant_id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          sync_duration_seconds: be_a(Numeric),
+
+          # Identity fields
+          identity_success: true,
+          identity_supported: true,
+          identity_count: 1,
+          identity_full_name_present: true,
+          identity_full_name_length: 15,
+          identity_date_of_birth_present: true,
+          identity_ssn_present: true,
+          identity_emails_count: 1,
+          identity_phone_numbers_count: 1,
+
+          # Income fields
+          income_success: true,
+          income_supported: true,
+          income_compensation_amount_present: true,
+          income_compensation_unit_present: true,
+          income_pay_frequency_present: true,
+
+          # Paystubs fields
+          paystubs_success: true,
+          paystubs_supported: true,
+          paystubs_count: 10,
+          paystubs_deductions_count: 16,
+          paystubs_hours_by_earning_category_count: 10,
+          paystubs_hours_present: true,
+          paystubs_earnings_count: 33,
+          paystubs_earnings_with_hours_count: 10,
+          paystubs_earnings_type_base_count: 10,
+          paystubs_earnings_type_bonus_count: 10,
+          paystubs_earnings_type_overtime_count: 5,
+          paystubs_earnings_type_commission_count: 8,
+
+          # Employment fields
+          employment_success: true,
+          employment_supported: true,
+          employment_status: "employed",
+          employment_type: "w2",
+          employment_employer_name: "Whole Foods",
+          employment_employer_address_present: true,
+          employment_employer_phone_number_present: true,
+          employment_start_date: "2022-08-08",
+          employment_termination_date: nil,
+          employment_type_w2_count: 1,
+          employment_type_gig_count: 0,
+
+          # Gigs fields
+          gigs_success: true,
+          gigs_supported: true
+        )
       end
 
-      it 'tracks an ApplicantReportMetUsefulRequirements event' do
-        process_webhook("accounts.connected")
-        process_webhook("identities.added")
-        process_webhook("users.fully_synced")
-        process_webhook("gigs.partially_synced")
+      process_webhook("paystubs.partially_synced")
+    end
 
-        expect(fake_event_logger).to receive(:track)
-           .with("ApplicantReportMetUsefulRequirements", anything, anything).exactly(1).times
+    it 'tracks an ApplicantReportMetUsefulRequirements event' do
+      process_webhook("accounts.connected")
+      process_webhook("identities.added")
+      process_webhook("users.fully_synced")
+      process_webhook("gigs.partially_synced")
 
-        process_webhook("paystubs.partially_synced")
-      end
+      expect(fake_event_logger).to receive(:track)
+         .with("ApplicantReportMetUsefulRequirements", anything, anything).exactly(1).times
 
-      it 'sequentially tests argyle "system_error" on accounts.updated' do
-        expect(PayrollAccount.count).to eq(0)
+      process_webhook("paystubs.partially_synced")
+    end
 
-        process_webhook("accounts.updated", variant: :invalid_mfa)
-        process_webhook("accounts.updated", variant: :connecting)
-        process_webhook("accounts.connected")
-        process_webhook("accounts.updated", variant: :connected)
+    it 'results in a sync failure after receiving "system_error" on accounts.updated' do
+      expect(PayrollAccount.count).to eq(0)
 
-        expect(PayrollAccount.count).to eq(1)
-        payroll_account = PayrollAccount.last
+      process_webhook("accounts.updated", variant: :invalid_mfa)
+      process_webhook("accounts.updated", variant: :connecting)
+      process_webhook("accounts.connected")
+      process_webhook("accounts.updated", variant: :connected)
 
-        expect_any_instance_of(PayrollAccount).to receive(:broadcast_replace).twice
+      expect(PayrollAccount.count).to eq(1)
+      payroll_account = PayrollAccount.last
 
-        expect(payroll_account.identity_errored_at).to be_nil
+      expect_any_instance_of(PayrollAccount).to receive(:broadcast_replace).twice
 
-        expect(fake_event_logger)
-          .to receive(:track)
-          .with("ApplicantEncounteredArgyleAccountSystemError", anything, anything).exactly(1).times
+      expect(payroll_account.identity_errored_at).to be_nil
 
-        process_webhook("accounts.updated", variant: :system_error)
-        payroll_account.reload.webhook_events.reload
+      expect(fake_event_logger)
+        .to receive(:track)
+        .with("ApplicantEncounteredArgyleAccountSystemError", anything, anything).exactly(1).times
 
-        expect(payroll_account.webhook_events.count).to eq(5)
-        expect(payroll_account.job_status("accounts")).to equal(:failed)
-        expect(payroll_account.sync_failed?).to equal(true)
-        expect(payroll_account.has_fully_synced?).to be_falsey
-      end
+      process_webhook("accounts.updated", variant: :system_error)
+      payroll_account.reload.webhook_events.reload
+
+      expect(payroll_account.webhook_events.count).to eq(5)
+      expect(payroll_account.job_status("accounts")).to equal(:failed)
+      expect(payroll_account.sync_failed?).to equal(true)
+      expect(payroll_account.has_fully_synced?).to be_falsey
     end
   end
 end

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
       expect(payroll_account.reload.sync_succeeded?).to eq(true)
     end
 
+    it "is fully synced even without the *.partially_synced events" do
+      process_webhook("accounts.connected")
+      process_webhook("identities.added")
+      process_webhook("gigs.fully_synced")
+      process_webhook("paystubs.fully_synced")
+      process_webhook("users.fully_synced")
+
+      payroll_account = PayrollAccount.last
+      expect(payroll_account.has_fully_synced?).to eq(true)
+      expect(payroll_account.reload.sync_succeeded?).to eq(true)
+    end
+
     it 'tracks an ApplicantFinishedArgyleSync event' do
       process_webhook("accounts.connected")
       process_webhook("identities.added")

--- a/app/spec/factories/payroll_account.rb
+++ b/app/spec/factories/payroll_account.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
         payroll_account.supported_jobs.each do |job|
           payroll_account.webhook_events << build(
             :webhook_event,
-            event_name: PayrollAccount::Argyle.event_for_job(job),
+            event_name: Aggregators::Webhooks::Argyle::EVENT_NAMES_BY_JOB[job].first,
             event_outcome: evaluator.with_errored_jobs.include?(job) ? "error" : "success"
           )
         end

--- a/app/spec/models/payroll_account/argyle_spec.rb
+++ b/app/spec/models/payroll_account/argyle_spec.rb
@@ -26,31 +26,56 @@ RSpec.describe PayrollAccount::Argyle, type: :model do
       end
     end
 
-    describe '#necessary_jobs_succeeded?' do
+    describe "#necessary_jobs_succeeded?" do
       let(:account) { create(:payroll_account, :argyle, cbv_flow: cbv_flow) }
 
-      it 'returns true when paystubs succeeded' do
-        create(:webhook_event, payroll_account: account, event_name: 'paystubs.partially_synced', event_outcome: 'success')
-
-        expect(account.necessary_jobs_succeeded?).to be true
-      end
-
-      it 'returns true when gigs succeeded' do
-        create(:webhook_event, payroll_account: account, event_name: 'gigs.partially_synced', event_outcome: 'success')
-
-        expect(account.necessary_jobs_succeeded?).to be true
-      end
-
-      it 'returns false when neither paystubs nor gigs succeeded' do
+      it "returns false when no webhooks have returned" do
         expect(payroll_account.necessary_jobs_succeeded?).to be false
       end
 
-      context "when the accounts job fails" do
+      it "returns false when only paystubs and gigs have been received" do
+        create(:webhook_event, payroll_account: account, event_name: "paystubs.partially_synced", event_outcome: "success")
+        create(:webhook_event, payroll_account: account, event_name: "gigs.partially_synced", event_outcome: "success")
+
+        expect(payroll_account.necessary_jobs_succeeded?).to be false
+      end
+
+      context "when accounts has succeeded" do
         before do
-          create(:webhook_event, payroll_account: account, event_name: "accounts.updated", event_outcome: "error")
+          create(:webhook_event, payroll_account: account, event_name: "accounts.connected", event_outcome: "success")
         end
 
-        it "returns false" do
+        it "returns true when paystubs succeeded" do
+          create(:webhook_event, payroll_account: account, event_name: "paystubs.partially_synced", event_outcome: "success")
+
+          expect(account.necessary_jobs_succeeded?).to be true
+        end
+
+        it "returns true when gigs succeeded" do
+          create(:webhook_event, payroll_account: account, event_name: "gigs.partially_synced", event_outcome: "success")
+
+          expect(account.necessary_jobs_succeeded?).to be true
+        end
+
+        it "returns true when paystubs.fully_synced has been received" do
+          # this is the case for gig jobs where paystubs.partially_synced may
+          # never be fetched
+          create(:webhook_event, payroll_account: account, event_name: "paystubs.fully_synced", event_outcome: "success")
+
+          expect(account.necessary_jobs_succeeded?).to be true
+        end
+
+        it "returns true when gigs.fully_synced has been received" do
+          # this is the case for W2 jobs where gigs.partially_synced may
+          # never be fetched
+          create(:webhook_event, payroll_account: account, event_name: "gigs.fully_synced", event_outcome: "success")
+
+          expect(account.necessary_jobs_succeeded?).to be true
+        end
+
+        it "returns false when an errored accounts.updated is received later" do
+          create(:webhook_event, payroll_account: account, event_name: "accounts.updated", event_outcome: "error")
+
           expect(payroll_account.necessary_jobs_succeeded?).to be false
         end
       end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2800](https://jiraent.cms.gov/browse/FFS-2800) and [FFS-2801](https://jiraent.cms.gov/browse/FFS-2801). Built atop #604.


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Reformat tests in Webhooks::Argyle::EventsController spec**
> * Rename the `describe` to make it more clear that the block is for
>   testing all webhooks in combination, not Argyle specifically (as all
>   the tests in this file are actually Argyle-specific).
> * Rename some of the other tests to be a bit more understandable what
>   the expectation is.
> * Remove one level of indenting.

**FFS-2800: Allow multiple webhook events to indicate success**
> We want to allow for either the `paystubs.partially_synced` or
> `paystubs.fully_synced` events to indicate the success of the "paystubs"
> job, since users with no paystubs will never get the `partially_synced`
> event. This necessitated an override to our default logic of using the
> `find_webhook_event` method, which attempts to check only a single
> webhook event name.

> This also allowed a cleanup of some "account"-job specific logic, since
> the mulitple event logic is now sharable across the "account",
> "paystubs", and "gigs" jobs.

> Also fixes FFS-2801.



## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
