### PR TITLE
FFS-2828: fix paystub event generation so if paystubs_days_since_last_pay_date includes an empty paystub date, still processes

### DIFF
--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -138,7 +138,7 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         paystubs_gross_pay_amounts_median: paystub_gross_pay_amounts.sort[paystub_gross_pay_amounts.length / 2],
         paystubs_gross_pay_amounts_average: paystub_gross_pay_amounts.sum.to_f / paystub_gross_pay_amounts.length,
         paystubs_gross_pay_amounts_min: paystub_gross_pay_amounts.min,
-        paystubs_days_since_last_pay_date: report.paystubs.map { |p| Date.parse(p.pay_date) }.compact.max&.then { |last_pay_date| (Date.current - last_pay_date).to_i },
+        paystubs_days_since_last_pay_date: report.days_since_last_paydate,
 
         # Employment fields
         employment_success: @payroll_account.job_succeeded?("employment"),

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -82,6 +82,12 @@ module Aggregators::AggregatorReports
     def total_gross_income
       @paystubs.reduce(0) { |sum, paystub| sum + paystub.gross_pay_amount }
     end
+
+    def days_since_last_paydate
+      latest_paystub_date = paystubs.map(&:pay_date).compact.map { |pay_date| Date.parse(pay_date) }.max
+      return nil if latest_paystub_date.nil?
+      (Date.current - latest_paystub_date).to_i
+    end
   end
 
   private

--- a/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
       expect(report.days_since_last_paydate).to be_nil
     end
 
-    it "returns the least date when dates available" do
+    it "returns the latest date when dates available, compared to current time" do
       paystubs = [ OpenStruct.new(pay_date: "2021-02-01"), OpenStruct.new(pay_date: "2021-03-02") ]
       report = described_class.new
       report.paystubs = paystubs


### PR DESCRIPTION

## Ticket

Resolves [FFS-2828](https://jiraent.cms.gov/browse/FFS-2828).


## Changes
Fixes a collision between changes in two branches.

## Context for reviewers
We should probably do a followup PR where rspec runs in main branch CI, to catch potential issues like this in the future.

- [X ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
