### PR TITLE
FFS-2794: Update data redaction fields for LA LDH

### DIFF
--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -1,4 +1,6 @@
 class CbvApplicant < ApplicationRecord
+  include Redactable
+
   after_initialize :set_snap_application_date, if: :new_record?
   after_initialize :set_applicant_attributes
   attr_reader :applicant_attributes, :required_applicant_attributes
@@ -49,19 +51,6 @@ class CbvApplicant < ApplicationRecord
   validates :snap_application_date, presence: {
     message: :invalid_date
   }
-
-  include Redactable
-  has_redactable_fields(
-    first_name: :string,
-    middle_name: :string,
-    last_name: :string,
-    client_id_number: :string,
-    case_number: :string,
-    agency_id_number: :string,
-    beacon_id: :string,
-    snap_application_date: :date,
-    date_of_birth: :date
-  )
 
   def date_of_birth=(value)
     self[:date_of_birth] = parse_date(value)

--- a/app/app/models/cbv_applicant/az_des.rb
+++ b/app/app/models/cbv_applicant/az_des.rb
@@ -8,5 +8,12 @@ class CbvApplicant::AzDes < CbvApplicant
     income_changes
   ]
 
+  has_redactable_fields(
+    first_name: :string,
+    middle_name: :string,
+    last_name: :string,
+    # TODO[FFS-2669]: Redact income_changes by removing member name only.
+  )
+
   validates :case_number, presence: true
 end

--- a/app/app/models/cbv_applicant/la_ldh.rb
+++ b/app/app/models/cbv_applicant/la_ldh.rb
@@ -7,4 +7,11 @@ class CbvApplicant::LaLdh < CbvApplicant
     case_number
     date_of_birth
   ]
+
+  has_redactable_fields(
+    first_name: :string,
+    middle_name: :string,
+    last_name: :string,
+    date_of_birth: :date
+  )
 end

--- a/app/app/models/cbv_applicant/ma.rb
+++ b/app/app/models/cbv_applicant/ma.rb
@@ -23,4 +23,12 @@ class CbvApplicant::Ma < CbvApplicant
       message: :invalid_date
     },
     if: -> { snap_application_date.present? }
+
+  has_redactable_fields(
+    first_name: :string,
+    middle_name: :string,
+    last_name: :string,
+    agency_id_number: :string,
+    beacon_id: :string
+  )
 end

--- a/app/app/models/cbv_applicant/nyc.rb
+++ b/app/app/models/cbv_applicant/nyc.rb
@@ -26,6 +26,14 @@ class CbvApplicant::Nyc < CbvApplicant
     },
     if: -> { snap_application_date.present? }
 
+  has_redactable_fields(
+    first_name: :string,
+    middle_name: :string,
+    last_name: :string,
+    case_number: :string,
+    client_id_number: :string,
+  )
+
   def format_case_number
     return if case_number.blank?
     case_number.upcase!

--- a/app/app/models/cbv_applicant/sandbox.rb
+++ b/app/app/models/cbv_applicant/sandbox.rb
@@ -6,4 +6,11 @@ class CbvApplicant::Sandbox < CbvApplicant
     case_number
     date_of_birth
   ]
+
+  has_redactable_fields(
+    first_name: :string,
+    middle_name: :string,
+    last_name: :string,
+    date_of_birth: :date
+  )
 end

--- a/app/spec/factories/cbv_applicant.rb
+++ b/app/spec/factories/cbv_applicant.rb
@@ -88,6 +88,8 @@ FactoryBot.define do
         # TODO: Determine actual LA LDH case number format.
         8.times.map { rand(10) }.join
       end
+
+      date_of_birth { Date.new(2000, 1, 1) }
     end
   end
 end

--- a/app/spec/models/cbv_applicant/az_des_spec.rb
+++ b/app/spec/models/cbv_applicant/az_des_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe CbvApplicant::AzDes, type: :model do
       )
     end
   end
