### PR TITLE
Do not remap argyle's "inactive" unemployment status

### DIFF
--- a/app/app/services/aggregators/format_methods/argyle.rb
+++ b/app/app/services/aggregators/format_methods/argyle.rb
@@ -7,8 +7,6 @@ module Aggregators::FormatMethods::Argyle
     case employment_status
     when "active"
       "employed"
-    when "inactive"
-      "furloughed"
     else
       employment_status
     end

--- a/app/spec/services/aggregators/format_methods/argyle_spec.rb
+++ b/app/spec/services/aggregators/format_methods/argyle_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Aggregators::FormatMethods::Argyle, type: :service do
     end
 
     it 'returns "furloughed" for "inactive"' do
-      expect(described_class.format_employment_status("inactive")).to eq("furloughed")
+      expect(described_class.format_employment_status("inactive")).to eq("inactive")
     end
 
     it 'returns the original status for other values' do


### PR DESCRIPTION

## Ticket

Resolves Issue:

Employment Status was marked as “Furloughed”, even though she is unemployed.
* **Cause**: This is due to how we are normalizing the Argyle employment status ( active / inactive / terminated ) to Pinwheel’s definitions ( employed / furloughed / terminated). In particular, the issue here is that Argyle’s inactive is being translated to “furloughed”. According to Argyle, “inactive: typically indicates the employee left voluntarily, is on leave, or has not been active for a certain period of time.” This definition of inactive does not fully match the situation of being RIF’d, but “inactive” is still better than “furloughed”. 
* **Suggested resolution**: do not remap Argyle’s inactive as furloughed.


## Changes
<!-- What was added, updated, or removed in this PR. -->
* Un-maps Argyle's inactive definition to pinwheel's "furloughed".  It will now show up in the report as "inactive".

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
