### PR TITLE
FFS-2688: fixes round 2

### DIFF
--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -57,7 +57,7 @@
 <table class="usa-table usa-table--borderless width-full margin-top-2">
   <h3><%= t(".your_information") %></h3>
   <div class="usa-prose">
-    <p><%= t(".must_match", agency_acronym: current_agency.agency_short_name) %></p>
+    <p><%= agency_translation(".must_match", agency_acronym: current_agency.agency_short_name) %></p>
   </div>
   <thead class="border-top-05">
     <tr>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -253,6 +253,10 @@ ignore_missing:
     # LA fixes (FFS-2688)
     - "cbv.applicant_informations.show.explanation"
     - "cbv.employer_searches.show.exit_button_text"
+
+    # LA fixes-2 (FFS-2688)
+    - "cbv.summaries.show.must_match.default"
+    - "cbv.summaries.show.must_match.la_ldh"
 ## Consider these keys used:
 ignore_unused:
   all:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -484,7 +484,9 @@ en:
         application_information: Applicant information
         description: The report below has your income from the past 90 days, from %{start_date} to %{end_date}. Please review it before sending.
         header: Review your income report
-        must_match: This must match what is shown on your %{agency_acronym} application.
+        must_match:
+          default: This must match what is shown on your %{agency_acronym} application.
+          la_ldh: This must match what is shown on your Medicaid benefits.
         none_found: We didn't find any payments from this employer in the past 90 days.
         payment: Payment of %{amount} before taxes on %{date}
         phone_number: Employer phone

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
         criteria_disclaimer: 'Note: If you''ve had other jobs in the past %{pay_income_days} days that don''t meet these criteria, you may need to submit that income information separately.'
         header: Do you have another job to report?
         learn_more_link_html:
-          la_ldh: Learn more on <a href="%{agency_url} target="_blank" rel="noopener noreferrer">LDH's website</a>.
+          la_ldh: Learn more on <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">LDH's website</a>.
           sandbox: Learn more on <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank" rel="noopener noreferrer">CBV Test Agency's website</a>.
         no_radio: No, I don’t have another job that meets the criteria
         subheader: Please add other jobs you’ve had in the past %{pay_income_days} days, even if you're no longer at that job.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -255,7 +255,6 @@ es:
     summaries:
       show:
         additional_comments: Comentarios adicionales
-        must_match: Estos datos deben coincidir con lo que se muestra en la solicitud que presentó ante %{agency_acronym}.
         none_found: No encontramos ningún pago de este empleador en los últimos 90 días.
         payment: Pago de %{amount} antes de pago impuestos en %{date}
         phone_number: Teléfono del empleador


### PR DESCRIPTION
## [FFS-2688](https://jiraent.cms.gov/browse/FFS-2688)

## Changes
Various fixes found during AC testing of the original fix PR. These include:
1. /add_job: the link in the body text above the CTA opened a 404 page in LA. Not, it does not.
2. /summary: this string now reads "your Medicaid benefits" in LA.
![image](https://github.com/user-attachments/assets/88066bb4-d693-4420-88e4-9ae0d253420b)


## Testing instructions
1. Use [this link](http://localhost:3000/en/cbv/links/la_ldh) to kick off the generic link flow for LA
2. Proceed through the flow to the pages mentioned above and make sure the copy you see reflects the fix described.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [X] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)






