### PR TITLE
FFS-2828: Added paystubs_days_since_last_pay_date metric

### DIFF
--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -222,7 +222,7 @@ class Webhooks::Argyle::EventsController < ApplicationController
         paystubs_earnings_type_bonus_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "bonus" } },
         paystubs_earnings_type_overtime_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "overtime" } },
         paystubs_earnings_type_commission_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "commission" } },
-        paystubs_days_since_last_paid: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
+        paystubs_days_since_last_pay_date: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
 
         # Employment fields (originally from "identities" endpoint)
         employment_success: payroll_account.job_succeeded?("employment"),

--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -222,6 +222,7 @@ class Webhooks::Argyle::EventsController < ApplicationController
         paystubs_earnings_type_bonus_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "bonus" } },
         paystubs_earnings_type_overtime_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "overtime" } },
         paystubs_earnings_type_commission_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "commission" } },
+        paystubs_days_since_last_paid: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
 
         # Employment fields (originally from "identities" endpoint)
         employment_success: payroll_account.job_succeeded?("employment"),

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -120,7 +120,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         paystubs_earnings_category_salary_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "salary" } },
         paystubs_earnings_category_bonus_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "bonus" } },
         paystubs_earnings_category_overtime_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "overtime" } },
-        paystubs_days_since_last_paid: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
+        paystubs_days_since_last_pay_date: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
 
         # Employment fields
         employment_success: @payroll_account.job_succeeded?("employment"),

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -120,6 +120,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         paystubs_earnings_category_salary_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "salary" } },
         paystubs_earnings_category_bonus_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "bonus" } },
         paystubs_earnings_category_overtime_count: report.paystubs.sum { |p| p.earnings.count { |e| e.category == "overtime" } },
+        paystubs_days_since_last_paid: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
 
         # Employment fields
         employment_success: @payroll_account.job_succeeded?("employment"),

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
           paystubs_earnings_type_bonus_count: 10,
           paystubs_earnings_type_overtime_count: 5,
           paystubs_earnings_type_commission_count: 8,
-          paystubs_days_since_last_paid: 73,
+          paystubs_days_since_last_pay_date: 73,
 
           # Employment fields
           employment_success: true,

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -104,6 +104,10 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
     end
 
     before do
+      # The report metric, "paystubs_days_since_last_paid" will use Timecop
+      # for a static date to reference as "now". This allows for consistent test results
+      Timecop.freeze(Time.local(2025, 5, 15))
+
       allow_any_instance_of(Aggregators::Sdk::ArgyleService)
         .to receive(:fetch_identities_api)
         .and_return(argyle_load_relative_json_file("sarah", "request_identity.json"))
@@ -115,6 +119,10 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
         .and_return(argyle_load_relative_json_file("bob", "request_gigs.json"))
       allow(controller).to receive(:event_logger).and_return(fake_event_logger)
       allow(fake_event_logger).to receive(:track)
+    end
+
+    after do
+      Timecop.return
     end
 
     it "results in a fully synced payroll account" do
@@ -202,6 +210,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
           paystubs_earnings_type_bonus_count: 10,
           paystubs_earnings_type_overtime_count: 5,
           paystubs_earnings_type_commission_count: 8,
+          paystubs_days_since_last_paid: 73,
 
           # Employment fields
           employment_success: true,

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               invitation_id: cbv_flow.cbv_flow_invitation_id,
               client_agency_id: "sandbox",
               pinwheel_environment: "sandbox",
-              sync_duration_seconds: within(1.second).of(5.minutes),
+              sync_duration_seconds: be_a(Numeric),
 
               # Identity fields
               identity_success: true,
@@ -170,7 +170,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               paystubs_earnings_category_salary_count: 2,
               paystubs_earnings_category_bonus_count: 2,
               paystubs_earnings_category_overtime_count: 0,
-              paystubs_days_since_last_paid: 1565,
+              paystubs_days_since_last_pay_date: 1565,
 
 
               # Employment fields

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
         let(:event_logger) { instance_double(GenericEventTracker) }
 
         before do
+          # The report metric, "paystubs_days_since_last_paid" will use Timecop
+          # for a static date to reference as "now". This allows for consistent test results
+          Timecop.freeze(Time.local(2025, 5, 15))
+
           pinwheel_stub_request_identity_response
           pinwheel_stub_request_income_metadata_response
           pinwheel_stub_request_end_user_multiple_paystubs_response
@@ -117,6 +121,10 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
           pinwheel_stub_request_shifts_response
 
           allow(controller).to receive(:event_logger).and_return(event_logger)
+        end
+
+        after do
+          Timecop.return
         end
 
         it "sends full report analytics when synced" do
@@ -162,6 +170,8 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               paystubs_earnings_category_salary_count: 2,
               paystubs_earnings_category_bonus_count: 2,
               paystubs_earnings_category_overtime_count: 0,
+              paystubs_days_since_last_paid: 1565,
+
 
               # Employment fields
               employment_success: true,


### PR DESCRIPTION
Resolves [FFS-2828](https://jiraent.cms.gov/browse/FFS-2828).


## Changes
- Added a new metric `paystubs_days_since_last_pay_date` which is the difference between the latest pay date of all of the applicant's paystubs and the date the report was generated.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
