### PR TITLE
FFS-2829: Track multiple partially_synced durations during F&F testing

### DIFF
--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
       process_webhook("users.fully_synced")
       process_webhook("gigs.partially_synced")
 
+      expect(fake_event_logger).to receive(:track).with("ApplicantReceivedArgyleData", anything, anything)
       expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
         expect(event_name).to eq("ApplicantFinishedArgyleSync")
         expect(attributes).to include(
@@ -233,6 +234,50 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
          .with("ApplicantReportMetUsefulRequirements", anything, anything).exactly(1).times
 
       process_webhook("paystubs.partially_synced")
+    end
+
+    it "tracks an ApplicantReceivedArgyleData event with multiple partially_synced events" do
+      process_webhook("accounts.connected")
+      process_webhook("identities.added")
+      process_webhook("gigs.partially_synced")
+
+      expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
+        expect(event_name).to eq("ApplicantReceivedArgyleData")
+        expect(attributes).to include(
+          cbv_flow_id: cbv_flow.id,
+          cbv_applicant_id: cbv_flow.cbv_applicant_id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          sync_duration_seconds: be_a(Numeric),
+          sync_data: "sixty_days"
+        )
+      end
+      process_webhook("paystubs.partially_synced")
+
+      expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
+        expect(event_name).to eq("ApplicantReceivedArgyleData")
+        expect(attributes).to include(
+          cbv_flow_id: cbv_flow.id,
+          cbv_applicant_id: cbv_flow.cbv_applicant_id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          sync_data: "six_months",
+          sync_duration_seconds: be_a(Numeric),
+          sync_event: "paystubs.partially_synced"
+        )
+      end
+      process_webhook("paystubs.partially_synced", variant: :six_months)
+
+      expect(fake_event_logger).to receive(:track) do |event_name, _request, attributes|
+        expect(event_name).to eq("ApplicantReceivedArgyleData")
+        expect(attributes).to include(
+          cbv_flow_id: cbv_flow.id,
+          cbv_applicant_id: cbv_flow.cbv_applicant_id,
+          invitation_id: cbv_flow.cbv_flow_invitation_id,
+          sync_data: "fully_synced",
+          sync_duration_seconds: be_a(Numeric),
+          sync_event: "users.fully_synced"
+        )
+      end
+      process_webhook("users.fully_synced")
     end
 
     it 'results in a sync failure after receiving "system_error" on accounts.updated' do

--- a/app/spec/factories/webhook_request.rb
+++ b/app/spec/factories/webhook_request.rb
@@ -54,16 +54,18 @@ FactoryBot.define do
               }
             }
           when "paystubs.partially_synced"
+            days_synced = evaluator.variant == :six_months ? 182 : 30
+
             {
               "event" => evaluator.event_type,
               "name" => evaluator.user,
               "data" => {
                 "account" => evaluator.argyle_account_id,
                 "user" => evaluator.argyle_user_id,
-                "available_from" => 30.days.ago.iso8601,
+                "available_from" => days_synced.days.ago.iso8601,
                 "available_to" => 1.day.ago.iso8601,
                 "available_count" => 16,
-                "days_synced" => 30
+                "days_synced" => days_synced
               }
             }
           when "paystubs.fully_synced"
@@ -79,6 +81,8 @@ FactoryBot.define do
               }
             }
           when "gigs.partially_synced"
+            days_synced = evaluator.variant == :six_months ? 182 : 30
+
             {
               "event" => evaluator.event_type,
               "name" => evaluator.user,
@@ -86,10 +90,10 @@ FactoryBot.define do
                 "account" => evaluator.argyle_account_id,
                 "user" => evaluator.argyle_user_id,
                 "item_id" => "item_000041078",
-                "available_from" => 30.days.ago.iso8601,
+                "available_from" => days_synced.days.ago.iso8601,
                 "available_to" => 1.days.ago.iso8601,
                 "available_count" => 16,
-                "days_synced" => 30
+                "days_synced" => days_synced
               }
             }
           when "gigs.fully_synced"
