### PR TITLE
Update `flow_started_seconds_ago` to be relative to consent page

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -142,7 +142,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
       paystub_count: payments.count,
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },
-      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
+      flow_started_seconds_ago: (cbv_flow.consented_to_authorized_use_at - cbv_flow.created_at).to_i,
       locale: I18n.locale
     })
   rescue => ex

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
   let(:cbv_applicant) { create(:cbv_applicant, created_at: current_time, case_number: "ABC1234") }
   let(:errored_jobs) { [] }
-  let(:current_time) { Date.parse('2024-06-18') }
+  let(:current_time) { DateTime.parse('2024-06-18 00:00:00') }
   let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
   let(:fake_event_logger) { instance_double(GenericEventTracker, track: nil) }
 
@@ -18,9 +18,13 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
            :invited,
            :with_pinwheel_account,
            with_errored_jobs: errored_jobs,
-           created_at: current_time,
+           created_at: current_time - 10.minutes,
            cbv_applicant: cbv_applicant
     )
+  end
+
+  around do |ex|
+    Timecop.freeze(current_time, &ex)
   end
 
   let(:transmission_method) {
@@ -128,7 +132,8 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
         expect(fake_event_logger).to have_received(:track)
           .with("ApplicantSharedIncomeSummary", anything, include(
-            cbv_flow_id: cbv_flow.id
+            cbv_flow_id: cbv_flow.id,
+            flow_started_seconds_ago: 10.minutes.to_i,
           ))
       end
     end
@@ -142,7 +147,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
         "bucket"     => "test-bucket",
         "public_key" => @public_key
       }}
-      # let(:pinwheel_service_double) { instance_double(Aggregators::Sdk::PinwheelService) }
+
       before do
         allow(S3Service).to receive(:new).and_return(s3_service_double)
         allow(s3_service_double).to receive(:upload_file)


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - Other metric bug we noticed.


## Changes
<!-- What was added, updated, or removed in this PR. -->


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

Rather than using `Time.now`, let's use
`consented_to_authorized_use_at`, since it represents when the user
finished the CBV flow. This will allow the calculated value of
`flow_started_seconds_ago` to not be changed if there is a long queue or
some error in processing the CaseWorkerTransmitterJob.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
