### PR TITLE
enforce last 4 of ssn for argyle

### DIFF
--- a/app/app/services/aggregators/format_methods/argyle.rb
+++ b/app/app/services/aggregators/format_methods/argyle.rb
@@ -64,4 +64,9 @@ module Aggregators::FormatMethods::Argyle
       :w2
     end
   end
+
+  def self.obfuscate_ssn(full_ssn)
+    return unless full_ssn
+    "XXX-XX-#{full_ssn.last(4).to_s.rjust(4, "X")}"
+  end
 end

--- a/app/app/services/aggregators/response_objects/identity.rb
+++ b/app/app/services/aggregators/response_objects/identity.rb
@@ -26,7 +26,7 @@ module Aggregators::ResponseObjects
         full_name: identity_response_body["full_name"],
         date_of_birth: identity_response_body["birth_date"],
         emails: [ identity_response_body["email"] ],
-        ssn: identity_response_body["ssn"],
+        ssn: (identity_response_body["ssn"]&.last(4) if identity_response_body["ssn"].present?),
         phone_numbers: [ identity_response_body["phone_number"] ]
       )
     end

--- a/app/app/services/aggregators/response_objects/identity.rb
+++ b/app/app/services/aggregators/response_objects/identity.rb
@@ -26,7 +26,7 @@ module Aggregators::ResponseObjects
         full_name: identity_response_body["full_name"],
         date_of_birth: identity_response_body["birth_date"],
         emails: [ identity_response_body["email"] ],
-        ssn: (identity_response_body["ssn"]&.last(4) if identity_response_body["ssn"].present?),
+        ssn: Aggregators::FormatMethods::Argyle.obfuscate_ssn(identity_response_body["ssn"]),
         phone_numbers: [ identity_response_body["phone_number"] ]
       )
     end

--- a/app/spec/services/aggregators/response_objects/identity_spec.rb
+++ b/app/spec/services/aggregators/response_objects/identity_spec.rb
@@ -31,8 +31,34 @@ RSpec.describe Aggregators::ResponseObjects::Identity do
       expect(identity.full_name).to eq("Bob Jones")
       expect(identity.emails).to eq([ "test1@argyle.com" ])
       expect(identity.phone_numbers).to eq([ "+18009000010" ])
-      expect(identity.ssn).to eq("522-09-1191")
+      expect(identity.ssn).to eq("1191")
       expect(identity.date_of_birth).to eq("1980-10-10")
+    end
+
+    context "test variations of ssn" do
+      it "shortens full ssn to 4 digits" do
+        argyle_response["ssn"] = "000-11-2222"
+        identity = described_class.from_argyle(argyle_response)
+        expect(identity.ssn).to eq("2222")
+      end
+
+      it "shortens 4-digit ssn to 4 digits" do
+        argyle_response["ssn"] = "2222"
+        identity = described_class.from_argyle(argyle_response)
+        expect(identity.ssn).to eq("2222")
+      end
+
+      it "shortens 2-digit ssn to 4 digits" do
+        argyle_response["ssn"] = "22"
+        identity = described_class.from_argyle(argyle_response)
+        expect(identity.ssn).to eq("22")
+      end
+
+      it "nil" do
+        argyle_response["ssn"] = nil
+        identity = described_class.from_argyle(argyle_response)
+        expect(identity.ssn).to be_nil
+      end
     end
   end
 end

--- a/app/spec/services/aggregators/response_objects/identity_spec.rb
+++ b/app/spec/services/aggregators/response_objects/identity_spec.rb
@@ -39,22 +39,22 @@ RSpec.describe Aggregators::ResponseObjects::Identity do
       it "shortens full ssn to 4 digits" do
         argyle_response["ssn"] = "000-11-2222"
         identity = described_class.from_argyle(argyle_response)
-        expect(identity.ssn).to eq("2222")
+        expect(identity.ssn).to eq("XXX-XX-2222")
       end
 
       it "shortens 4-digit ssn to 4 digits" do
         argyle_response["ssn"] = "2222"
         identity = described_class.from_argyle(argyle_response)
-        expect(identity.ssn).to eq("2222")
+        expect(identity.ssn).to eq("XXX-XX-2222")
       end
 
       it "shortens 2-digit ssn to 4 digits" do
         argyle_response["ssn"] = "22"
         identity = described_class.from_argyle(argyle_response)
-        expect(identity.ssn).to eq("22")
+        expect(identity.ssn).to eq("XXX-XX-XX22")
       end
 
-      it "nil" do
+      it "handles a nil ssn" do
         argyle_response["ssn"] = nil
         identity = described_class.from_argyle(argyle_response)
         expect(identity.ssn).to be_nil

--- a/app/spec/services/aggregators/response_objects/identity_spec.rb
+++ b/app/spec/services/aggregators/response_objects/identity_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Aggregators::ResponseObjects::Identity do
       expect(identity.full_name).to eq("Bob Jones")
       expect(identity.emails).to eq([ "test1@argyle.com" ])
       expect(identity.phone_numbers).to eq([ "+18009000010" ])
-      expect(identity.ssn).to eq("1191")
+      expect(identity.ssn).to eq("XXX-XX-1191")
       expect(identity.date_of_birth).to eq("1980-10-10")
     end
 


### PR DESCRIPTION
## Ticket

## Changes
* Argyle sends back the full SSN on the identities endpoint.  This ensures that we only capture the last 4 characters max.


## Acceptance testing
<!-- Check one: -->

- [x ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
