### PR TITLE
FFS-2688: Invitations: implemented LA copy

### DIFF
--- a/app/app/mailers/applicant_mailer.rb
+++ b/app/app/mailers/applicant_mailer.rb
@@ -18,6 +18,7 @@ class ApplicantMailer < ApplicationMailer
 
   def set_params
     @cbv_flow_invitation = params[:cbv_flow_invitation]
+    @cbv_flow = params[:cbv_flow]
   end
 
   def current_agency

--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -9,12 +9,15 @@
         <%= image_tag "dta_logo.png", class: "text-middle", style: "width: 140px" %>
       <% elsif current_agency.id == "nyc" %>
         <%= image_tag "hra_logo.png", class: "text-middle", style: "width: 170px" %>
+      <% elsif current_agency.id == "la_ldh" %>
+        <%= image_tag "hra_logo.png", class: "text-middle", style: "width: 170px" %>
+        <%# TIMOTEST TODO: implement image here too %>
       <% else %>
         <%= agency_translation("shared.header.cbv_flow_title") %>
       <% end %>
     </h3>
     <h1>
-      <%= agency_translation(".header") %>
+      <%= agency_translation(".header", agency_short_name: current_agency.agency_short_name) %>
     </h1>
     <div class="line-height-sans-5">
       <p>
@@ -22,11 +25,17 @@
       </p>
 
       <p><%= agency_translation(".body_1", agency_acronym: current_agency.agency_short_name) %></p>
