### PR TITLE
add testing routing to see if we can isolate who is responsible for the issue

### DIFF
--- a/app/app/controllers/health_check_controller.rb
+++ b/app/app/controllers/health_check_controller.rb
@@ -5,6 +5,12 @@ class HealthCheckController < ActionController::Base
     render json: { status: "ok", version: ENV["IMAGE_TAG"] }
   end
 
+  def test_ok
+    # adding a second database query to distinguish healthiness of using one query vs another
+    PerformanceTestingJob.perform_later(Random.new.rand(1..CbvFlow.last.id))
+    render json: { status: "ok" }
+  end
+
   def test_rendering
     return head :not_found unless Rails.env.development?
 

--- a/app/app/jobs/performance_testing_job.rb
+++ b/app/app/jobs/performance_testing_job.rb
@@ -1,0 +1,5 @@
+class PerformanceTestingJob < ApplicationJob
+  queue_as :default
+  def perform(random_id)
+  end
+end

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     root "pages#home"
 
     get "/health", to: "health_check#ok"
+    get "/health/test_ok", to: "health_check#test_ok"
     get "/health/test_rendering", to: "health_check#test_rendering"
     get "/help", to: "help#index", as: :help
     get "/help/:topic", to: "help#show", as: :help_topic


### PR DESCRIPTION
## Changes

The performance under certain load is highly questionable--and we're having a hard time isolating where the issue is. This exposes a new endpoint that should assist in determining this--this will give us a newrelic query with A) exactly two queries, one to solid queue and one without and B) using a much simpler solidqueue query insert than what EventTrackingJob currently does. 

If this performs better than our current setup, that means we need to rethink how we queue more complex jobs into solid queue.
If this performs equally to our current setup OR the performance is better but the throughput does not increase, I think this increases my suspicion that something's messed up with the load balancer. 

- [ X] Acceptance testing after merge
 * we will remove this route after a round of testing in demo.