### PR TITLE
FFS-2938 fix caseworker report being rendered in spanish

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -60,7 +60,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
         "#{time_now.strftime('%Y%m%d%H%M%S')}"
 
       # Generate PDF
-      pdf_service = PdfService.new
+      pdf_service = PdfService.new(language: :en)
       @pdf_output = pdf_service.generate(
         renderer: Cbv::SubmitsController.new,
         template: "cbv/submits/show",

--- a/app/app/services/pdf_service.rb
+++ b/app/app/services/pdf_service.rb
@@ -13,14 +13,23 @@ class PdfService
     end
   end
 
+  attr_reader :language
+
+  def initialize(language:)
+    @language = language
+  end
+
   def generate(renderer:, template:, variables: {})
-    html_content = renderer.render_to_string(
-      template: template,
-      formats: [ :pdf ],
-      layout: "layouts/pdf",
-      locals: variables,
-      assigns: variables
-    )
+    html_content = I18n.with_locale(language) do
+      renderer.render_to_string(
+        template: template,
+        formats: [ :pdf ],
+        layout: "layouts/pdf",
+        locals: variables,
+        assigns: variables
+      )
+    end
+
 
     begin
       pdf_content = WickedPdf.new.pdf_from_string(html_content)

--- a/app/app/services/sftp_case_transmitter.rb
+++ b/app/app/services/sftp_case_transmitter.rb
@@ -16,7 +16,7 @@ class SftpCaseTransmitter
 
   def pdf_output
     @_pdf_output ||= begin
-                       pdf_service = PdfService.new
+                       pdf_service = PdfService.new(language: :en)
                        pdf_service.generate(
                          renderer: Cbv::SubmitsController.new,
                          template: "cbv/submits/show",

--- a/app/spec/services/pdf_service_spec.rb
+++ b/app/spec/services/pdf_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PdfService, type: :service do
   include ApplicationHelper
 
   let(:current_time) { Date.parse('2024-06-18') }
-  let(:cbv_flow) { create(:cbv_flow) }
+  let(:cbv_flow) { create(:cbv_flow, :invited) }
 
   let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
   let(:variables) do
@@ -14,13 +14,21 @@ RSpec.describe PdfService, type: :service do
       is_caseworker: true,
       cbv_flow: cbv_flow,
       aggregator_report: pinwheel_report,
-      has_consent: false
+      has_consent: false,
+      locale: :en
     }
   end
 
+
   describe "#generate" do
-    it 'generates a PDF file' do
-      pdf_service = PdfService.new
+    around do |ex|
+      I18n.with_locale(locale, &ex)
+    end
+
+    context "english locale" do
+      let(:locale) { :en }
+      it 'generates a PDF file' do
+      pdf_service = PdfService.new(language: :en)
       @pdf_results = pdf_service.generate(
         renderer: ApplicationController.renderer,
         template: 'cbv/submits/show',
@@ -30,6 +38,24 @@ RSpec.describe PdfService, type: :service do
       expect(@pdf_results&.html).to include('Gross pay YTD')
       expect(@pdf_results&.html).to include('Agreement Consent Timestamp')
       expect(@pdf_results&.file_size).to be > 0
+    end
+    end
+
+
+    context "spanish locale" do
+      let(:locale) { :es }
+      it 'generates a PDF file in english' do
+      pdf_service = PdfService.new(language: :en)
+      F @pdf_results = pdf_service.generate(
+              renderer: ApplicationController.renderer,
+              template: 'cbv/submits/show',
+              variables: variables
+            )
+      expect(@pdf_results&.content).to include('%PDF-1.4')
+      expect(@pdf_results&.html).to include('Gross pay YTD')
+      expect(@pdf_results&.html).to include('Agreement Consent Timestamp')
+      expect(@pdf_results&.file_size).to be > 0
+    end
     end
   end
 end


### PR DESCRIPTION

## Ticket

Resolves [FFS-2938](https://jiraent.cms.gov/browse/FFS-2938).


## Changes

Gives pdf generation the capability to choose which language it is, and assume that for caseworkers we currently want it to be in english.


## Acceptance testing
<!-- Check one: -->

- [ X] Acceptance testing prior to merge
  * Generate an az des report going through the flow in spanish, then look at the report as a caseworker. should be in english.
