### PR TITLE
FFS-2852: Fix date format issues

### DIFF
--- a/app/app/helpers/report_view_helper.rb
+++ b/app/app/helpers/report_view_helper.rb
@@ -5,7 +5,7 @@ module ReportViewHelper
   end
 
   # Default format is Month Day, Year (e.g. January 1, 2020)
-  def format_parsed_date(date, format = "%B %-d, %Y")
+  def format_parsed_date(date, format = :long)
     return unless date
     I18n.l(date.to_date, format: format)
   end

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -522,6 +522,7 @@ en:
   date:
     formats:
       default: "%Y-%m-%d"
+      long: "%B %-d, %Y"
   help:
     alert:
       heading: Need help connecting to your payroll provider?

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -294,7 +294,7 @@ es:
     - Vie
     - Sáb
     abbr_month_names:
-    - nil
+    -
     - Ene
     - Feb
     - Mar
@@ -319,7 +319,7 @@ es:
       default: "%d/%m/%Y"
       long: "%-d de %B de %Y"
     month_names:
-    - nil
+    -
     - Enero
     - Febrero
     - Marzo

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -294,6 +294,7 @@ es:
     - Vie
     - Sáb
     abbr_month_names:
+    - nil
     - Ene
     - Feb
     - Mar
@@ -318,6 +319,7 @@ es:
       default: "%d/%m/%Y"
       long: "%-d de %B de %Y"
     month_names:
+    - nil
     - Enero
     - Febrero
     - Marzo

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -286,27 +286,27 @@ es:
   continue: Continuar
   date:
     abbr_day_names:
-    - Do
-    - Lu
-    - Ma
-    - Mi
-    - Ju
-    - Vi
-    - Sá
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
     abbr_month_names:
     -
-    - ene.
-    - feb.
-    - mar.
-    - abr.
-    - may.
-    - jun.
-    - jul.
-    - ago.
-    - sep.
-    - oct.
-    - nov.
-    - dic.
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
     day_names:
     - domingo
     - lunes
@@ -316,8 +316,9 @@ es:
     - viernes
     - sábado
     formats:
-      default: "%d/%m/%Y"
+      default: "%-d/%-m/%Y"
       long: "%-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
     -
     - enero

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -286,52 +286,52 @@ es:
   continue: Continuar
   date:
     abbr_day_names:
-    - Dom
-    - Lun
-    - Mar
-    - Mié
-    - Jue
-    - Vie
-    - Sáb
+    - Do
+    - Lu
+    - Ma
+    - Mi
+    - Ju
+    - Vi
+    - Sá
     abbr_month_names:
     -
-    - Ene
-    - Feb
-    - Mar
-    - Abr
-    - May
-    - Jun
-    - Jul
-    - Ago
-    - Sep
-    - Oct
-    - Nov
-    - Dic
+    - ene.
+    - feb.
+    - mar.
+    - abr.
+    - may.
+    - jun.
+    - jul.
+    - ago.
+    - sep.
+    - oct.
+    - nov.
+    - dic.
     day_names:
-    - Domingo
-    - Lunes
-    - Martes
-    - Miércoles
-    - Jueves
-    - Viernes
-    - Sábado
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
     formats:
       default: "%d/%m/%Y"
       long: "%-d de %B de %Y"
     month_names:
     -
-    - Enero
-    - Febrero
-    - Marzo
-    - Abril
-    - Mayo
-    - Junio
-    - Julio
-    - Agosto
-    - Septiembre
-    - Octubre
-    - Noviembre
-    - Diciembre
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
   help:
     index:
       company_id: No sé la identificación de mi empresa

--- a/app/spec/components/aggregate_data_point_component_spec.rb
+++ b/app/spec/components/aggregate_data_point_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AggregateDataPointComponent, type: :component do
     expect(
       render_inline(described_class.new(:pay_period, "2024-01-01", "2024-01-15"))
     ).to have_text(
-      "January 01, 2024 to January 15, 2024"
+      "January 1, 2024 to January 15, 2024"
     )
   end
 
@@ -55,7 +55,7 @@ RSpec.describe AggregateDataPointComponent, type: :component do
     expect(
       render_inline(described_class.new(:employment_start_date, "2024-01-01"))
     ).to have_text(
-      "January 01, 2024"
+      "January 1, 2024"
     )
   end
 
@@ -63,7 +63,7 @@ RSpec.describe AggregateDataPointComponent, type: :component do
     expect(
       render_inline(described_class.new(:employment_end_date, "2024-01-01"))
     ).to have_text(
-      "January 01, 2024"
+      "January 1, 2024"
     )
   end
 

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ReportViewHelper, type: :helper do
         date_string = Date.new(2023, 8, 7) # A Tuesday
         format = "%b"
 
