### PR TITLE
apply standard retry for jobs that fail

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -79,7 +79,7 @@ jobs:
           echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Anchore vulnerability scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v6.2.0
         with:
           image: ${{ steps.build-image.outputs.image }}
           output-format: table

--- a/.grype.yml
+++ b/.grype.yml
@@ -25,8 +25,6 @@ ignore:
   - vulnerability: GHSA-gh9q-2xrm-x6qv # Ruby "cgi" version 0.4.1
   - vulnerability: GHSA-mhwm-jh88-3gjf # Ruby "cgi" version 0.4.1
   - vulnerability: GHSA-22h5-pq3x-2gf2 # Ruby "uri" version 0.13.1
-  - vulnerability: CVE-2024-38541 # linux-lib-c-dev version 6.1.135-1
-  - vulnerability: CVE-2024-26739 # linux-lib-c-dev version 6.1.135-1
 
 exclude:
   - '/rails/node_modules/@esbuild/*/bin/esbuild' # Ignore this go binary since it is only used in the asset build process

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,5 +10,3 @@
 #  Issue:         Why there is a finding and why this is here or not been removed
 #  Last checked:  Date last checked in scans
 #The-CVE-or-vuln-id # Remove comment at start of line
-CVE-2024-38541 # linux-lib-c-dev version 6.1.135-1
-CVE-2024-26739 # linux-lib-c-dev version 6.1.135-1

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,2 +1,2 @@
 /node_modules
