### PR TITLE
remove libvips, because its an image processing library that had a security vuln and rather than update, why bump this unless we need it

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -140,7 +140,6 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl=7.88.1-10+deb12u12 \
         libgpgme11=1.18.0-3+b1 \
-        libvips42=8.14.1-3+deb12u1 \
         linux-libc-dev=6.1.135-1 \
         openssl=3.0.15-1~deb12u1 \
         postgresql-client=15+248 \


### PR DESCRIPTION
## Changes
remove libvips, because its an image processing library that had a security vuln and rather than update, why bump this unless we need it

## Context for reviewers

This came up because of a recent trivy scan 
```
[info] checking github for release tag='v0.74.4' 
[info] fetching release script for tag='v0.74.4' 
[info] checking github for release tag='v0.74.4' 
[info] using release tag='v0.74.4' version='0.74.4' os='linux' arch='amd64' 
[info] installed /home/runner/work/_temp/16c6f042-66e4-4667-a5ee-3647b167ab34_grype/grype 
grype output...
NAME       INSTALLED         FIXED-IN          TYPE  VULNERABILITY   SEVERITY 
libvips42  8.[14](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/14838901311/job/41656699205?pr=597#step:4:15).1-3+deb12u1  8.14.1-3+deb12u2  deb   CVE-2025-29769  High
```
## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
