### PR TITLE
FFS-2664: Allow CBV links to be re-used by other household members

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -18,8 +18,12 @@ class Cbv::BaseController < ApplicationController
         track_expired_event(invitation)
         return redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
       end
-      if invitation.complete?
-        return redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
+
+      client_agency = agency_config[invitation.client_agency_id]
+      unless client_agency.allow_invitation_reuse
+        if invitation.complete?
+          return redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
+        end
       end
 
       @cbv_flow = CbvFlow.create_from_invitation(invitation)

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -82,6 +82,7 @@
     name: "az_des"
   pay_income_days: 90
   invitation_valid_days: 14
+  allow_invitation_reuse: true
   # TODO[FFS-2629]: Get permission to use the AZ DES logo.
   # logo_path: dta_logo.png
   # logo_square_path: dta_logo_square.png

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -44,6 +44,7 @@ class ClientAgencyConfig
       transmission_method_configuration
       weekly_report
       applicant_attributes
+      allow_invitation_reuse
     ])
 
     def initialize(yaml)
@@ -67,6 +68,7 @@ class ClientAgencyConfig
       @sso = yaml["sso"]
       @weekly_report = yaml["weekly_report"]
       @applicant_attributes = yaml["applicant_attributes"] || {}
+      @allow_invitation_reuse = yaml["allow_invitation_reuse"] || false
 
       raise ArgumentError.new("Client Agency missing id") if @id.blank?
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `agency_name`") if @agency_name.blank?


### PR DESCRIPTION
## Ticket

Resolves [FFS-2664](https://jiraent.cms.gov/browse/FFS-2664).


## Changes
Agency-configurable reuse of invitation links for multi-household


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