-        expect(helper.format_date(date_string, format: format)).to match(/ago\./)
+        expect(helper.format_date(date_string, format: format)).to match(/ago/)
       end
 
       it 'formats a date with "%A" format as Wednesday correctly' do

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -87,4 +87,75 @@ RSpec.describe ReportViewHelper, type: :helper do
       end
     end
   end
+
+  describe '#format_date and #format_parsed_date' do
+    around do |ex|
+      I18n.with_locale(locale, &ex)
+    end
+
+    context 'when locale is :en' do
+      let(:locale) { :en }
+
+      it 'formats January 1st correctly' do
+        date_string = "2023-01-01"
+        expect(helper.format_date(date_string)).to eq('January 1, 2023')
+
+        date_string = "2023-1-1"
+        expect(helper.format_date(date_string)).to eq('January 1, 2023')
+
+        date = Date.new(2023, 1, 1)
+        expect(helper.format_date(date)).to eq('January 1, 2023')
+        expect(helper.format_parsed_date(date)).to eq('January 1, 2023')
+      end
+
+      it 'formats February 28th correctly' do
+        date_string = "2023-02-28"
+        expect(helper.format_date(date_string)).to eq('February 28, 2023')
+
+        date = Date.new(2023, 2, 28)
+        expect(helper.format_date(date)).to eq('February 28, 2023')
+        expect(helper.format_parsed_date(date)).to eq('February 28, 2023')
+      end
+
+      it 'formats December 31st correctly' do
+        date_string = "2023-12-31"
+        expect(helper.format_date(date_string)).to eq('December 31, 2023')
+
+        date = Date.new(2023, 12, 31)
+        expect(helper.format_date(date)).to eq('December 31, 2023')
+        expect(helper.format_parsed_date(date)).to eq('December 31, 2023')
+      end
+    end
+
+    context 'when locale is :es' do
+      let(:locale) { :es }
+
+      it 'formats January 1st correctly' do
+        date_string = "2023-1-1"
+        expect(helper.format_date(date_string)).to eq('1 de Enero de 2023')
+
+        date = Date.new(2023, 1, 1)
+        expect(helper.format_date(date)).to eq('1 de Enero de 2023')
+        expect(helper.format_parsed_date(date)).to eq('1 de Enero de 2023')
+      end
+
+      it 'formats February 28th correctly' do
+        date_string = "2023-02-28"
+        expect(helper.format_date(date_string)).to eq('28 de Febrero de 2023')
+
+        date = Date.new(2023, 2, 28)
+        expect(helper.format_date(date)).to eq('28 de Febrero de 2023')
+        expect(helper.format_parsed_date(date)).to eq('28 de Febrero de 2023')
+      end
+
+      it 'formats December 31st correctly' do
+        date_string = "2023-12-31"
+        expect(helper.format_date(date_string)).to eq('31 de Diciembre de 2023')
+
+        date = Date.new(2023, 12, 31)
+        expect(helper.format_date(date)).to eq('31 de Diciembre de 2023')
+        expect(helper.format_parsed_date(date)).to eq('31 de Diciembre de 2023')
+      end
+    end
+  end
 end

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -147,44 +147,44 @@ RSpec.describe ReportViewHelper, type: :helper do
 
       it 'formats January 1st correctly' do
         date_string = "2023-1-1"
-        expect(helper.format_date(date_string)).to eq('1 de Enero de 2023')
+        expect(helper.format_date(date_string)).to eq('1 de enero de 2023')
 
         date = Date.new(2023, 1, 1)
-        expect(helper.format_date(date)).to eq('1 de Enero de 2023')
-        expect(helper.format_parsed_date(date)).to eq('1 de Enero de 2023')
+        expect(helper.format_date(date)).to eq('1 de enero de 2023')
+        expect(helper.format_parsed_date(date)).to eq('1 de enero de 2023')
       end
 
       it 'formats February 28th correctly' do
         date_string = "2023-02-28"
-        expect(helper.format_date(date_string)).to eq('28 de Febrero de 2023')
+        expect(helper.format_date(date_string)).to eq('28 de febrero de 2023')
 
         date = Date.new(2023, 2, 28)
-        expect(helper.format_date(date)).to eq('28 de Febrero de 2023')
-        expect(helper.format_parsed_date(date)).to eq('28 de Febrero de 2023')
+        expect(helper.format_date(date)).to eq('28 de febrero de 2023')
+        expect(helper.format_parsed_date(date)).to eq('28 de febrero de 2023')
       end
 
       it 'formats December 31st correctly' do
         date_string = "2023-12-31"
