### PR TITLE
Add account_id to Mixpanel/New-Relic Finish Sync Events

### DIFF
--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -209,6 +209,7 @@ class Webhooks::Argyle::EventsController < ApplicationController
         identity_zip_code: report.identities.first&.zip_code,
         identity_age_range: get_age_range(report.identities.first&.date_of_birth),
         identity_age_range_applicant: get_age_range(@cbv_flow.cbv_applicant.date_of_birth),
+        identity_account_id: report.identities.first&.account_id,
 
         # Income fields (originally from "identities" endpoint)
         income_success: payroll_account.job_succeeded?("income"),

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -108,6 +108,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         identity_zip_code: report.identities.first&.zip_code,
         identity_age_range: get_age_range(report.identities.first&.date_of_birth),
         identity_age_range_applicant: get_age_range(@cbv_flow.cbv_applicant.date_of_birth),
+        identity_account_id: report.identities.first&.account_id,
 
         # Income fields
         income_success: @payroll_account.job_succeeded?("income"),

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
           identity_age_range: "40-49",
           identity_age_range_applicant: "30-39",
           identity_zip_code: "10281",
+          identity_account_id: "01956d5f-cb8d-af2f-9232-38bce8531f58",
 
           # Income fields
           income_success: true,

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               identity_age_range: "30-39",
               identity_age_range_applicant: "30-39",
               identity_zip_code: "99999",
+              identity_account_id: "03e29160-f7e7-4a28-b2d8-813640e030d3",
 
               # Income fields
               income_success: true,


### PR DESCRIPTION
## Changes
<!-- What was added, updated, or removed in this PR. -->
* Added account_id onto Argyle and Pinwheel finished sync event logs as "identity_account_id".  This change is to allow faster investigations with provider data. 
 
View in Mixpanel on Sync event:
<img width="565" alt="image" src="https://github.com/user-attachments/assets/140ffe3c-cf92-4f01-847c-6660c8756756" />

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
