### PR TITLE
FFS-2868: Fix three metric bugs

### DIFF
--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -114,14 +114,7 @@ class Webhooks::Argyle::EventsController < ApplicationController
   def process_webhook_event(webhook_event)
     payroll_account = webhook_event.payroll_account
 
-    if webhook_event.event_name == "accounts.connected"
-      event_logger.track("ApplicantCreatedArgyleAccount", request, {
-        cbv_applicant_id: @cbv_flow.cbv_applicant_id,
-        cbv_flow_id: @cbv_flow.id,
-        invitation_id: @cbv_flow.cbv_flow_invitation_id,
-        provider_name: params.dig("data", "resource", "providers_connected")&.first
-      })
-    elsif webhook_event.event_name == "accounts.updated"
+    if webhook_event.event_name == "accounts.updated"
       process_accounts_updated_event(webhook_event)
     elsif payroll_account.has_fully_synced?
       return if payroll_account.sync_succeeded? || payroll_account.sync_failed?

--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -141,7 +141,7 @@ export default class ArgyleModalAdapter extends ModalAdapter {
   async onSuccess(eventPayload: ArgyleAccountData) {
     await trackUserAction("ArgyleSuccess", {
       account_id: eventPayload.accountId,
-      user_id: eventPayload.userId,
+      argyle_user_id: eventPayload.userId,
       item_id: eventPayload.itemId,
       payload: eventPayload,
     })

--- a/app/app/jobs/application_job.rb
+++ b/app/app/jobs/application_job.rb
@@ -4,4 +4,8 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  def event_logger
+    @event_logger ||= GenericEventTracker.new
+  end
 end

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -132,7 +132,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
   end
 
   def track_transmitted_event(cbv_flow, payments)
-    event_logger.track("ApplicantSharedIncomeSummary", request, {
+    event_logger.track("ApplicantSharedIncomeSummary", nil, {
       timestamp: Time.now.to_i,
       client_agency_id: cbv_flow.client_agency_id,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
@@ -146,6 +146,8 @@ class CaseWorkerTransmitterJob < ApplicationJob
       locale: I18n.locale
     })
   rescue => ex
+    raise ex unless Rails.env.production?
+
     Rails.logger.error "Failed to track NewRelic event: #{ex.message}"
   end
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2868](https://jiraent.cms.gov/browse/FFS-2868).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Fix sending ApplicantSharedIncomeSummary when transmitting**
> The `event_logger` object was not defined (nor was `request`). The
> exception was being silenced. And, we removed the test of it during the
> refactor.

After the fix, here is an example of this event sending again:
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/e787c72d-df64-4968-8677-c7211f39efd6" />


**Fix ArgyleSuccess event to not set `user_id` attribute**
> This attribute is special, it is used by the MixpanelEventTracker to
> associate an event with a caseworker's session of that ID.

> Let's rename this to `argyle_user_id` so it doesn't collide there.

After the fix, here is an example of this event sending with the proper `distinct_id` (not caseworker-[uuid]):

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/951524cc-ab1c-4667-84b3-b65e96b50395" />


**Remove duplicate event for ApplicantCreatedArgyleAccount**
> This event is being tracked twice for Argyle - once by the modal's user
> action and once when receiving the webhook.

> Let's simplify the EventsController by deduplicating in favor of the
> Argyle modal event, since the Argyle modal event has more useful
> attributes.

After the fix, here is an example showing only a single ApplicantCreatedArgyleAccount:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/5410b79a-de34-4633-af0e-4cd5c2ab4f5d" />


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

[This Mixpanel user](https://mixpanel.com/project/3512948/view/4014736/app/profile#distinct_id=applicant-48) is an example of going through the flow taking into account these fixes.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