-        expect(helper.format_date(date_string)).to eq('31 de Diciembre de 2023')
+        expect(helper.format_date(date_string)).to eq('31 de diciembre de 2023')
 
         date = Date.new(2023, 12, 31)
-        expect(helper.format_date(date)).to eq('31 de Diciembre de 2023')
-        expect(helper.format_parsed_date(date)).to eq('31 de Diciembre de 2023')
+        expect(helper.format_date(date)).to eq('31 de diciembre de 2023')
+        expect(helper.format_parsed_date(date)).to eq('31 de diciembre de 2023')
       end
 
       it 'formats a date with "%b" format as August correctly' do
         date_string = Date.new(2023, 8, 7) # A Tuesday
         format = "%b"
 
-        expect(helper.format_date(date_string, format: format)).to match(/Ago/)
+        expect(helper.format_date(date_string, format: format)).to match(/ago\./)
       end
 
       it 'formats a date with "%A" format as Wednesday correctly' do
         date_string = Date.new(2023, 11, 8) # A Wednesday
         format = { format: "%A" }
 
-        expect(helper.format_date(date_string, format: format)).to match(/Miércoles/)
-        expect(helper.format_parsed_date(date_string, format: format)).to match(/Miércoles/)
+        expect(helper.format_date(date_string, format: format)).to match(/miércoles/)
+        expect(helper.format_parsed_date(date_string, format: format)).to match(/miércoles/)
       end
     end
   end

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -87,8 +87,51 @@ RSpec.describe ReportViewHelper, type: :helper do
       end
     end
   end
+  describe '#format_parsed_date' do
+    around do |ex|
+      I18n.with_locale(locale, &ex)
+    end
 
-  describe '#format_date and #format_parsed_date' do
+    context 'when locale is :en' do
+      let(:locale) { :en }
+
+      it 'formats January 1st correctly' do
+        date = Date.new(2023, 1, 1)
+        expect(helper.format_parsed_date(date)).to eq('January 1, 2023')
+      end
+
+      it 'formats February 28th correctly' do
+        date = Date.new(2023, 2, 28)
+        expect(helper.format_parsed_date(date)).to eq('February 28, 2023')
+      end
+
+      it 'formats December 31st correctly' do
+        date = Date.new(2023, 12, 31)
+        expect(helper.format_parsed_date(date)).to eq('December 31, 2023')
+      end
+    end
+
+    context 'when locale is :es' do
+      let(:locale) { :es }
+
+      it 'formats January 1st correctly' do
+        date = Date.new(2023, 1, 1)
+        expect(helper.format_parsed_date(date)).to eq('1 de enero de 2023')
+      end
+
+      it 'formats February 28th correctly' do
+        date = Date.new(2023, 2, 28)
+        expect(helper.format_parsed_date(date)).to eq('28 de febrero de 2023')
+      end
+
+      it 'formats December 31st correctly' do
+        date = Date.new(2023, 12, 31)
+        expect(helper.format_parsed_date(date)).to eq('31 de diciembre de 2023')
+      end
+    end
+  end
+
+  describe '#format_date' do
     around do |ex|
       I18n.with_locale(locale, &ex)
     end
@@ -105,7 +148,6 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 1, 1)
         expect(helper.format_date(date)).to eq('January 1, 2023')
-        expect(helper.format_parsed_date(date)).to eq('January 1, 2023')
       end
 
       it 'formats February 28th correctly' do
@@ -114,7 +156,6 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 2, 28)
         expect(helper.format_date(date)).to eq('February 28, 2023')
-        expect(helper.format_parsed_date(date)).to eq('February 28, 2023')
       end
 
       it 'formats December 31st correctly' do
@@ -123,22 +164,20 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 12, 31)
         expect(helper.format_date(date)).to eq('December 31, 2023')
-        expect(helper.format_parsed_date(date)).to eq('December 31, 2023')
       end
 
       it 'formats a date with "%b" format as August correctly' do
-        date_string = Date.new(2023, 8, 7) # A Tuesday
+        date = Date.new(2023, 8, 7) # A Tuesday
         format = "%b"
 
-        expect(helper.format_date(date_string, format: format)).to match(/Aug/)
+        expect(helper.format_date(date, format: format)).to match(/Aug/)
       end
 
       it 'formats a date with "%A" format as Wednesday correctly' do
-        date_string = Date.new(2023, 11, 8) # A Wednesday
+        date = Date.new(2023, 11, 8) # A Wednesday
         format = "%A"
 
