### PR TITLE
FFS-2870: Terraform configuration to support LA launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ spec/examples.txt
 secrets.auto.tfvars
 terraform.tfstate
 terraform.tfstate.backup
+results.sarif
 
 #IDE Specific (RubyMine)
 .idea

--- a/infra/app/app-config/env-config/database.tf
+++ b/infra/app/app-config/env-config/database.tf
@@ -8,6 +8,9 @@ locals {
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
     migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
 
+    serverless_min_capacity = var.database_serverless_min_capacity
+    serverless_max_capacity = var.database_serverless_max_capacity
+
     # Enable extensions that require the rds_superuser role to be created here
     # See docs/infra/set-up-database.md for more information
     superuser_extensions = {}

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -25,7 +25,7 @@ output "service_config" {
     cpu                               = var.service_cpu
     memory                            = var.service_memory
     desired_instance_count            = var.service_desired_instance_count
-    desired_solidqueue_instance_count = var.desired_solidqueue_instance_count
+    solidqueue_desired_instance_count = var.solidqueue_desired_instance_count
     enable_command_execution          = var.enable_command_execution
     additional_domains                = var.additional_domains
 

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -18,15 +18,16 @@ output "network_name" {
 
 output "service_config" {
   value = {
-    service_name             = "${local.prefix}${var.app_name}-${var.environment}"
-    domain_name              = var.domain_name
-    enable_https             = var.enable_https
-    region                   = var.default_region
-    cpu                      = var.service_cpu
-    memory                   = var.service_memory
-    desired_instance_count   = var.service_desired_instance_count
-    enable_command_execution = var.enable_command_execution
-    additional_domains       = var.additional_domains
+    service_name                      = "${local.prefix}${var.app_name}-${var.environment}"
+    domain_name                       = var.domain_name
+    enable_https                      = var.enable_https
+    region                            = var.default_region
+    cpu                               = var.service_cpu
+    memory                            = var.service_memory
+    desired_instance_count            = var.service_desired_instance_count
+    desired_solidqueue_instance_count = var.desired_solidqueue_instance_count
+    enable_command_execution          = var.enable_command_execution
+    additional_domains                = var.additional_domains
 
     extra_environment_variables = merge(
       local.default_extra_environment_variables,

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -111,3 +111,15 @@ variable "service_override_extra_environment_variables" {
   EOT
   default     = {}
 }
+
+variable "database_serverless_min_capacity" {
+  description = "The minimum capacity for the Aurora Serverless cluster in ACUs (Aurora Capacity Units)"
+  type        = number
+  default     = 0.5
+}
+
+variable "database_serverless_max_capacity" {
+  description = "The maximum capacity for the Aurora Serverless cluster in ACUs (Aurora Capacity Units)"
+  type        = number
+  default     = 1.0
+}

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -99,8 +99,8 @@ variable "service_desired_instance_count" {
 }
 
 variable "desired_solidqueue_instance_count" {
-  type        = number
   description = "Number of SolidQueue worker instances to run"
+  type        = number
   default     = 1
 }
 

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -98,9 +98,9 @@ variable "service_desired_instance_count" {
   default = 1
 }
 
-variable "desired_solidqueue_instance_count" {
-  description = "Number of SolidQueue worker instances to run"
+variable "solidqueue_desired_instance_count" {
   type        = number
+  description = "Number of SolidQueue worker instances to run"
   default     = 1
 }
 

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -98,6 +98,12 @@ variable "service_desired_instance_count" {
   default = 1
 }
 
+variable "desired_solidqueue_instance_count" {
+  type        = number
+  description = "Number of SolidQueue worker instances to run"
+  default     = 1
+}
+
 variable "service_memory" {
   type    = number
   default = 512

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -11,12 +11,15 @@ module "prod_config" {
   has_incident_management_service = local.has_incident_management_service
   enable_identity_provider        = local.enable_identity_provider
 
+  database_serverless_min_capacity = 5.0
+  database_serverless_max_capacity = 10.0
+
   # These numbers are a starting point based on this article
   # Update the desired instance size and counts based on the project's specific needs
   # https://conchchow.medium.com/aws-ecs-fargate-compute-capacity-planning-a5025cb40bd0
   service_cpu                    = 1024
   service_memory                 = 4096
-  service_desired_instance_count = 3
+  service_desired_instance_count = 10
 
   # Create DNS records for these `additional_domains` in the default hosted
   # zone (this is necessary to support CBV agency subdomains).

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -17,9 +17,10 @@ module "prod_config" {
   # These numbers are a starting point based on this article
   # Update the desired instance size and counts based on the project's specific needs
   # https://conchchow.medium.com/aws-ecs-fargate-compute-capacity-planning-a5025cb40bd0
-  service_cpu                    = 1024
-  service_memory                 = 4096
-  service_desired_instance_count = 10
+  service_cpu                       = 1024
+  service_memory                    = 4096
+  service_desired_instance_count    = 10
+  desired_solidqueue_instance_count = 2
 
   # Create DNS records for these `additional_domains` in the default hosted
   # zone (this is necessary to support CBV agency subdomains).

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -20,7 +20,7 @@ module "prod_config" {
   service_cpu                       = 1024
   service_memory                    = 4096
   service_desired_instance_count    = 10
-  desired_solidqueue_instance_count = 2
+  solidqueue_desired_instance_count = 2
 
   # Create DNS records for these `additional_domains` in the default hosted
   # zone (this is necessary to support CBV agency subdomains).

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -93,7 +93,6 @@ module "database" {
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
   is_temporary                   = local.is_temporary
 
-  enable_performance_insights = true
-  serverless_min_capacity     = local.database_config.serverless_min_capacity
-  serverless_max_capacity     = local.database_config.serverless_max_capacity
+  serverless_min_capacity = local.database_config.serverless_min_capacity
+  serverless_max_capacity = local.database_config.serverless_max_capacity
 }

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -92,4 +92,8 @@ module "database" {
   private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
   is_temporary                   = local.is_temporary
+
+  enable_performance_insights = true
+  serverless_min_capacity     = local.database_config.serverless_min_capacity
+  serverless_max_capacity     = local.database_config.serverless_max_capacity
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -173,10 +173,11 @@ module "service" {
   certificate_arn    = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
   additional_domains = local.service_config.additional_domains
 
-  cpu                      = local.service_config.cpu
-  memory                   = local.service_config.memory
-  desired_instance_count   = local.service_config.desired_instance_count
-  enable_command_execution = local.service_config.enable_command_execution
+  cpu                               = local.service_config.cpu
+  memory                            = local.service_config.memory
+  desired_instance_count            = local.service_config.desired_instance_count
+  desired_solidqueue_instance_count = local.service_config.desired_solidqueue_instance_count
+  enable_command_execution          = local.service_config.enable_command_execution
 
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -176,7 +176,7 @@ module "service" {
   cpu                               = local.service_config.cpu
   memory                            = local.service_config.memory
   desired_instance_count            = local.service_config.desired_instance_count
-  desired_solidqueue_instance_count = local.service_config.desired_solidqueue_instance_count
+  solidqueue_desired_instance_count = local.service_config.solidqueue_desired_instance_count
   enable_command_execution          = local.service_config.enable_command_execution
 
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -34,6 +34,7 @@ resource "aws_rds_cluster" "db" {
   storage_encrypted           = true
   kms_key_id                  = aws_kms_key.db.arn
   allow_major_version_upgrade = false
+  enable_http_endpoint        = true
 
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
 
@@ -49,8 +50,8 @@ resource "aws_rds_cluster" "db" {
   deletion_protection = !var.is_temporary
 
   serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
+    max_capacity = var.serverless_max_capacity
+    min_capacity = var.serverless_min_capacity
   }
 
   db_subnet_group_name   = var.database_subnet_group_name
@@ -60,14 +61,16 @@ resource "aws_rds_cluster" "db" {
 }
 
 resource "aws_rds_cluster_instance" "primary" {
-  identifier                 = local.primary_instance_name
-  cluster_identifier         = aws_rds_cluster.db.id
-  instance_class             = "db.serverless"
-  engine                     = aws_rds_cluster.db.engine
-  engine_version             = aws_rds_cluster.db.engine_version
-  auto_minor_version_upgrade = true
-  monitoring_role_arn        = aws_iam_role.rds_enhanced_monitoring.arn
-  monitoring_interval        = 30
+  identifier                      = local.primary_instance_name
+  cluster_identifier              = aws_rds_cluster.db.id
+  instance_class                  = "db.serverless"
+  engine                          = aws_rds_cluster.db.engine
+  engine_version                  = aws_rds_cluster.db.engine_version
+  auto_minor_version_upgrade      = true
+  monitoring_role_arn             = aws_iam_role.rds_enhanced_monitoring.arn
+  monitoring_interval             = 30
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = aws_kms_key.db.arn
 }
 
 resource "aws_kms_key" "db" {

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -77,3 +77,21 @@ variable "vpc_id" {
   type        = string
   description = "Uniquely identifies the VPC."
 }
+
+variable "enable_performance_insights" {
+  description = "Whether to enable Performance Insights for the RDS instance. Usually enabled only in production."
+  type        = bool
+  default     = false
+}
+
+variable "serverless_min_capacity" {
+  description = "The minimum capacity for the Aurora Serverless cluster. Value should be in Aurora capacity units (ACU)"
+  type        = number
+  default     = 0.5
+}
+
+variable "serverless_max_capacity" {
+  description = "The maximum capacity for the Aurora Serverless cluster. Value should be in Aurora capacity units (ACU)"
+  type        = number
+  default     = 1.0
+}

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -78,12 +78,6 @@ variable "vpc_id" {
   description = "Uniquely identifies the VPC."
 }
 
-variable "enable_performance_insights" {
-  description = "Whether to enable Performance Insights for the RDS instance. Usually enabled only in production."
-  type        = bool
-  default     = false
-}
-
 variable "serverless_min_capacity" {
   description = "The minimum capacity for the Aurora Serverless cluster. Value should be in Aurora capacity units (ACU)"
   type        = number

--- a/infra/modules/service/async_workers.tf
+++ b/infra/modules/service/async_workers.tf
@@ -1,4 +1,3 @@
-
 resource "aws_ecs_service" "solid_queue" {
   name                   = "${var.service_name}-solid_queue"
   cluster                = aws_ecs_cluster.cluster.arn
@@ -6,10 +5,6 @@ resource "aws_ecs_service" "solid_queue" {
   task_definition        = aws_ecs_task_definition.solid_queue.arn
   desired_count          = var.desired_solidqueue_instance_count
   enable_execute_command = var.enable_command_execution ? true : null
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
 
   network_configuration {
     assign_public_ip = false

--- a/infra/modules/service/async_workers.tf
+++ b/infra/modules/service/async_workers.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "solid_queue" {
   cluster                = aws_ecs_cluster.cluster.arn
   launch_type            = "FARGATE"
   task_definition        = aws_ecs_task_definition.solid_queue.arn
-  desired_count          = var.desired_solidqueue_instance_count
+  desired_count          = var.solidqueue_desired_instance_count
   enable_execute_command = var.enable_command_execution ? true : null
 
   network_configuration {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -46,12 +46,6 @@ resource "aws_ecs_service" "app" {
   desired_count          = var.desired_instance_count
   enable_execute_command = var.enable_command_execution ? true : null
 
-  # Allow changes to the desired_count without differences in terraform plan.
-  # This allows autoscaling to manage the desired count for us.
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
   network_configuration {
     assign_public_ip = false
     subnets          = var.private_subnet_ids

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -50,7 +50,7 @@ variable "desired_instance_count" {
   default     = 1
 }
 
-variable "desired_solidqueue_instance_count" {
+variable "solidqueue_desired_instance_count" {
   type        = number
   description = "Number of background instances of the task definition to place and keep running."
   default     = 1


### PR DESCRIPTION
## Ticket

Resolves [FFS-2870](https://jiraent.cms.gov/browse/FFS-2870).


## Changes
- Add `results.sarif` from Checkov to our `.gitignore`
- Environment specific Aurora RDS min and max scaling to be set by Terraform config
- Performance insights to stop Checkov from complaining
- Preserve `enable_http_endpoint` functionality that was set via AWS console
- Environment specific SolidQueue worker num can be set via Terraform config

## Context
This hasn't been applied to dev or prod, but I did do a `terraform plan` to confirm the changes are what we expect.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
