### PR TITLE
FFS-2924: Fix missing_results page view render logic

### DIFF
--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -2,7 +2,6 @@ class Cbv::MissingResultsController < Cbv::BaseController
   before_action :track_missing_results_event, only: :show
 
   def show
-    @has_payroll_account = @cbv_flow.payroll_accounts.any?
   end
 
   def track_missing_results_event

--- a/app/app/controllers/cbv/missing_results_controller.rb
+++ b/app/app/controllers/cbv/missing_results_controller.rb
@@ -2,6 +2,7 @@ class Cbv::MissingResultsController < Cbv::BaseController
   before_action :track_missing_results_event, only: :show
 
   def show
+    @has_payroll_account = @cbv_flow.payroll_accounts.any?
   end
 
   def track_missing_results_event

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<% if @has_payroll_account %>
+<% if @cbv_flow.has_account_with_required_data? %>
   <hr class="margin-top-5 margin-bottom-5 border-base-light border-top-0">
   <h2><%= t(".no_more_jobs") %></h2>
   <div class="usa-prose">

--- a/app/spec/controllers/cbv/missing_results_controller_spec.rb
+++ b/app/spec/controllers/cbv/missing_results_controller_spec.rb
@@ -2,30 +2,44 @@ require "rails_helper"
 
 RSpec.describe Cbv::MissingResultsController do
   describe "#show" do
-    render_views
+     render_views
 
-    let(:cbv_flow) { create(:cbv_flow, :invited) }
+     let(:cbv_flow) { create(:cbv_flow, :invited) }
 
-    before do
-      session[:cbv_flow_id] = cbv_flow.id
-    end
+     before do
+       session[:cbv_flow_id] = cbv_flow.id
+     end
 
-    it "renders successfully" do
-      get :show
-      expect(response).to be_successful
-    end
+     it "renders successfully" do
+       get :show
+       expect(response).to be_successful
+     end
 
-    context "when the user has already linked a pinwheel account" do
-      let!(:payroll_account) { create(:payroll_account, cbv_flow: cbv_flow) }
+     context "when the user has already linked a pinwheel account" do
+       let!(:payroll_account) { create(:payroll_account, cbv_flow: cbv_flow) }
 
-      it "renders successfully" do
-        get :show
-        expect(response).to be_successful
-      end
-    end
+       it "renders successfully" do
+         get :show
+         expect(response).to be_successful
+       end
+     end
 
-    context "shows the continue to review my report link when the cbv_flow has a fully_synced payroll account" do
+     context "when the cbv_flow has a fully_synced payroll account" do
+       let!(:payroll_account) { create(:payroll_account, :argyle_fully_synced, cbv_flow: cbv_flow) }
 
-    end
-  end
+       it "renders the link in the view" do
+         get :show
+         expect(response.body).to include(cbv_flow_applicant_information_path)
+       end
+     end
+
+     context "when the cbv_flow does not have a fully_synced payroll account" do
+       let!(:payroll_account) { create(:payroll_account, :argyle_sync_in_progress, cbv_flow: cbv_flow) }
+
+       it "does not render the link in the view" do
+         get :show
+         expect(response.body).not_to include(cbv_flow_applicant_information_path)
+       end
+     end
+   end
 end

--- a/app/spec/controllers/cbv/missing_results_controller_spec.rb
+++ b/app/spec/controllers/cbv/missing_results_controller_spec.rb
@@ -2,44 +2,44 @@ require "rails_helper"
 
 RSpec.describe Cbv::MissingResultsController do
   describe "#show" do
-     render_views
+    render_views
 
-     let(:cbv_flow) { create(:cbv_flow, :invited) }
+    let(:cbv_flow) { create(:cbv_flow, :invited) }
 
-     before do
-       session[:cbv_flow_id] = cbv_flow.id
-     end
+    before do
+      session[:cbv_flow_id] = cbv_flow.id
+    end
 
-     it "renders successfully" do
-       get :show
-       expect(response).to be_successful
-     end
+    it "renders successfully" do
+      get :show
+      expect(response).to be_successful
+    end
 
-     context "when the user has already linked a pinwheel account" do
-       let!(:payroll_account) { create(:payroll_account, cbv_flow: cbv_flow) }
+    context "when the user has already linked a pinwheel account" do
+      let!(:payroll_account) { create(:payroll_account, cbv_flow: cbv_flow) }
 
-       it "renders successfully" do
-         get :show
-         expect(response).to be_successful
-       end
-     end
+      it "renders successfully" do
+        get :show
+        expect(response).to be_successful
+      end
+    end
 
-     context "when the cbv_flow has a fully_synced payroll account" do
-       let!(:payroll_account) { create(:payroll_account, :argyle_fully_synced, cbv_flow: cbv_flow) }
+    context "when the cbv_flow has a fully_synced payroll account" do
+      let!(:payroll_account) { create(:payroll_account, :argyle_fully_synced, cbv_flow: cbv_flow) }
 
-       it "renders the link in the view" do
-         get :show
-         expect(response.body).to include(cbv_flow_applicant_information_path)
-       end
-     end
+      it "renders the link in the view" do
+        get :show
+        expect(response.body).to include(cbv_flow_applicant_information_path)
+      end
+    end
 
-     context "when the cbv_flow does not have a fully_synced payroll account" do
-       let!(:payroll_account) { create(:payroll_account, :argyle_sync_in_progress, cbv_flow: cbv_flow) }
+    context "when the cbv_flow does not have a fully_synced payroll account" do
+      let!(:payroll_account) { create(:payroll_account, :argyle_sync_in_progress, cbv_flow: cbv_flow) }
 
-       it "does not render the link in the view" do
-         get :show
-         expect(response.body).not_to include(cbv_flow_applicant_information_path)
-       end
-     end
-   end
+      it "does not render the link in the view" do
+        get :show
+        expect(response.body).not_to include(cbv_flow_applicant_information_path)
+      end
+    end
+  end
 end

--- a/app/spec/controllers/cbv/missing_results_controller_spec.rb
+++ b/app/spec/controllers/cbv/missing_results_controller_spec.rb
@@ -23,5 +23,9 @@ RSpec.describe Cbv::MissingResultsController do
         expect(response).to be_successful
       end
     end
+
+    context "shows the continue to review my report link when the cbv_flow has a fully_synced payroll account" do
+
+    end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves [FFS-2924](https://jiraent.cms.gov/browse/FFS-2924).


## Changes
Replace the `@has_payroll_account` view variable with `@cbv_flow.has_account_with_required_data?` in the conditional for rendering the `/applicant_information` link. 

## Context for reviewers
During our LA pilot an applicant encountered an [error](https://nava.slack.com/archives/C0792AR4570/p1747748131396709) which is a result of a bug in our view rendering logic whereas the `Continue to review my report` `(/applicant_information)` link was being rendered on the `/missing_results` page even if an applicant does not have a fully synced payroll account. 

The applicant clicked this button despite not having a `fully_synced` payroll account (or any payroll account linked for that matter) which resulted in the error above.

The view logic should first determine if the `cbv_flow` has the required data e.g. at least one fully synced payroll account before rendering the link to the `/applicant_information` page.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