-
+log/*.log

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -141,7 +141,7 @@ RUN apt-get update -qq && \
         curl=7.88.1-10+deb12u12 \
         libgpgme11=1.18.0-3+b1 \
         libvips42=8.14.1-3+deb12u2 \
-        linux-libc-dev=6.1.135-1 \
+        linux-libc-dev=6.1.137-1 \
         openssl=3.0.16-1~deb12u1 \
         postgresql-client=15+248 \
         python-is-python3=3.11.2-1+deb12u1 \
@@ -149,10 +149,10 @@ RUN apt-get update -qq && \
         unzip=6.0-28 \
         && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf ./awscli-bundle awscli-bundle.zip
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf ./aws awscliv2.zip
 
 # Remove base rexml for GHSA-4xqq-m2hx-25v8
 RUN gem uninstall -i /usr/local/lib/ruby/gems/3.3.0 debug && \

--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -176,6 +176,7 @@ class Webhooks::Argyle::EventsController < ApplicationController
       event_logger.track("ApplicantFinishedArgyleSync", request, {
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
         cbv_flow_id: @cbv_flow.id,
+        client_agency_id: @cbv_flow.client_agency_id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id,
         argyle_environment: agency_config[@cbv_flow.client_agency_id].argyle_environment,
         sync_duration_seconds: Time.now - payroll_account.sync_started_at,

--- a/app/app/jobs/application_job.rb
+++ b/app/app/jobs/application_job.rb
@@ -1,6 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
+  retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -142,7 +142,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
       paystub_count: payments.count,
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },
-      flow_started_seconds_ago: (Time.now - cbv_flow.created_at).to_i,
+      flow_started_seconds_ago: (cbv_flow.consented_to_authorized_use_at - cbv_flow.created_at).to_i,
       locale: I18n.locale
     })
   rescue => ex

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -80,7 +80,7 @@ module Aggregators::AggregatorReports
     end
 
     def total_gross_income
-      @paystubs.reduce(0) { |sum, paystub| sum + paystub.gross_pay_amount }
+      @paystubs.reduce(0) { |sum, paystub| sum + (paystub.gross_pay_amount || 0) }
     end
 
     def days_since_last_paydate

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<% if @has_payroll_account %>
+<% if @cbv_flow.has_account_with_required_data? %>
   <hr class="margin-top-5 margin-bottom-5 border-base-light border-top-0">
   <h2><%= t(".no_more_jobs") %></h2>
   <div class="usa-prose">

--- a/app/spec/controllers/cbv/missing_results_controller_spec.rb
+++ b/app/spec/controllers/cbv/missing_results_controller_spec.rb
@@ -23,5 +23,23 @@ RSpec.describe Cbv::MissingResultsController do
         expect(response).to be_successful
       end
     end
+
+    context "when the cbv_flow has a fully_synced payroll account" do
+      let!(:payroll_account) { create(:payroll_account, :argyle_fully_synced, cbv_flow: cbv_flow) }
+
+      it "renders the link in the view" do
+        get :show
+        expect(response.body).to include(cbv_flow_applicant_information_path)
+      end
+    end
+
+    context "when the cbv_flow does not have a fully_synced payroll account" do
+      let!(:payroll_account) { create(:payroll_account, :argyle_sync_in_progress, cbv_flow: cbv_flow) }
+
+      it "does not render the link in the view" do
+        get :show
+        expect(response.body).not_to include(cbv_flow_applicant_information_path)
+      end
+    end
   end
 end

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
         expect(attributes).to include(
           cbv_flow_id: cbv_flow.id,
           cbv_applicant_id: cbv_flow.cbv_applicant_id,
+          client_agency_id: cbv_flow.client_agency_id,
           invitation_id: cbv_flow.cbv_flow_invitation_id,
           argyle_environment: "sandbox",
           sync_duration_seconds: be_a(Numeric),

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
   let(:cbv_applicant) { create(:cbv_applicant, created_at: current_time, case_number: "ABC1234") }
   let(:errored_jobs) { [] }
-  let(:current_time) { Date.parse('2024-06-18') }
+  let(:current_time) { DateTime.parse('2024-06-18 00:00:00') }
   let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
   let(:fake_event_logger) { instance_double(GenericEventTracker, track: nil) }
 
@@ -18,9 +18,13 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
            :invited,
            :with_pinwheel_account,
            with_errored_jobs: errored_jobs,
-           created_at: current_time,
+           created_at: current_time - 10.minutes,
            cbv_applicant: cbv_applicant
     )
+  end
+
+  around do |ex|
+    Timecop.freeze(current_time, &ex)
   end
 
   let(:transmission_method) {
@@ -128,7 +132,8 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
         expect(fake_event_logger).to have_received(:track)
           .with("ApplicantSharedIncomeSummary", anything, include(
-            cbv_flow_id: cbv_flow.id
+            cbv_flow_id: cbv_flow.id,
+            flow_started_seconds_ago: 10.minutes.to_i,
           ))
       end
     end
@@ -142,7 +147,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
         "bucket"     => "test-bucket",
         "public_key" => @public_key
       }}
-      # let(:pinwheel_service_double) { instance_double(Aggregators::Sdk::PinwheelService) }
+
       before do
         allow(S3Service).to receive(:new).and_return(s3_service_double)
         allow(s3_service_double).to receive(:upload_file)

--- a/app/spec/mailers/applicant_mailer_spec.rb
+++ b/app/spec/mailers/applicant_mailer_spec.rb
@@ -43,33 +43,5 @@ RSpec.describe ApplicantMailer, type: :mailer do
         expect(mail.body.encoded).to include(I18n.t("applicant_mailer.invitation_email.body_1.default", locale: :es, agency_acronym: "CBV"))
       end
     end
-
-    context "for a NYC CbvFlowInvitation" do
-      let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :nyc, email_address: email) }
-
-      it "renders the body" do
-        unescaped_body = CGI.unescape_html(mail.body.encoded)
-        expect(unescaped_body).to match(I18n.t('applicant_mailer.invitation_email.header.nyc'))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_1.default", agency_acronym: "HRA"))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_2_html.default", deadline: "July 21, 2024"))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_3.default", app_name: "ACCESS HRA"))
-      end
-    end
-
-    context "for a MA CbvFlowInvitation" do
-      let(:cbv_flow_invitation) { create(:cbv_flow_invitation, :ma, email_address: email) }
-
-      it "renders the subject" do
-        expect(mail.subject).to eq(I18n.t('applicant_mailer.invitation_email.subject.ma'))
-      end
-
-      it "renders the body" do
-        unescaped_body = CGI.unescape_html(mail.body.encoded)
-        expect(unescaped_body).to match(I18n.t('applicant_mailer.invitation_email.header.ma'))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_1.ma", agency_acronym: "DTA"))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_2_html.ma", deadline: "July 21, 2024"))
-        expect(unescaped_body).to match(I18n.t("applicant_mailer.invitation_email.body_3.ma", app_name: "DTA Connect"))
-      end
-    end
   end
 end

--- a/app/spec/mailers/previews/applicant_mailer_preview.rb
+++ b/app/spec/mailers/previews/applicant_mailer_preview.rb
@@ -2,18 +2,6 @@
 class ApplicantMailerPreview < BaseMailerPreview
   include ReportViewHelper
 
-  def invitation_email_dta
-    ApplicantMailer.with(
-      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :ma, user: unique_user, language: I18n.locale)
-    ).invitation_email
-  end
-
-  def invitation_email_nyc
-    ApplicantMailer.with(
-      cbv_flow_invitation: FactoryBot.create(:cbv_flow_invitation, :nyc, user: unique_user, language: I18n.locale)
-    ).invitation_email
-  end
-
   private
   def unique_user
     FactoryBot.create(:user, email: "#{SecureRandom.uuid}@example.com")

--- a/app/spec/mailers/previews/caseworker_mailer_preview.rb
+++ b/app/spec/mailers/previews/caseworker_mailer_preview.rb
@@ -1,25 +1,26 @@
-
 # Preview all emails at http://localhost:3000/rails/mailers/caseworker_mailer
 class CaseworkerMailerPreview < BaseMailerPreview
   include ReportViewHelper
   include TestHelpers
 
-  def summary_email
+  def summary_email_la_ldh
     caseworker_user = FactoryBot.create(:user, email: "#{SecureRandom.uuid}@example.com")
-    invitation = FactoryBot.create(:cbv_flow_invitation, :nyc, user: caseworker_user)
+
     cbv_flow = FactoryBot.create(
       :cbv_flow,
       :with_pinwheel_account,
       :completed,
-      cbv_flow_invitation: invitation
+      client_agency_id: "la_ldh",
+      cbv_applicant_attributes: {
+        case_number: "LA12345"
+      }
     )
 
     aggregator_report = FactoryBot.build(:pinwheel_report)
 
     CaseworkerMailer.with(
-      email_address: invitation.email_address,
+      email_address: caseworker_user.email,
       cbv_flow: cbv_flow,
-      case_number: "12345",
       aggregator_report: aggregator_report
     ).summary_email
   end

--- a/app/spec/mailers/previews/weekly_report_mailer_preview.rb
+++ b/app/spec/mailers/previews/weekly_report_mailer_preview.rb
@@ -1,6 +1,9 @@
-# Preview all emails at http://localhost:3000/rails/mailers/weekly_report_mailer_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/weekly_report_mailer
 class WeeklyReportMailerPreview < ActionMailer::Preview
-  def report_email
-    WeeklyReportMailer.with(client_agency_id: "nyc").report_email
+  def report_email_la_ldh
+    WeeklyReportMailer.with(
+      client_agency_id: "la_ldh",
+      report_date: Date.today
+    ).report_email
   end
 end

--- a/app/spec/mailers/weekly_report_mailer_spec.rb
+++ b/app/spec/mailers/weekly_report_mailer_spec.rb
@@ -113,27 +113,6 @@ RSpec.describe WeeklyReportMailer, type: :mailer do
     end
   end
 
-  context "for the MA client agency" do
-    let(:client_agency_id) { "ma" }
-
-    it "renders the CSV data with MA-specific columns" do
-      expect(mail.attachments.first.filename).to eq("weekly_report_20240902-20240908.csv")
-      expect(mail.attachments.first.content_type).to start_with('text/csv')
-
-      expect(parsed_csv[0]).to match(
-        "beacon_id" => cbv_flow_invitation.cbv_applicant.beacon_id,
-        "started_at" => "2024-09-04 13:15:00 UTC",
-        "transmitted_at" => "2024-09-04 13:30:00 UTC",
-        "agency_id_number" => cbv_flow_invitation.cbv_applicant.agency_id_number,
-        "invited_at" => "2024-09-04 13:00:00 UTC",
-        "snap_application_date" => "2024-09-03",
-        "completed_at" => "2024-09-04 13:30:00 UTC",
-        "email_address" => "test@example.com"
-      )
-      expect(parsed_csv.length).to eq(1)
-    end
-  end
-
   context "for the LA LDH client agency" do
     let(:client_agency_id) { "la_ldh" }
 

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service do
+  describe '#total_gross_income' do
+    it 'handles nil gross_pay_amount values' do
+      report = Aggregators::AggregatorReports::AggregatorReport.new
+      report.paystubs = [
+        Aggregators::ResponseObjects::Paystub.new(gross_pay_amount: 100),
+        Aggregators::ResponseObjects::Paystub.new(gross_pay_amount: nil)
+      ]
+
+      expect { report.total_gross_income }.not_to raise_error
+      expect(report.total_gross_income).to eq(100)
+    end
+  end
+end

--- a/bin/lint-markdown
+++ b/bin/lint-markdown
@@ -14,4 +14,8 @@ link_check_config=".github/workflows/markdownlint-config.json"
 
 # Recursively find all markdown files (*.md) in the current directory, excluding node_modules and .venv subfolders.
 # Pass them in as args to the lint command using the handy `xargs` command.
-find . -name \*.md -not -path "*/node_modules/*" -not -path "*/.venv/*" -print0 | xargs -0 -n1 npx markdown-link-check --config "${link_check_config}"
+find . -name \*.md \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.venv/*" \
+  -not -path "*/.terraform/*" \
+  -print0 | xargs -0 -n1 npx markdown-link-check --config "${link_check_config}"

--- a/docs/infra/vulnerability-management.md
+++ b/docs/infra/vulnerability-management.md
@@ -46,8 +46,8 @@ AWS_PROFILE=prod aws ecr get-login-password --region us-east-1 | \
   docker login --username AWS --password-stdin 730335532059.dkr.ecr.us-east-1.amazonaws.com
 
 # Find and output the Grype issues
-grype --config $(git rev-parse --show-toplevel)/.grype.yml -o json --fail-on medium "$image_name" |
-  jq '.matches | map(.artifact | { name, version, "location": .locations[0].path })'
+grype --config $(git rev-parse --show-toplevel)/.grype.yml -o json --fail-on high "$image_name" |
+  jq '.matches | map((.vulnerability | { severity }) + (.artifact | { name, version, "location": .locations[0].path }))'
 ```
 
 ### Dockle

--- a/load_testing/README.md
+++ b/load_testing/README.md
@@ -10,7 +10,7 @@ Follow these steps to perform a load test:
     * ECS service (app-dev) = 10 containers (tasks)
     * DB cluster (app-dev) = 10 ACUs
 3. Pause the "default" queue so we don't track a ton of useless Mixpanel events during the test.
-    * https://verify-demo.navapbc.cloud/jobs      (un/pw in 1Password)
+    * https://verify-demo.navapbc.cloud/jobs      (un/pw in 1Password) <!-- markdown-link-check-disable-line -->
 
 ### Running the test
 3. Get a fresh COOKIE by starting the CBV session and copying out the value of the cookie
@@ -34,7 +34,7 @@ Follow these steps to perform a load test:
     > SolidQueue::Queue.new("default").clear
     ```
 7. Resume the "default" queue execution.
-    * https://verify-demo.navapbc.cloud/jobs      (un/pw in 1Password)
+    * https://verify-demo.navapbc.cloud/jobs      (un/pw in 1Password) <!-- markdown-link-check-disable-line -->
 
 
 ## Developing Locally with K6


### PR DESCRIPTION
## Changes

Changes jobs to try and rerun on initial failure.

## Context for reviewers

assumptions:

1) your background job should be idempotent (safe to rerun) 2) most of the background jobs will have some level of jitter

in that case, lets apply this to ApplicationJob rather than require each job to specify a default retry strategy.

## Acceptance testing

- [ X ] Acceptance testing prior to merge
  * Kick off TestQueueingJob in a way that fails. see it rerun.