### PR TITLE
bring back libvips because i suspect thats why the background worker started failing

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -140,7 +140,7 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl=7.88.1-10+deb12u12 \
         libgpgme11=1.18.0-3+b1 \
-        libvips42=8.16.1 \
+        libvips42=8.14.1-3+deb12u2 \
         linux-libc-dev=6.1.135-1 \
         openssl=3.0.15-1~deb12u1 \
         postgresql-client=15+248 \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -140,6 +140,7 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl=7.88.1-10+deb12u12 \
         libgpgme11=1.18.0-3+b1 \
+        libvips42=8.14.1 \
         linux-libc-dev=6.1.135-1 \
         openssl=3.0.15-1~deb12u1 \
         postgresql-client=15+248 \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -140,7 +140,7 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl=7.88.1-10+deb12u12 \
         libgpgme11=1.18.0-3+b1 \
-        libvips42=8.14.1 \
+        libvips42=8.16.1 \
         linux-libc-dev=6.1.135-1 \
         openssl=3.0.15-1~deb12u1 \
         postgresql-client=15+248 \


### PR DESCRIPTION
# Context

not that its about libvips in particular, but this is doing the quick fix before taking time to address technical debt later.

why did this break things?

wkhtmltopdf depends on a host of dependencies, and I think libvips's dependencies is secretly saving us here. because wkhtmltopdf is a dragon of a dependency management problem, lets make that better another day.

error in particular:

Failed to execute:
["/usr/local/bundle/ruby/3.3.0/gems/wkhtmltopdf-binary-<IPV4>/bin/wkhtmltopdf", "--footer-right", "Income Verification Report | Page [page] of [topage]", "--footer-font-size", "10", "file:////rails/tmp/wicked_pdf20250506-68-5caeoy.html", "/rails/tmp/wicked_pdf_generated_file20250506-68-b0q2u5.pdf"]
Error: PDF could not be generated!
 Command Error: pid <NUMBER> exit 127
/usr/local/bundle/ruby/3.3.0/gems/wkhtmltopdf-binary-<IPV4>/bin/wkhtmltopdf_debian_12_amd64: error while loading shared libraries: libjpeg.so.62: cannot open shared object file: No such file or directory

- [ X] Acceptance testing after merge
  * The difficult thing about this change is because our CI doesn't run using the docker container, and I couldn't even get the test to fail locally using a docker container, it seems like the only way to check this is in staging right now.