@@ -122,6 +126,7 @@ FactoryBot.define do
 end
 
 private
+
 def build_accounts_updated_payload(evaluator)
   case evaluator.variant
   when :connecting

--- a/app/spec/services/argyle_webhooks_manager_spec.rb
+++ b/app/spec/services/argyle_webhooks_manager_spec.rb
@@ -91,9 +91,9 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
         )
 
         expect(test_logger).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = https://different-url.ngrok.io/webhooks/argyle/events)")
-        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...").exactly(3).times
-        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}").exactly(3).times
-        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}").exactly(3).times
+        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...").exactly(4).times
+        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}").exactly(4).times
+        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}").exactly(4).times
 
         expect(argyle_service).to receive(:create_webhook_subscription).with(
           non_partial_webhook_events,
@@ -146,15 +146,16 @@ RSpec.describe ArgyleWebhooksManager, type: :service do
 
         expect(test_logger).to receive(:puts).with("  Existing Argyle webhook subscription found in Argyle sandbox: #{receiver_url}")
         expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([ other_sub ]).and_call_original # non-partial
-        expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([]).and_call_original.twice # no subscriptions for partial and include-resource webhooks
-        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...").twice
+        expect(argyle_webhooks_manager).to receive(:remove_subscriptions).with([]).and_call_original.exactly(3).times # no subscriptions for partial and include-resource webhooks
+        expect(test_logger).to receive(:puts).with("  Registering Argyle webhooks for Ngrok tunnel in Argyle sandbox...").exactly(3).times
         expect(test_logger).to receive(:puts).with("  Removing existing Argyle webhook subscription (url = #{other_sub["url"]})")
-        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}").twice
-        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}").twice
+        expect(test_logger).to receive(:puts).with("  ✅ Set up Argyle webhook: #{create_webhook_subscription_response["id"]}").exactly(3).times
+        expect(test_logger).to receive(:puts).with(" Argyle webhook url: #{receiver_url}").exactly(3).times
         expect(argyle_service).to receive(:delete_webhook_subscription).with(other_sub["id"])
         # Should NOT create a new subscription since we're reusing existing
         expect(argyle_service).not_to receive(:create_webhook_subscription).with(array_including("paystubs.fully_synced"), anything, anything, anything)
         # But it will create a subscription for the partially synced webhooks, since we didn't set it up earlier in the test
+        expect(argyle_service).to receive(:create_webhook_subscription).with(array_including("paystubs.partially_synced"), anything, anything, anything)
         expect(argyle_service).to receive(:create_webhook_subscription).with(array_including("paystubs.partially_synced"), anything, anything, anything)
         expect(argyle_service).to receive(:create_webhook_subscription).with(array_including("accounts.updated"), anything, anything, anything)
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2829](https://jiraent.cms.gov/browse/FFS-2829).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2650: Track ApplicantReceivedArgyleData for partial data**
> We want to track events tracking sync time for 6 months of data, and
> when the data is fully synced (in addition to our existing
> ApplicantFinishedArgyleSync event, which also track sync time for 90
> days of data).

> This commit:
> * Adds a new webhook to subscribe to the partially_synced webhooks for 6
>   months of data (182 days)
> * Updates Webhooks::Argyle::EventsController to send Mixpanel events
>   when receiving these partially_synced events
> * Updates Webhooks::Argyle::EventsController to also send the
>   ApplicantReceivedArgyleData event when getting the
>   `users.fully_synced` event.

> There is one other change: updating our definition of when the sync
> begins. Because we create the `PayrollAccount` upon receiving the
> `accounts.updated` webhook, and we receive those webhooks while the
> Argyle modal is still in the MFA step, we should really wait to receive
> the `accounts.connected` webhook in order to start the clock.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