+
+  it "redacts all sensitive PII fields" do
+    applicant = CbvApplicant.create(az_attributes)
+    applicant.redact!
+    expect(applicant).to have_attributes(
+      first_name: "REDACTED",
+      middle_name: "REDACTED",
+      last_name: "REDACTED",
+      case_number: /[0-9]+/, # Not redacted as it's not sensitive PII
+      # TODO[FFS-2669]: Test the redaction of income_changes
+    )
+  end
 end

--- a/app/spec/models/cbv_applicant/la_ldh_spec.rb
+++ b/app/spec/models/cbv_applicant/la_ldh_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe CbvApplicant::LaLdh, type: :model do
       expect(applicant.class.name).to eq("CbvApplicant::LaLdh")
     end
   end
+
+  it "redacts all sensitive PII fields" do
+    applicant = CbvApplicant.create(la_ldh_attributes)
+    applicant.redact!
+    expect(applicant).to have_attributes(
+      first_name: "REDACTED",
+      middle_name: "REDACTED",
+      last_name: "REDACTED",
+      date_of_birth: Date.new(1990, 1, 1),
+      case_number: /[0-9]+/, # Not redacted as it's not sensitive PII
+    )
+  end
 end

--- a/app/spec/models/cbv_applicant/ma_spec.rb
+++ b/app/spec/models/cbv_applicant/ma_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe CbvApplicant::Ma, type: :model do
       expect(applicant.errors[:client_id_number]).to be_empty
     end
   end
+
+  it "redacts all sensitive PII fields" do
+    applicant = CbvApplicant.create(ma_attributes)
+    applicant.redact!
+    expect(applicant).to have_attributes(
+      first_name: "REDACTED",
+      middle_name: "REDACTED",
+      last_name: "REDACTED",
+      agency_id_number: "REDACTED",
+      beacon_id: "REDACTED",
+    )
+  end
 end

--- a/app/spec/models/cbv_applicant/nyc_spec.rb
+++ b/app/spec/models/cbv_applicant/nyc_spec.rb
@@ -83,4 +83,16 @@ RSpec.describe CbvApplicant::Nyc, type: :model do
       )
     end
   end
+
+  it "redacts all sensitive PII fields" do
+    applicant = CbvApplicant.create(nyc_attributes)
+    applicant.redact!
+    expect(applicant).to have_attributes(
+      first_name: "REDACTED",
+      middle_name: "REDACTED",
+      last_name: "REDACTED",
+      case_number: "REDACTED",
+      client_id_number: "REDACTED",
+    )
+  end
 end

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DataRetentionService do
         it "redacts the associated CbvApplicant" do
           service.redact_invitations
           expect(cbv_flow_invitation.cbv_applicant.reload).to have_attributes(
-            case_number: "REDACTED",
+            first_name: "REDACTED",
             redacted_at: within(1.second).of(Time.now)
           )
         end
@@ -114,7 +114,7 @@ RSpec.describe DataRetentionService do
       it "redacts the associated CbvApplicant" do
         service.redact_incomplete_cbv_flows
         expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-          case_number: "REDACTED"
+          first_name: "REDACTED"
         )
       end
 
@@ -234,7 +234,7 @@ RSpec.describe DataRetentionService do
       it "redacts the associated applicant" do
         service.redact_complete_cbv_flows
         expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-          case_number: "REDACTED"
+          first_name: "REDACTED"
         )
       end
 
@@ -259,7 +259,7 @@ RSpec.describe DataRetentionService do
         redacted_at: within(1.second).of(Time.now)
       )
       expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-        case_number: "REDACTED",
+        first_name: "REDACTED",
         redacted_at: within(1.second).of(Time.now)
       )
       expect(second_cbv_flow.reload).to have_attributes(


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Precursor to [FFS-2794](https://jiraent.cms.gov/browse/FFS-2794).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2794: Update data redaction for LA LDH**
> We updated our data retention policy for Phase 2 pilots, but never
> updated the list of fields we redact. We no longer want to redact
> `case_number` since it is not sensitive PII.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
