### PR TITLE
apply standard retry for jobs that fail

### DIFF
--- a/app/app/jobs/application_job.rb
+++ b/app/app/jobs/application_job.rb
@@ -1,4 +1,6 @@
 class ApplicationJob < ActiveJob::Base
+  retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
   def event_logger
     @event_logger ||= GenericEventTracker.new
   end


### PR DESCRIPTION
## Changes

Changes jobs to try and rerun on initial failure.

## Context for reviewers

assumptions:

1) your background job should be idempotent (safe to rerun) 2) most of the background jobs will have some level of jitter

in that case, lets apply this to ApplicationJob rather than require each job to specify a default retry strategy.

## Acceptance testing

- [ X ] Acceptance testing prior to merge
  * Kick off TestQueueingJob in a way that fails. see it rerun.