### PR TITLE
FFS-2842: Update source of pay_frequency for argyle

### DIFF
--- a/app/app/services/aggregators/response_objects/income.rb
+++ b/app/app/services/aggregators/response_objects/income.rb
@@ -1,11 +1,11 @@
-INCOME_FIELDS = %i[
-  account_id
-  pay_frequency
-  compensation_amount
-  compensation_unit
-]
-
 module Aggregators::ResponseObjects
+  INCOME_FIELDS = %i[
+    account_id
+    pay_frequency
+    compensation_amount
+    compensation_unit
+  ]
+
   Income = Struct.new(*INCOME_FIELDS, keyword_init: true) do
     def self.from_pinwheel(response_body)
       new(
@@ -19,7 +19,7 @@ module Aggregators::ResponseObjects
     def self.from_argyle(identities_response_body)
       new(
         account_id: identities_response_body["account"],
-        pay_frequency: identities_response_body["base_pay"]["period"],
+        pay_frequency: identities_response_body["pay_cycle"],
         compensation_amount: Aggregators::FormatMethods::Argyle.format_currency(
           identities_response_body["base_pay"]["amount"]
         ),

--- a/app/spec/services/aggregators/response_objects/income_spec.rb
+++ b/app/spec/services/aggregators/response_objects/income_spec.rb
@@ -26,10 +26,11 @@ RSpec.describe Aggregators::ResponseObjects::Income do
       {
         "account" => "67890",
         "base_pay" => {
-          "period" => "semimonthly",
+          "period" => "biweekly",
           "amount" => "50.24",
           "currency" => "USD"
-        }
+        },
+        "pay_cycle" => "semimonthly"
       }
     end
     it 'creates an Income object from argyle response' do


### PR DESCRIPTION
## [FFS-2842](https://jiraent.cms.gov/browse/FFS-2842)

## Changes
In Argyle, pay_frequency should come from Identities.pay_cycle, not Identities.base_pay.period.

## Testing Instructions
0. Set up your local dev instance to use Argyle (set SUPPORTED_PROVIDERS).
1. Navigate through the CBV workflow until you get to /payment details and observe the pay frequency. It should match what was returned in the Identities.pay_cycle value.
2. Also verify this value on on the PDF
3. Repeat the test using Pinwheel and verify that the pay frequency reporting is unchanged in these places

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [X] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshot
![image](https://github.com/user-attachments/assets/9873faa6-e56c-4e16-a0e0-343bb623ff2d)