-        expect(helper.format_date(date_string, format: format)).to match(/Wednesday/)
-        expect(helper.format_parsed_date(date_string, format: format)).to match(/Wednesday/)
+        expect(helper.format_date(date, format: format)).to match(/Wednesday/)
       end
     end
 
@@ -151,7 +190,6 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 1, 1)
         expect(helper.format_date(date)).to eq('1 de enero de 2023')
-        expect(helper.format_parsed_date(date)).to eq('1 de enero de 2023')
       end
 
       it 'formats February 28th correctly' do
@@ -160,7 +198,6 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 2, 28)
         expect(helper.format_date(date)).to eq('28 de febrero de 2023')
-        expect(helper.format_parsed_date(date)).to eq('28 de febrero de 2023')
       end
 
       it 'formats December 31st correctly' do
@@ -169,22 +206,20 @@ RSpec.describe ReportViewHelper, type: :helper do
 
         date = Date.new(2023, 12, 31)
         expect(helper.format_date(date)).to eq('31 de diciembre de 2023')
-        expect(helper.format_parsed_date(date)).to eq('31 de diciembre de 2023')
       end
 
       it 'formats a date with "%b" format as August correctly' do
-        date_string = Date.new(2023, 8, 7) # A Tuesday
+        date = Date.new(2023, 8, 7) # A Tuesday
         format = "%b"
 
-        expect(helper.format_date(date_string, format: format)).to match(/ago/)
+        expect(helper.format_date(date, format: format)).to match(/ago/)
       end
 
       it 'formats a date with "%A" format as Wednesday correctly' do
-        date_string = Date.new(2023, 11, 8) # A Wednesday
+        date = Date.new(2023, 11, 8) # A Wednesday
         format = { format: "%A" }
 
-        expect(helper.format_date(date_string, format: format)).to match(/miércoles/)
-        expect(helper.format_parsed_date(date_string, format: format)).to match(/miércoles/)
+        expect(helper.format_date(date, format: format)).to match(/miércoles/)
       end
     end
   end

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe ReportViewHelper, type: :helper do
         expect(helper.format_date(date)).to eq('December 31, 2023')
         expect(helper.format_parsed_date(date)).to eq('December 31, 2023')
       end
+
+      it 'formats a date with "%b" format as August correctly' do
+        date_string = Date.new(2023, 8, 7) # A Tuesday
+        format = "%b"
+
+        expect(helper.format_date(date_string, format: format)).to match(/Aug/)
+      end
+
+      it 'formats a date with "%A" format as Wednesday correctly' do
+        date_string = Date.new(2023, 11, 8) # A Wednesday
+        format = "%A"
+
+        expect(helper.format_date(date_string, format: format)).to match(/Wednesday/)
+        expect(helper.format_parsed_date(date_string, format: format)).to match(/Wednesday/)
+      end
     end
 
     context 'when locale is :es' do
@@ -155,6 +170,21 @@ RSpec.describe ReportViewHelper, type: :helper do
         date = Date.new(2023, 12, 31)
         expect(helper.format_date(date)).to eq('31 de Diciembre de 2023')
         expect(helper.format_parsed_date(date)).to eq('31 de Diciembre de 2023')
+      end
+
+      it 'formats a date with "%b" format as August correctly' do
+        date_string = Date.new(2023, 8, 7) # A Tuesday
+        format = "%b"
+
+        expect(helper.format_date(date_string, format: format)).to match(/Ago/)
+      end
+
+      it 'formats a date with "%A" format as Wednesday correctly' do
+        date_string = Date.new(2023, 11, 8) # A Wednesday
+        format = { format: "%A" }
+
+        expect(helper.format_date(date_string, format: format)).to match(/Miércoles/)
+        expect(helper.format_parsed_date(date_string, format: format)).to match(/Miércoles/)
       end
     end
   end


### PR DESCRIPTION
## Ticket

Resolves [FFS-2852](https://jiraent.cms.gov/browse/FFS-2852).


## Changes
<!-- What was added, updated, or removed in this PR. -->
* Fixes issue where all Spanish dates were off by a month (e.g. January 1 became 1 Febrero). 
    * This is caused by Ruby's default Date string mappings set 0'th index to nil so that January has index position 1. 
* Copied all spanish date translation configuration from [i18n gem template](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/es.yml). 
 
![image](https://github.com/user-attachments/assets/15c649f9-165a-44a7-8f87-96701c96805c)
![image](https://github.com/user-attachments/assets/491d3209-e9a9-49ce-8918-f53063079f7b)

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