-      <p><%= agency_translation(".body_2_html", deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %></p>
-      <p><%= agency_translation(".body_3", app_name: agency_translation("shared.app_name")) %></p>
+
+      <% if @cbv_flow.cbv_flow_invitation_id.present? %>
+        <p><%= agency_translation(".tokenized_link_deadline", deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %></p>
+      <% else %>
+        <p><%= t(".generic_link_deadline", deadline: format_date(@cbv_flow_invitation.expires_at.to_s)) %></p>
+      <% end %>
+
+      <p><%= t(".body_3", app_name: agency_translation("shared.app_name")) %></p>
 
       <p>
-        <%= t(".button_caption") %>
+        <%= agency_translation(".button_caption") %>
       </p>
     </div>
 
@@ -39,7 +48,7 @@
     <hr >
 
     <p class="font-body-3xs">
-      <%= t(".footer") %>
+      <%= agency_translation(".footer", agency_acronym: current_agency.agency_short_name) %>
     </p>
   </div>
 </section>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -192,19 +192,31 @@ ignore_missing:
     - "cbv.applicant_informations.la_ldh.fields.case_number.help_text"
     - "cbv.applicant_informations.la_ldh.fields.case_number.prompt"
     - "cbv.applicant_informations.la_ldh.fields.case_number.super_one_html"
-    
+
     # LA welcome (FFS-2688)
     - "pages.home.description_1"
     - "pages.home.description_2"
     - "pages.home.description_3"
     - "pages.home.header"
-    
+
     # LA client_pdf (FFS-2688)
     - "aggregator_strings.payment_frequencies.annual"
     - "aggregator_strings.payment_frequencies.annually"
     - "cbv.payment_details.show.employment_end_date"
     - "cbv.submits.show.application_or_recertification_date.la_ldh"
     - "cbv.submits.show.none_found"
+
+    # LA inviations (FFS-2688)
+    - "applicant_mailer.invitation_email.body_1.la_ldh"
+    - "applicant_mailer.invitation_email.body_3"
+    - "applicant_mailer.invitation_email.button_caption.default"
+    - "applicant_mailer.invitation_email.button_caption.la_ldh"
+    - "applicant_mailer.invitation_email.footer.default"
+    - "applicant_mailer.invitation_email.footer.la_ldh"
+    - "applicant_mailer.invitation_email.generic_link_deadline"
+    - "applicant_mailer.invitation_email.header.la_ldh"
+    - "applicant_mailer.invitation_email.subject.la_ldh"
+    - "applicant_mailer.invitation_email.tokenized_link_deadline_html.default"
 ## Consider these keys used:
 ignore_unused:
   all:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -114,24 +114,25 @@ en:
     invitation_email:
       body_1:
         default: "%{agency_acronym} wants you to verify your income as part of your SNAP application or recertification. The SNAP Income Pilot is a new tool designed to help you share your income data directly with %{agency_acronym} by logging into your payroll provider."
-        ma: "%{agency_acronym} wants you to verify your income as part of your SNAP recertification. The SNAP Income Pilot is a new tool designed to help you share your income data directly with %{agency_acronym} by logging into your payroll provider."
-      body_2_html:
-        default: This process is unique to you. Please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you can request a new invitation.
-        ma: This process is unique to you. Please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong>
-      body_3:
-        default: This is an optional tool. If you decide that you don't want to use it, you can provide income documents via the %{app_name} app, fax, mail, or in-person.
-        ma: This is an optional tool. If you decide that you don't want to use it, you can provide proof of your gross income and hours using %{app_name}, by fax, by mail, or in-person.
+        la_ldh: "%{agency_acronym} wants you to verify your income as part of your Medicaid application. The Medicaid Income Pilot is a new tool designed to help you share your income data directly with %{agency_acronym} by logging into your payroll provider or app-based/gig work employer."
+      body_3: This is an optional tool. If you decide that you don't want to use it, you can provide income documents via the %{app_name}.
       button: Verify your income
-      button_caption: 'To verify your income with the SNAP Income Pilot, click the button below:'
-      footer: This is an automatically generated message from your SNAP agency. Please don’t reply to this email.
+      button_caption:
+        default: 'To verify your income with the SNAP Income Pilot, click the button below:'
+        la_ldh: 'To verify your income with the Medicaid Income Pilot, click the button below:'
+      footer:
+        default: This is an automatically generated message from your SNAP agency. Please don’t reply to this email.
+        la_ldh: This is an automatically generated message from %{agency_acronym}. Please don’t reply to this email.
+      generic_link_deadline: You have until %{deadline} to complete your verification.
       greeting: Hello,
       header:
-        ma: DTA has sent you an invitation to verify your income
-        nyc: HRA has sent you an invitation to verify your income
+        la_ldh: "%{agency_short_name} has sent you an invitation to report your income"
         sandbox: CBV Test Agency has sent you an invitation to verify your income
       subject:
         default: Verify your income for your SNAP application or renewal
-        ma: Verify your income to renew your SNAP benefits
+        la_ldh: Verify your income for your Medicaid application
+      tokenized_link_deadline_html:
+        default: "<strong>You have until %{deadline} to complete your verification.</strong> Do not share this invitation with anyone outside your household."
   caseworker:
     cbv_flow_invitations:
       az_des:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -45,24 +45,12 @@ es:
     invitation_email:
       body_1:
         default: "%{agency_acronym} quiere que usted verifique sus ingresos como parte de su solicitud o recertificación del Programa de Asistencia Nutricional Suplementaria (SNAP, por sus siglas en inglés). El SNAP Income Pilot (Piloto de ingresos) es una nueva herramienta diseñada para ayudarle a compartir información de sus ingresos directamente con %{agency_acronym} iniciando sesión en su proveedor de nóminas."
-        ma: "%{agency_acronym} quiere que usted verifique sus ingresos como parte de su solicitud o recertificación del Programa de Asistencia Nutricional Suplementaria (SNAP, por sus siglas en inglés). El SNAP Income Pilot (Piloto de ingresos) es una nueva herramienta diseñada para ayudarle a compartir información de sus ingresos directamente con %{agency_acronym} iniciando sesión en su proveedor de nóminas."
-      body_2_html:
-        default: Este proceso es solo para usted. Por favor, no comparta esta invitación con nadie más. <strong>Tiene hasta el %{deadline}, para realizar su verificación.</strong> De lo contrario, puede solicitar una nueva invitación.
-        ma: Este proceso es solo para usted. Por favor, no comparta esta invitación con nadie más. <strong>Tiene hasta el %{deadline}, para realizar su verificación.</strong>
-      body_3:
-        default: Esta es una herramienta opcional. Si decide que no desea usarla, puede proveer los documentos de sus ingresos a través de la aplicación %{app_name}, fax, correo postal o en persona.
-        ma: Esta es una herramienta opcional. Si decide no usarla, puede proveer el comprobante de sus ingresos brutos y horas usando %{app_name}, por fax, por correo postal o en persona.
       button: Verifique sus ingresos
-      button_caption: 'Para verificar sus ingresos con el SNAP Income Pilot, haga clic en el siguiente botón:'
-      footer: Este es un mensaje generado automáticamente desde su agencia de SNAP. Por favor no conteste a este correo electrónico.
       greeting: "¡Hola!"
       header:
-        ma: El Departamento de Asistencia Transitoria (DTA, por sus siglas en inglés) le ha enviado una invitación para verificar sus ingresos
-        nyc: La Administración de Recursos Humanos (HRA, por sus siglas en inglés) le ha enviado una invitación para verificar sus ingresos
         sandbox: La Agencia de pruebas CBV le ha enviado una invitación para verificar sus ingresos
       subject:
         default: Verifique sus ingresos para su solicitud o renovación de SNAP
-        ma: Verifique sus ingresos para renovar sus beneficios de SNAP
   caseworker:
     cbv_flow_invitations:
       create:

--- a/app/spec/factories/cbv_flow_invitation.rb
+++ b/app/spec/factories/cbv_flow_invitation.rb
@@ -25,6 +25,12 @@ FactoryBot.define do
       cbv_applicant { create(:cbv_applicant, :az_des) }
     end
 
+    trait :la_ldh do
+      client_agency_id { "la_ldh" }
+
+      cbv_applicant { create(:cbv_applicant, :la_ldh) }
+    end
+
     transient do
       cbv_applicant_attributes { {} }
     end

--- a/app/spec/mailers/previews/applicant_mailer_preview.rb
+++ b/app/spec/mailers/previews/applicant_mailer_preview.rb
@@ -4,13 +4,22 @@ class ApplicantMailerPreview < BaseMailerPreview
 
   def invitation_email_dta
     ApplicantMailer.with(
-      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :ma, user: unique_user, language: I18n.locale)
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :ma, user: unique_user, language: I18n.locale),
+      cbv_flow: FactoryBot.create(:cbv_flow, :with_pinwheel_account)
     ).invitation_email
   end
 
   def invitation_email_nyc
     ApplicantMailer.with(
-      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc, user: unique_user, language: I18n.locale)
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc, user: unique_user, language: I18n.locale),
+      cbv_flow: FactoryBot.create(:cbv_flow, :with_pinwheel_account)
+    ).invitation_email
+  end
+
+  def invitation_email_la_ldh
+    ApplicantMailer.with(
+      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :la_ldh, user: unique_user, language: I18n.locale),
+      cbv_flow: FactoryBot.create(:cbv_flow, :with_pinwheel_account)
     ).invitation_email
   end
 


### PR DESCRIPTION
## [FFS-2688-invitations](https://jiraent.cms.gov/browse/FFS-2688)

## Changes
Implemented LA copy for invitations email

## Testing instructions
1. Use [this link](http://localhost:3000/rails/mailers/applicant_mailer/invitation_email_la_ldh) to access the mailer preview for the LA invitation
2. Verify the copy matches [the design](https://confluenceent.cms.gov/display/SFIV/Invitations)

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshot






