### PR TITLE
FFS-2688-paystub_failed: implemented LA copy

### DIFF
--- a/app/app/views/cbv/synchronization_failures/show.html.erb
+++ b/app/app/views/cbv/synchronization_failures/show.html.erb
@@ -21,7 +21,7 @@
   </li>
   <li class="usa-button-group__item">
     <% if @cbv_flow.has_account_with_required_data? %>
-  <%= link_to t(".continue_to_report"), cbv_flow_summary_path, class: "usa-button" %>
+      <%= link_to t(".continue_to_report"), cbv_flow_summary_path, class: "usa-button" %>
     <% else %>
       <%= agency_translation("cbv.expired_invitations.show.cta_button_html") %>
     <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -340,8 +340,7 @@ en:
         body_1: You've either successfully completed your verification process, or are trying to access this invitation after it has expired.
         body_2: If you still need to verify your income, please submit your income information by visiting %{agency_short_name}'s website.
         cta_button_html:
-          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Visit DTA website</a>
-          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page" class="usa-button">Visit HRA website</a>
+          la_ldh: <a href="http://mymedicaid.la.gov/" class="usa-button">Visit LDH's website</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Learn more at CBV Test Agency</a>
         title: Your invitation to verify income has expired
     missing_results:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -180,8 +180,7 @@ es:
         body_1: Usted ya ha completado con éxito su proceso de verificación, o está intentando acceder a esta invitación después de que ha expirado.
         body_2: Si todavía no termina de verificar sus ingresos, envíe su información de ingresos desde el mismo sitio web de %{agency_short_name}.
         cta_button_html:
-          ma: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Visite el sitio web del DTA</a>
-          nyc: <a href="https://www.nyc.gov/site/hra/help/snap-application-frequently-asked-questions.page" class="usa-button">Visite el sitio web de la HRA</a>
+          la_ldh: <a href="http://mymedicaid.la.gov/" class="usa-button">Visite el sitio web del LDH</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button">Obtenga más información en la Agencia de pruebas CBV</a>
         title: Su invitación para verificar ingresos ha expirado
     missing_results:


### PR DESCRIPTION
## [FFS-2688-paystub_failed](https://jiraent.cms.gov/browse/FFS-2688)

## Changes
Implemented LA copy for /paystub_failed

## Testing instructions
1. Use [this link](http://localhost:3000/en/cbv/links/la_ldh) to kick off the generic link flow for LA
2. Running locally, edit synchrnonizations_controller.rb:10 to be "if true" to force a sync failure
3. Verify the copy matches [the design](https://confluenceent.cms.gov/pages/viewpage.action?pageId=815436921)
4. Redo the workflow but with one employer already linked and review the copy again. (You may also just be able to reload the page, since it seems like the sync "completes" in the background somehow.)

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshot
![image](https://github.com/user-attachments/assets/ee3e1a38-7a29-4001-9c47-a7c630e2be4c)



