### PR TITLE
FFS-2729 guide someone who was going directly from a search page to missing results to get guided to applicant information

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -61,7 +61,7 @@ class Cbv::BaseController < ApplicationController
     when "cbv/synchronizations"
       cbv_flow_payment_details_path
     when "cbv/missing_results"
-      cbv_flow_summary_path
+      cbv_flow_applicant_information_path
     when "cbv/payment_details"
       cbv_flow_add_job_path
     when "cbv/applicant_informations"


### PR DESCRIPTION
## Ticket

Resolves [FFS-2729](https://jiraent.cms.gov/browse/FFS-2729).


## Changes
previous fix handled the case where NOT on the missing results page clicking through (search with 0 results --> click to proceed), but this handles the case where they directly click on missing results from searching and getting results back.

## Acceptance testing
<!-- Check one: -->

- [X ] Acceptance testing prior to merge
  The previous fix corrected a link on the /missing_results page. But there is another link that can appear when you've already linked results and returned to the /employer_searches page. This PR fixes that link. To test:

Link an employer and return to the /employer_searches screen by clicking "yes I have more employers to link"
Search something that will produce some results, like "mcdonald"
Click the "Missing my employer" button, then press "continue" . Previously, this would not trigger a load of /applicant_information, but now it will. (Note: if testing in LA, you will still see the /summary page, but this is because of a separate issue that will be fixed once the DOB control is merged. If you look at your logs, you can tell that clicking continue triggered the /applicant_information page, but it then redirected to /summary)