### PR TITLE
filter a list of employers from search results

### DIFF
--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -3,8 +3,12 @@ class ProviderSearchService
 
   # item_000136007 - SSA
   # item_000042186 - Veterans Affairs
-  BLOCKED_ARGYLE_EMPLOYERS = %w[item_000136007 item_000042186]
-  BLOCKED_PINWHEEL_EMPLOYERS = %w[]
+  # item_000023897 - Louisiana Workforce Commission, which administers Unemployment Insurance
+  BLOCKED_ARGYLE_EMPLOYERS = %w[item_000136007 item_000042186 item_000023897]
+
+  # 0bab321e-64ea-4047-8d8a-44ba283f6cd8 - Social Security Administration - Retirement, Survivors, Disability benefits
+  # 3f7b6ce9-6371-4bb8-8c2f-051c446dc55c - Veterans Affairs benefits
+  BLOCKED_PINWHEEL_EMPLOYERS = %w[0bab321e-64ea-4047-8d8a-44ba283f6cd8 3f7b6ce9-6371-4bb8-8c2f-051c446dc55c]
 
   def initialize(client_agency_id, providers: SUPPORTED_PROVIDERS)
     @client_agency_config = site_config[client_agency_id]

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -46,7 +46,7 @@ class ProviderSearchService
   end
 
   def filter_results(results, blocked_employers)
-    results.select { |result| !result.provider_options.provider_id.in? blocked_employers }
+    results.select { |result| blocked_employers.exclude?(result.provider_options.provider_id) }
   end
 
   # TODO: this data should be loading from a config file instead of from hardcoded arrays within this file - see FFS-2661

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -1,6 +1,9 @@
 class ProviderSearchService
   SUPPORTED_PROVIDERS = (ENV["SUPPORTED_PROVIDERS"] || "pinwheel")&.split(",")&.map(&:to_sym)
 
+  # We are temporarily blocking these employers because they return data in a form we don't expect
+  # and they constitute unearned income, which our current state partner (LA) does not want us to report.
+
   # item_000136007 - SSA
   # item_000042186 - Veterans Affairs
   # item_000023897 - Louisiana Workforce Commission, which administers Unemployment Insurance

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -11,7 +11,9 @@ class ProviderSearchService
   # item_000136007 - SSA
   # item_000042186 - Veterans Affairs
   # item_000023897 - Louisiana Workforce Commission, which administers Unemployment Insurance
-  BLOCKED_ARGYLE_EMPLOYERS = %w[item_000136007 item_000042186 item_000023897]
+  # item_000012092 - Disability
+  # item_000033060 - Retirement
+  BLOCKED_ARGYLE_EMPLOYERS = %w[item_000136007 item_000042186 item_000023897 item_000012092 item_000033060]
 
   # 0bab321e-64ea-4047-8d8a-44ba283f6cd8 - Social Security Administration - Retirement, Survivors, Disability benefits
   # 3f7b6ce9-6371-4bb8-8c2f-051c446dc55c - Veterans Affairs benefits

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -31,11 +31,11 @@ class ProviderSearchService
         Aggregators::ResponseObjects::SearchResult.from_pinwheel(result)
       end
 
+      results = filter_results(results, BLOCKED_PINWHEEL_EMPLOYERS)
+
       # Use Pinwheel's results if there aren't any results from Argyle, or
       # there is an exact match from Pinwheel.
       results = pinwheel_results if results.length == 0 || any_exact_matches?(pinwheel_results, query)
-
-      results = filter_results(results, BLOCKED_PINWHEEL_EMPLOYERS)
     end
 
     results

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -31,11 +31,11 @@ class ProviderSearchService
         Aggregators::ResponseObjects::SearchResult.from_pinwheel(result)
       end
 
-      results = filter_results(results, BLOCKED_PINWHEEL_EMPLOYERS)
-
       # Use Pinwheel's results if there aren't any results from Argyle, or
       # there is an exact match from Pinwheel.
       results = pinwheel_results if results.length == 0 || any_exact_matches?(pinwheel_results, query)
+
+      results = filter_results(results, BLOCKED_PINWHEEL_EMPLOYERS)
     end
 
     results

--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -1,8 +1,12 @@
 class ProviderSearchService
   SUPPORTED_PROVIDERS = (ENV["SUPPORTED_PROVIDERS"] || "pinwheel")&.split(",")&.map(&:to_sym)
 
-  # We are temporarily blocking these employers because they return data in a form we don't expect
-  # and they constitute unearned income, which our current state partner (LA) does not want us to report.
+  # We are blocking these employers because they constitute unearned
+  # income, which our current state partner (LA) does not want us to report.
+  # They're also returning data in a format that we don't expect, and since our
+  # state partner doesn't even want us to report this data, we won't fix that
+  # discrepancy at this time. We may reconsider later, especially as we add
+  # more states.
 
   # item_000136007 - SSA
   # item_000042186 - Veterans Affairs

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe Cbv::EmployerSearchesController do
         ))
         get :show, params: { query: "results" }
       end
+
+      context "when some results should be blocked" do
+        before do
+          pinwheel_stub_request_items_response
+          stub_const("ProviderSearchService::BLOCKED_PINWHEEL_EMPLOYERS", [ "fce3eee0-285b-496f-9b36-30e976194736" ])
+        end
+
+        render_views
+
+        it "renders successfully without those results" do
+          get :show, params: { query: "results" }
+          expect(response).to be_successful
+          expect(response.body).not_to include("Acme Payroll")
+          expect(response.body).to include("Lumon")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## [FFS-2930](https://jiraent.cms.gov/browse/FFS-2930)

## Changes
Now, we filter a list of blocked employers from the search results from Argyle and Pinwheel.

## Context for reviewers
See [this thread](https://cmsgov.slack.com/archives/C066XS5543S/p1747861309595409?thread_ts=1747856345.708169&cid=C066XS5543S). We decided to block certain employers who will always send us data in a format we don't expect (and which causes a crash). These employers were chosen because they represent unearned income, which is not what LA wants us to be reporting.

## Testing Instructions
0. Set up to use argyle and pinwheel
1. Search for Social Security Administration, Veteran's Affairs, and Louisiana Workforce Commission (this never showed up anyway for some unknown reason, but we're blocking it at Patricia's request since it falls under a common unearned income category.
- Before, you would have seen matches that looked like these exact queries. Now, they will have been removed. You may still see entries for these as _employers_ (eg, if you earn a paycheck (earned income) from working at one of these institutions), but the entries for them as benefits providers (unearned income) will not appear.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
