### PR TITLE
FFS-2817: Add NewRelic monitoring role to AWS terraform

### DIFF
--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -32,4 +32,7 @@ module "dev_config" {
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
   # Defaults to `false`. Uncomment the next line to enable.
   enable_command_execution = true
+
+  # NewRelic configuration for metrics
+  newrelic_account_id = "4619676"
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -47,6 +47,12 @@ output "identity_provider_config" {
   value = local.identity_provider_config
 }
 
+output "newrelic_config" {
+  value = {
+    account_id = var.newrelic_account_id
+  }
+}
+
 output "notifications_config" {
   value = local.notifications_config
 }

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -79,6 +79,11 @@ variable "network_name" {
   type        = string
 }
 
+variable "newrelic_account_id" {
+  description = "NewRelic Account ID"
+  type        = string
+}
+
 variable "project_name" {
   type = string
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -26,4 +26,7 @@ module "prod_config" {
   # Defaults to `false`. Uncomment the next line to enable.
   # ⚠️ Warning! It is not recommended to enable this in a production environment.
   # enable_command_execution = true
+
+  # NewRelic configuration for metrics
+  newrelic_account_id = "4619676"
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -259,7 +259,7 @@ module "email" {
   source                      = "../../modules/email"
   hosted_zone_domain          = local.network_config.domain_config.hosted_zone
   domain                      = local.service_config.domain_name
-  newrelic_account_id         = "4619676"
+  newrelic_account_id         = local.environment_config.newrelic_config.account_id
   newrelic_api_key_param_name = "/service/${local.service_config.service_name}/newrelic-key"
 }
 

--- a/infra/app/service/newrelic.tf
+++ b/infra/app/service/newrelic.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "newrelic_metrics" {
+  # checkov:skip=CKV_AWS_61:This policy principal needs to be broad to allow for monitoring all services.
+
+  name = "newrelic-metrics-collector"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = "754728514883" # NewRelic's AWS Account ID
+        }
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = local.environment_config.newrelic_config.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "newrelic_metrics" {
+  role       = aws_iam_role.newrelic_metrics.id
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Necessary so I can make the dashboards/alerts called for in [FFS-2817](https://jiraent.cms.gov/browse/FFS-2817).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2817: Add NewRelic monitoring role to AWS terraform**
> We want to be able to ingest AWS metrics into NewRelic so we can set up
> dashboards, alerts, and the like. To do so, we need to give NewRelic
> readonly access to everything.

> We already had a limited form of NewRelic integration in our email
> module - I took this time to more properly support configuration of this
> parameter via variables in the env config.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
