### PR TITLE
FFS-2875: Report six months of gig data for AZ

### DIFF
--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -1,5 +1,6 @@
 class Cbv::PaymentDetailsController < Cbv::BaseController
   include Cbv::AggregatorDataHelper
+
   helper_method :employer_name,
     :gross_pay,
     :employment_start_date,

--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -137,8 +137,8 @@ class Webhooks::Argyle::EventsController < ApplicationController
       report = Aggregators::AggregatorReports::ArgyleReport.new(
         payroll_accounts: [ payroll_account ],
         argyle_service: argyle_for(@cbv_flow),
-        from_date: @cbv_flow.cbv_applicant.paystubs_query_begins_at,
-        to_date: @cbv_flow.cbv_applicant.snap_application_date
+        days_to_fetch_for_w2: agency_config[@cbv_flow.client_agency_id].pay_income_days[:w2],
+        days_to_fetch_for_gig: agency_config[@cbv_flow.client_agency_id].pay_income_days[:gig]
       )
       report.fetch
 

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -64,8 +64,8 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
       report = Aggregators::AggregatorReports::PinwheelReport.new(
         payroll_accounts: [ @payroll_account ],
         pinwheel_service: @pinwheel,
-        from_date: @cbv_flow.cbv_applicant.paystubs_query_begins_at,
-        to_date: @cbv_flow.cbv_applicant.snap_application_date
+        days_to_fetch_for_w2: agency_config[@cbv_flow.client_agency_id].pay_income_days[:w2],
+        days_to_fetch_for_gig: agency_config[@cbv_flow.client_agency_id].pay_income_days[:gig]
       )
       report.fetch
 

--- a/app/app/helpers/cbv/aggregator_data_helper.rb
+++ b/app/app/helpers/cbv/aggregator_data_helper.rb
@@ -4,7 +4,11 @@ module Cbv::AggregatorDataHelper
 
   def set_aggregator_report
     if has_payroll_accounts("pinwheel") && has_payroll_accounts("argyle")
-      @aggregator_report = CompositeReport.new([ make_pinwheel_report, make_argyle_report ])
+      @aggregator_report = CompositeReport.new(
+        [ make_pinwheel_report, make_argyle_report ],
+        days_to_fetch_for_w2: agency_config[@cbv_flow.client_agency_id].pay_income_days[:w2],
+        days_to_fetch_for_gig: agency_config[@cbv_flow.client_agency_id].pay_income_days[:gig]
+      )
     elsif has_payroll_accounts("pinwheel")
       @aggregator_report = make_pinwheel_report
     elsif has_payroll_accounts("argyle")
@@ -36,20 +40,22 @@ module Cbv::AggregatorDataHelper
 
   def make_pinwheel_report(payroll_account: nil)
     report = PinwheelReport.new(
-        payroll_accounts: if payroll_account.present? then [ payroll_account ] else filter_payroll_accounts("pinwheel") end,
-        pinwheel_service: pinwheel,
-        from_date: @cbv_flow.cbv_applicant.paystubs_query_begins_at,
-        to_date: @cbv_flow.cbv_applicant.snap_application_date)
+      payroll_accounts: if payroll_account.present? then [ payroll_account ] else filter_payroll_accounts("pinwheel") end,
+      pinwheel_service: pinwheel,
+      days_to_fetch_for_w2: agency_config[@cbv_flow.client_agency_id].pay_income_days[:w2],
+      days_to_fetch_for_gig: agency_config[@cbv_flow.client_agency_id].pay_income_days[:gig]
+    )
     report.fetch
     report
   end
 
   def make_argyle_report(payroll_account: nil)
     report = ArgyleReport.new(
-        payroll_accounts: if payroll_account.present? then [ payroll_account ] else filter_payroll_accounts("argyle") end,
-        argyle_service: argyle,
-        from_date: @cbv_flow.cbv_applicant.paystubs_query_begins_at,
-        to_date: @cbv_flow.cbv_applicant.snap_application_date)
+      payroll_accounts: if payroll_account.present? then [ payroll_account ] else filter_payroll_accounts("argyle") end,
+      argyle_service: argyle,
+      days_to_fetch_for_w2: agency_config[@cbv_flow.client_agency_id].pay_income_days[:w2],
+      days_to_fetch_for_gig: agency_config[@cbv_flow.client_agency_id].pay_income_days[:gig]
+    )
     report.fetch
     report
   end

--- a/app/app/helpers/report_view_helper.rb
+++ b/app/app/helpers/report_view_helper.rb
@@ -23,6 +23,17 @@ module ReportViewHelper
     number_to_currency(dollars_in_cents.to_f / 100)
   end
 
+  def report_data_range(report)
+    case report.fetched_days
+    when 90
+      t("shared.report_data_range.ninety_days")
+    when 182
+      t("shared.report_data_range.six_months")
+    else
+      raise "Missing i18n key in `shared.report_data_range` for report.fetched_days = #{report.fetched_days}"
+    end
+  end
+
   def translate_aggregator_value(namespace, value)
     return unless value.present?
 

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -123,8 +123,6 @@ class CaseWorkerTransmitterJob < ApplicationJob
       beacon_userid: cbv_flow.cbv_applicant.beacon_id,
       app_date: cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
       report_date_created: payroll_account.created_at.strftime("%m/%d/%Y"),
-      report_date_start: cbv_flow.cbv_applicant.paystubs_query_begins_at.strftime("%m/%d/%Y"),
-      report_date_end: cbv_flow.cbv_applicant.snap_application_date.strftime("%m/%d/%Y"),
       confirmation_code: cbv_flow.confirmation_code,
       consent_timestamp: cbv_flow.consented_to_authorized_use_at.strftime("%m/%d/%Y %H:%M:%S"),
       pdf_filename: "#{@file_name}.pdf",

--- a/app/app/models/payroll_account/argyle.rb
+++ b/app/app/models/payroll_account/argyle.rb
@@ -8,8 +8,13 @@ class PayrollAccount::Argyle < PayrollAccount
   end
 
   def has_fully_synced?
+    # Consider the sync finished if every webhook has returned either an error
+    # or success. Any webhook with an "unknown" status will not impact the
+    # result of this method.
     supported_jobs.all? do |job|
-      supported_jobs.exclude?(job) || find_webhook_event_for_job(job).present?
+      supported_jobs.exclude?(job) ||
+        find_webhook_event_for_job(job, "error").present? ||
+        find_webhook_event_for_job(job, "success").present?
     end
   end
 

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -93,7 +93,11 @@ module Aggregators::AggregatorReports
     end
 
     def to_date
-      Date.current
+      # Use the CBV flow as the basis for the end of the report range, as it
+      # reflects the actual time that the user was completing the flow (as
+      # opposed to the invitation, which they could have been sitting on for
+      # many days.)
+      @payroll_accounts.first.cbv_flow.created_at.to_date
     end
   end
 end

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -1,9 +1,9 @@
 # This is an abstract class that should be inherited by all aggregator report classes.
 module Aggregators::AggregatorReports
   class AggregatorReport
-    attr_accessor :payroll_accounts, :identities, :incomes, :employments, :gigs, :paystubs, :from_date, :to_date, :has_fetched
+    attr_accessor :payroll_accounts, :identities, :incomes, :employments, :gigs, :paystubs, :has_fetched, :fetched_days
 
-    def initialize(payroll_accounts: [], from_date: nil, to_date: nil)
+    def initialize(payroll_accounts: [], days_to_fetch_for_w2: nil, days_to_fetch_for_gig: nil)
       @has_fetched = false
       @payroll_accounts = payroll_accounts
       @identities = []
@@ -11,8 +11,9 @@ module Aggregators::AggregatorReports
       @employments = []
       @paystubs = []
       @gigs = []
-      @from_date = from_date
-      @to_date = to_date
+      @days_to_fetch_for_w2 = days_to_fetch_for_w2
+      @days_to_fetch_for_gig = days_to_fetch_for_gig
+      @fetched_days = days_to_fetch_for_w2
     end
 
     def fetch
@@ -42,8 +43,6 @@ module Aggregators::AggregatorReports
       end
       @has_fetched = all_successful
     end
-
-
 
     AccountReportStruct = Struct.new(:identity, :income, :employment, :paystubs, :gigs)
     def find_account_report(account_id)
@@ -88,10 +87,13 @@ module Aggregators::AggregatorReports
       return nil if latest_paystub_date.nil?
       (Date.current - latest_paystub_date).to_i
     end
-  end
 
-  private
-  def fetch_report_data(from_date, to_date)
-    raise "must implement in subclass"
+    def from_date
+      @fetched_days.days.ago.to_date
+    end
+
+    def to_date
+      Date.current
+    end
   end
 end

--- a/app/app/services/aggregators/aggregator_reports/argyle_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/argyle_report.rb
@@ -16,17 +16,28 @@ module Aggregators::AggregatorReports
       identities_json = @argyle_service.fetch_identities_api(
         account: payroll_account.pinwheel_account_id
       )
+
+      # Override the date range to fetch when fetching a gig job.
+      has_gig_job = identities_json["results"].any? do |identity_json|
+        Aggregators::FormatMethods::Argyle.employment_type(identity_json["employment_type"]) == :gig
+      end
+      if has_gig_job
+        @fetched_days = @days_to_fetch_for_gig
+      end
+
       account_json = @argyle_service.fetch_account_api(
         account: payroll_account.pinwheel_account_id
       )
       paystubs_json = @argyle_service.fetch_paystubs_api(
         account: payroll_account.pinwheel_account_id,
-        from_start_date: @from_date,
-        to_start_date: @to_date
+        from_start_date: from_date,
+        to_start_date: to_date
       )
-      gigs_json = @argyle_service.fetch_gigs_api(account: payroll_account.pinwheel_account_id,
-                                                 from_start_datetime: @from_date,
-                                                 to_start_datetime: @to_date)
+      gigs_json = @argyle_service.fetch_gigs_api(
+        account: payroll_account.pinwheel_account_id,
+        from_start_datetime: from_date,
+        to_start_datetime: to_date
+      )
 
       @identities.append(*transform_identities(identities_json))
       @employments.append(*transform_employments(identities_json,

--- a/app/app/services/aggregators/aggregator_reports/composite_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/composite_report.rb
@@ -19,36 +19,9 @@ module Aggregators::AggregatorReports
         @incomes += aggregator_report.incomes
         @paystubs += aggregator_report.paystubs
 
-        @from_date = earlier_date(aggregator_report.from_date, @from_date)
-        @to_date = later_date(@to_date, aggregator_report.to_date)
+        @fetched_days = [ @fetched_days, aggregator_report.fetched_days ].max
       end
       @has_fetched = true
-    end
-
-    def earlier_date(a, b)
-      a_date = a.to_date if a.present?
-      b_date = b.to_date if b.present?
-
-      if a_date.present? && b_date.present?
-        [ a_date, b_date ].min
-      elsif a_date.present?
-        a_date
-      elsif b_date.present?
-        b_date
-      end
-    end
-
-    def later_date(a, b)
-      a_date = a.to_date if a.present?
-      b_date = b.to_date if b.present?
-
-      if a_date.present? && b_date.present?
-        [ a_date, b_date ].max
-      elsif a_date.present?
-        a_date
-      elsif b_date.present?
-        b_date
-      end
     end
   end
 end

--- a/app/app/services/aggregators/webhooks/argyle.rb
+++ b/app/app/services/aggregators/webhooks/argyle.rb
@@ -20,12 +20,12 @@ module Aggregators::Webhooks
         job: %w[identity income]
       },
       "paystubs.partially_synced" => {
-        status: :success,
+        status: :unknown,
         type: :partial,
         job: %w[paystubs employment]
       },
       "gigs.partially_synced" => {
-        status: :success,
+        status: :unknown,
         type: :partial,
         job: %w[gigs]
       },

--- a/app/app/services/argyle_webhooks_manager.rb
+++ b/app/app/services/argyle_webhooks_manager.rb
@@ -90,7 +90,7 @@ class ArgyleWebhooksManager
       # pay_income_days, so that agencies with shorter amounts of required data
       # can benefit from a quicker sync.
       largest_pay_income_days = Rails.application.config.client_agencies.client_agency_ids.map do |agency_id|
-        Rails.application.config.client_agencies[agency_id].pay_income_days
+        Rails.application.config.client_agencies[agency_id].pay_income_days[:w2]
       end.compact.max
 
       { days_synced: webhooks_config[:days_synced] || largest_pay_income_days }

--- a/app/app/services/client_agency/az_des/recently_submitted_cases_csv.rb
+++ b/app/app/services/client_agency/az_des/recently_submitted_cases_csv.rb
@@ -7,8 +7,6 @@ class ClientAgency::AzDes::RecentlySubmittedCasesCsv < CsvGenerator
         cbv_link_created_timestamp: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.cbv_flow_invitation.created_at),
         cbv_link_clicked_timestamp: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.created_at),
         report_created_timestamp: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.consented_to_authorized_use_at),
-        report_date_start: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.cbv_applicant.paystubs_query_begins_at),
-        report_date_end: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.cbv_applicant.snap_application_date),
         consent_timestamp: ClientAgency::AzDes::Configuration.format_timezone(cbv_flow.consented_to_authorized_use_at),
         pdf_filename: "#{ClientAgency::AzDes::Configuration.pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)}.pdf",
         pdf_filetype: "application/pdf",

--- a/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
+++ b/app/app/views/caseworker/cbv_flow_invitations/new.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= t(".header") %></h1>
 <div class="usa-prose">
-  <%= agency_translation(".description_html", pay_income_days: current_agency.pay_income_days) %>
+  <%= agency_translation(".description_html", pay_income_days: current_agency.pay_income_days[:w2]) %>
 </div>
 <%= uswds_form_with(model: @cbv_flow_invitation, url: invitations_path) do |f| %>
   <%= render partial: "caseworker/cbv_flow_invitations/#{@cbv_flow_invitation.client_agency_id}", locals: { f: f } %>

--- a/app/app/views/cbv/add_jobs/show.html.erb
+++ b/app/app/views/cbv/add_jobs/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t(".header") %>
 <h1><%= t(".header") %></h1>
-<p><%= t(".subheader", pay_income_days: current_agency.pay_income_days) %></p>
+<p><%= t(".subheader") %></p>
 
 <div data-controller="cbv-add-job">
   <h2><%= t(".answer_yes_header_html") %></h2>
@@ -24,7 +24,7 @@
   </ul>
 
     <p class="margin-bottom-2">
-      <%= t(".criteria_disclaimer", pay_income_days: current_agency.pay_income_days) %>
+      <%= t(".criteria_disclaimer") %>
       <%= agency_translation(".learn_more_link_html", agency_url: agency_url) %>
     </p>
 </div>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -70,7 +70,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <%= table.with_row(t(".none_found")) %>
+    <%= table.with_row(t(".none_found", report_data_range: report_data_range(@aggregator_report))) %>
   <% end %>
 <% end %>
 

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -5,23 +5,32 @@
 </h1>
 
 <div class="usa-prose">
-  <p><%= agency_translation(".subheader", start_date: format_date(@aggregator_report.from_date), end_date: format_date(@aggregator_report.to_date), agency_acronym: current_agency.agency_short_name) %></p>
+  <p>
+    <%= t(".subheader",
+        start_date: format_date(@aggregator_report.from_date),
+        end_date: format_date(@aggregator_report.to_date),
+        agency_acronym: agency_translation("shared.agency_acronym"),
+        report_data_range: report_data_range(@aggregator_report),
+        benefit: agency_translation("shared.benefit"),
+        reporting_purpose: agency_translation("shared.reporting_purpose")
+      ) %>
+  </p>
 </div>
 
 <% if @payroll_account_report.paystubs.any? %>
-<h2><%= t(".total_gross_income", amount: format_money(gross_pay)) %></h2>
-<div class="usa-prose">
-  <p><%= t(".total_gross_description") %></p>
-</div>
+  <h2><%= t(".total_gross_income", amount: format_money(gross_pay), report_data_range: report_data_range(@aggregator_report)) %></h2>
+  <div class="usa-prose">
+    <p><%= t(".total_gross_description") %></p>
+  </div>
 <% else %>
-<h2 class="site-preview-heading">
-  <%= t(".none_found") %>
-</h2>
-<div class="usa-prose">
-  <p>
-    <%= t(".none_found_description") %>
-  </p>
-</div>
+  <h2 class="site-preview-heading">
+    <%= t(".none_found", report_data_range: report_data_range(@aggregator_report)) %>
+  </h2>
+  <div class="usa-prose">
+    <p>
+      <%= t(".none_found_description", report_data_range: report_data_range(@aggregator_report)) %>
+    </p>
+  </div>
 <% end %>
 
 <%= render(TableComponent.new) do |table| %>

--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -77,7 +77,7 @@
   <% end %>
   <%= table.with_row(agency_translation(".application_or_recertification_date"), format_parsed_date(@cbv_flow.cbv_applicant.snap_application_date)) %>
   <%= table.with_row(t(".pdf.client.date_created"), format_parsed_date(@cbv_flow.consented_to_authorized_use_at)) %>
-  <%= table.with_row(t(".pdf.client.date_range"), "#{format_parsed_date(@cbv_flow.cbv_applicant.paystubs_query_begins_at)} to #{format_parsed_date(@cbv_flow.cbv_applicant.snap_application_date)}") %>
+  <%= table.with_row(t(".pdf.client.date_range"), "#{format_parsed_date(aggregator_report.from_date)} to #{format_parsed_date(aggregator_report.to_date)}") %>
   <% if is_caseworker %>
     <%= table.with_row(t(".pdf.caseworker.agreement_consent_timestamp"), @cbv_flow.consented_to_authorized_use_at) %>
     <% if current_agency?(:ma) %>

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -5,13 +5,8 @@
 
 <div class="margin-bottom-6 usa-prose" data-testid="summary-description">
   <p>
-      <%= t(".description", start_date: format_date(@aggregator_report.from_date), end_date: format_date(@aggregator_report.to_date), agency_acronym: current_agency.agency_short_name) %>
+    <%= t(".description", start_date: format_date(@aggregator_report.from_date), end_date: format_date(@aggregator_report.to_date), agency_acronym: current_agency.agency_short_name) %>
   </p>
-</div>
-
-<h2 class="site-preview-heading"><%= t(".total_payments", amount: format_money(@aggregator_report.total_gross_income)) %></h2>
-<div class="usa-prose">
-  <p><%= t(".total_payments_desc") %></p>
 </div>
 
 <% @aggregator_report.summarize_by_employer.each_with_index do |(account_id, summary), index| %>

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -21,7 +21,9 @@
     tenant_id:     <%= ENV["AZURE_NYC_DSS_TENANT_ID"] %>
     scope: "openid"
     name: "nyc_dss"
-  pay_income_days: 90
+  pay_income_days:
+    w2: 90
+    gig: 90
   invitation_valid_days: 14
   weekly_report:
     recipient: <%= ENV['NYC_HRA_EMAIL'] %>
@@ -49,7 +51,9 @@
     scope: "openid"
     name: "ma_dta"
   authorized_emails: <%= ENV["MA_DTA_ALLOWED_CASEWORKER_EMAILS"] %>
-  pay_income_days: 90
+  pay_income_days:
+    w2: 90
+    gig: 90
   invitation_valid_days: 14
   logo_path: dta_logo.png
   logo_square_path: dta_logo_square.png
@@ -83,7 +87,9 @@
     tenant_id:     <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
     scope: "openid"
     name: "az_des"
-  pay_income_days: 90
+  pay_income_days:
+    w2: 90
+    gig: 182
   invitation_valid_days: 10
   allow_invitation_reuse: true
   # TODO[FFS-2629]: Get permission to use the AZ DES logo.
@@ -115,7 +121,9 @@
   #   tenant_id:     <%= ENV["AZURE_LA_LDH_TENANT_ID"] %>
   #   scope: "openid"
   #   name: "la_ldh"
-  pay_income_days: 90
+  pay_income_days:
+    w2: 90
+    gig: 90
   invitation_valid_days: 14
   weekly_report:
     recipient: <%= ENV['LA_LDH_WEEKLY_REPORT_RECIPIENTS'] %>
@@ -146,7 +154,9 @@
     tenant_id:     <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
     scope: "openid"
     name: "sandbox"
-  pay_income_days: 90
+  pay_income_days:
+    w2: 90
+    gig: 90
   invitation_valid_days: 14
   weekly_report:
     recipient: ffs-eng@navapbc.com

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -72,15 +72,13 @@
     environment: <%= ENV["AZ_DES_PINWHEEL_ENVIRONMENT"] %>
   argyle:
     environment: <%= ENV["AZ_DES_ARGYLE_ENVIRONMENT"] %>
-  # TODO[FFS-2628]: This will be SFTP:
   transmission_method: sftp
   transmission_method_configuration:
     user: <%= ENV['AZ_DES_SFTP_USER'] %>
     password: <%= ENV['AZ_DES_SFTP_PASSWORD'] %>
     url: <%= ENV['AZ_DES_SFTP_URL'] %>
     sftp_directory: <%= ENV['AZ_DES_SFTP_DIRECTORY'] %>
-  # TODO: Disable staff portal before pilot launch
-  staff_portal_enabled: true
+  staff_portal_enabled: false
   sso:
     client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -268,6 +268,18 @@ ignore_missing:
     # LA fixes-2 (FFS-2688)
     - "cbv.summaries.show.must_match.default"
     - "cbv.summaries.show.must_match.la_ldh"
+
+    # AZ six months of data (FFS-2875)
+    - "cbv.payment_details.show.header"
+    - "cbv.payment_details.show.none_found"
+    - "cbv.payment_details.show.header_no_employer_name"
+    - "cbv.payment_details.show.subheader"
+    - "cbv.submits.show.none_found_confirmed"
+    - "cbv.summaries.show.none_found"
+    - "shared.report_data_range.six_months"
+    - "shared.agency_acronym.*" # duplicative of Daphne's branch
+    - "shared.benefit.*" # duplicative of Daphne's branch
+    - "shared.reporting_purpose.*" # duplicative of Daphne's branch
 ## Consider these keys used:
 ignore_unused:
   all:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -393,15 +393,15 @@ en:
         employment_start_date: Employment start date
         employment_status: Employment status
         frequency_unknown: Frequency Unknown
-        header: Your income information from %{employer_name}
-        header_no_employer_name: Your income information from your employer
+        header: Your payment information from %{employer_name}
+        header_no_employer_name: Your payment information from your employer
         hourly_rate: Compensation amount
         hours:
           one: "%{count} hour"
           other: "%{count} hours"
         hours_paid: "%{category}: Hours paid"
-        none_found: We didn't find any payments from this employer in the past 90 days.
-        none_found_description: This typically happens when you haven't received income from this job in the past 90 days. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
+        none_found: We didn't find any payments from this employer in the past %{report_data_range}.
+        none_found_description: This typically happens when you haven't received income from this job in the past %{report_data_range}. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
         number_of_hours_worked: Number of hours worked
         pay_date: 'Pay Date: %{pay_date}'
         pay_frequency: Pay frequency
@@ -412,11 +412,9 @@ en:
         pay_period_value: "%{start_date} to %{end_date}"
         payment_hours: "%{amount} hours"
         payments_and_deductions_table_header: Payments and deductions
-        subheader:
-          la_ldh: We have gathered your income records from the past 90 days, from %{start_date} to %{end_date}. If the information is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your income report and linked to your Medicaid benefits.
-          sandbox: We have gathered your income records from the past 90 days, from %{start_date} to %{end_date}. If the information is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your income report and linked to your SNAP application.
+        subheader: We have gathered your income records from the past %{report_data_range} as requested by %{agency_acronym} from %{start_date} to %{end_date}. If the information is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your income report and linked to your %{benefit} %{reporting_purpose}.
         total_gross_description: This is the total gross income from your job before taxes, benefits and deductions were taken out of your paycheck.
-        total_gross_income: 'Total income from the past 90 days, before taxes: %{amount}'
+        total_gross_income: 'Total income from the past %{report_data_range}, before taxes: %{amount}'
         unknown: Unknown
     submits:
       show:
@@ -428,8 +426,8 @@ en:
           az_des: Check this box to affirm under penalty of perjury that the information provided by you is true and complete to the best of your knowledge.<ul><li>You agree to tell %{agency_acronym} about:<ul><li>any other income not included in this report,</li><li>or any errors found in the information gathered with this tool.</li></ul></li><li>You understand that providing accurate and complete information is your responsibility.</li><li>Any false or missing information may result in:<ul><li>an overpayment, which you must repay to %{agency_acronym},</li><li>or program disqualification.</li></ul></li></ul>By sending this report, you authorize its use for income verification by %{agency_acronym} and authorized personnel.
           default: 'Check this box to confirm: <ul><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform the %{agency_full_name} of any income not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for income verification by authorized %{agency_acronym} personnel.'
         legal_header: Legal agreement
-        none_found: No payments from this employer in the past 90 days
-        none_found_confirmed: We've confirmed that there are no payments from this employer in the past 90 days. This happens when the client hasn't received income from this job during that time.
+        none_found: We didn't find any payments from this employer.
+        none_found_confirmed: We've confirmed that there are no recent payments from this employer. This happens when the client hasn't received income from this job.
         page_header: Submit your income report
         pdf:
           agency_header_name:
@@ -484,20 +482,18 @@ en:
       show:
         additional_comments: Additional comments
         application_information: Applicant information
-        description: The report below has your income from the past 90 days, from %{start_date} to %{end_date}. Please review it before sending.
+        description: The report below shows your recent income. Please review it before sending.
         header: Review your income report
         must_match:
           default: This must match what is shown on your %{agency_acronym} application.
           la_ldh: This must match what is shown on your Medicaid benefits.
-        none_found: We didn't find any payments from this employer in the past 90 days.
+        none_found: We didn't find any payments from this employer.
         payment: Payment of %{amount} before taxes on %{date}
         phone_number: Employer phone
         table_caption: 'Employer %{number}: %{employer_name}'
         table_caption_no_name: Employer %{number}
         total_income_from: 'Total income before taxes from %{employer_name}: %{amount}'
         total_income_from_no_employer_name: 'Total income before taxes: %{amount}'
-        total_payments: 'Total income from past 90 days, before taxes: %{amount}'
-        total_payments_desc: This is the total gross income from your job(s) before taxes, benefits and deductions were taken out of your paycheck.
         your_information: Your information
     synchronization_failures:
       show:
@@ -713,6 +709,9 @@ en:
       zh: 中文
     not_applicable: N/A
     pilot_name: Report My Income
+    report_data_range:
+      ninety_days: 90 days
+      six_months: 6 months
     reporting_purpose:
       az_des: Mid Approval Contact form
       la_ldh: benefits

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -251,13 +251,13 @@ en:
         answer_yes_bullet_3: Your job is app-based (Uber, DoorDash, Lyft, Instacart, etc.)
         answer_yes_header_html: 'Answer YES if <em>any</em> of these are true about your current or recent job:'
         continue: Continue
-        criteria_disclaimer: 'Note: If you''ve had other jobs in the past %{pay_income_days} days that don''t meet these criteria, you may need to submit that income information separately.'
+        criteria_disclaimer: 'Note: If you''ve had other jobs in the past 90 days that don''t meet these criteria, you may need to submit that income information separately.'
         header: Do you have another job to report?
         learn_more_link_html:
           la_ldh: Learn more on <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">LDH's website</a>.
           sandbox: Learn more on <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank" rel="noopener noreferrer">CBV Test Agency's website</a>.
         no_radio: No, I don’t have another job that meets the criteria
-        subheader: Please add other jobs you’ve had in the past %{pay_income_days} days, even if you're no longer at that job.
+        subheader: Please add other jobs you’ve had in the past 90 days, even if you're no longer at that job.
         yes_radio: Yes, I have another job that meets the criteria
     applicant_informations:
       la_ldh:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -83,13 +83,13 @@ es:
         answer_yes_bullet_3: Su trabajo se basa en aplicaciones (Uber, DoorDash, Lyft, Instacart, etc.)
         answer_yes_header_html: 'Responda que SÍ si <em>cualquiera</em> de las siguientes afirmaciones son ciertas sobre su trabajo actual o reciente:'
         continue: Continuar
-        criteria_disclaimer: 'Nota: Si ha tenido otros trabajos en los últimos %{pay_income_days} días que no cumplen estos criterios, es posible que tenga que presentar información de ese ingreso por separado.'
+        criteria_disclaimer: 'Nota: Si ha tenido otros trabajos en los últimos 90 días que no cumplen estos criterios, es posible que tenga que presentar información de ese ingreso por separado.'
         header: "¿Tiene otro trabajo que declarar?"
         learn_more_link_html:
           la_ldh: Obtenga más información en <a href="%{agency_url}" target="_blank" rel="noopener noreferer">el sitio web de LDH</a>.
           sandbox: Obtenga más información en <a href="https://www.mass.gov/guides/how-to-contact-dta" target="_blank" rel="noopener noreferrer">el sitio web de CBV Test Agency</a>.
         no_radio: No, no tengo otro trabajo que cumpla con los criterios
-        subheader: Por favor añada los otros trabajos que haya tenido en los últimos %{pay_income_days} días, incluso si ya no está en ese trabajo.
+        subheader: Por favor añada los otros trabajos que haya tenido en los últimos 90 días, incluso si ya no está en ese trabajo.
         yes_radio: Sí, tengo otro trabajo que cumpla con los criterios
     applicant_informations:
       sandbox:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -188,15 +188,12 @@ es:
         employment_start_date: Fecha de inicio del empleo
         employment_status: Estatus del empleo
         frequency_unknown: Frecuencia desconocida
-        header: Su información de pago de %{employer_name}
-        header_no_employer_name: Su información de pago por parte de su empleador
         hourly_rate: Monto de compensación
         hours:
           one: "%{count} hora"
           other: "%{count} horas"
         hours_paid: "%{category}: Horas pagadas"
-        none_found: No se encontraron pagos.
-        none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos 90 días. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
+        none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos %{report_data_range}. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
         pay_date: 'Fecha de pago: %{pay_date}'
         pay_gross: Pago antes de impuestos (bruto)
         pay_gross_ytd: Remuneración bruta desde el inicio del año a la fecha (YTD, por sus siglas en inglés)
@@ -205,10 +202,8 @@ es:
         pay_period_value: "%{start_date} al %{end_date}"
         payment_hours: "%{amount} horas"
         payments_and_deductions_table_header: Pagos y deducciones
-        subheader:
-          sandbox: Hemos recopilado sus registros de pago de los últimos 90 días, del %{start_date} al %{end_date}. Si falta información o esta es inexacta, añada un comentario para %{agency_acronym}. Esta información se incluirá en su informe de ingresos.
         total_gross_description: Estos son sus ingresos brutos totales provenientes de su trabajo, antes del pago de impuestos, beneficios y deducciones que se restaron de su cheque de pago.
-        total_gross_income: 'Ingresos totales de los últimos 90 días, antes de impuestos: %{amount}'
+        total_gross_income: 'Ingresos totales de los últimos %{report_data_range}, antes de impuestos: %{amount}'
         unknown: Desconocido
     submits:
       show:
@@ -216,7 +211,6 @@ es:
         application_or_recertification_date:
           sandbox: SNAP application or recertification interview date
         legal_header: Consentimiento legal
-        none_found_confirmed: Pudimos confirmar que este empleador no realizó ningún pago en los últimos 90 días. Esto sucede cuando el cliente no percibe ingresos de este trabajo durante tal período de tiempo.
         page_header: Envíe un informe de ingresos
         pdf:
           agency_header_name:
@@ -255,13 +249,11 @@ es:
     summaries:
       show:
         additional_comments: Comentarios adicionales
-        none_found: No encontramos ningún pago de este empleador en los últimos 90 días.
         payment: Pago de %{amount} antes de pago impuestos en %{date}
         phone_number: Teléfono del empleador
         table_caption: 'Empleador %{number}: %{employer_name}'
         table_caption_no_name: Empleador %{number}
         total_income_from_no_employer_name: 'Ingresos totales antes del pago de impuestos: %{amount}'
-        total_payments: 'Ingresos totales correspondiente a los últimos 90 días, antes de impuestos: %{amount}'
         your_information: Su información
     synchronization_failures:
       show:
@@ -492,6 +484,8 @@ es:
       fr: Francés
       zh: Chino
     not_applicable: N/C
+    report_data_range:
+      ninety_days: 90 días
     reporting_purpose:
       ma: beneficios
       nyc: beneficios

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -1,6 +1,17 @@
 require "yaml"
 
 class ClientAgencyConfig
+  # These are the only supported number of days we allow an agency to define in
+  # the `pay_income_days` configuration option.
+  #
+  # Every value in this array must have a corresponding partial webhook
+  # subscription in ArgyleWebhooksManager in order to properly allow the user
+  # to continue as soon as that amount of data has synced.
+  #
+  # If you add a new entry to this list, also search for
+  # 'ninety_days'/'six_months' to see other places you will need to customize.
+  VALID_PAY_INCOME_DAYS = [ 90, 182 ]
+
   def initialize(config_path)
     template = ERB.new File.read(config_path)
     @client_agencies = YAML
@@ -59,7 +70,7 @@ class ClientAgencyConfig
       @invitation_valid_days = yaml["invitation_valid_days"]
       @logo_path = yaml["logo_path"]
       @logo_square_path = yaml["logo_square_path"]
-      @pay_income_days = yaml["pay_income_days"]
+      @pay_income_days = yaml.fetch("pay_income_days", { w2: 90, gig: 90 }).symbolize_keys
       @pinwheel_environment = yaml["pinwheel"]["environment"] || "sandbox"
       @argyle_environment = yaml["argyle"]["environment"] || "sandbox"
       @transmission_method = yaml["transmission_method"]
@@ -73,6 +84,9 @@ class ClientAgencyConfig
       raise ArgumentError.new("Client Agency missing id") if @id.blank?
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `agency_name`") if @agency_name.blank?
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `pinwheel.environment`") if @pinwheel_environment.blank?
+      raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.w2") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:w2])
+      raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.gig") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:gig])
+
       # TODO: Add a validation for the dependent attribute, transmission_method_configuration.email, if transmission_method is present
     end
   end

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Cbv::SummariesController do
           doc = Nokogiri::HTML(response.body)
 
           expect(doc.css("title").text).to include("Review your income report")
-          expect(doc.at_xpath("//*[@data-testid=\"summary-description\"]").content).to include("from March 20, 2024 to June 18, 2024")
           expect(doc.at_xpath("//*[@data-testid=\"paystub-table-caption\"]").content).to include("Employer 1: Acme Corporation")
           expect(doc.at_xpath("//*[@data-testid=\"paystub-total-income\"]").content).to include("$4,807.20")
           expect(doc.at_xpath("//tr[@data-testid=\"paystub-row\"]").count).to eq(1)
@@ -90,7 +89,6 @@ RSpec.describe Cbv::SummariesController do
           doc = Nokogiri::HTML(response.body)
           expect(response).to be_successful
           expect(doc.css("title").text).to include("Review your income report")
-          expect(doc.at_xpath("//*[@data-testid=\"summary-description\"]").content).to include("from March 20, 2024 to June 18, 2024")
           expect(doc.at_xpath("//*[@data-testid=\"paystub-table-caption\"]").content).to include("Employer 1: Acme Corporation")
           expect(doc.at_xpath("//*[@data-testid=\"paystub-total-income\"]").content).to include("$9,614.40")
           expect(doc.at_xpath("//*[@data-testid=\"paystub-table\"]").css("td").count).to eq(2)

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Cbv::SummariesController do
   end
 
   around do |ex|
-    Timecop.freeze(&ex)
+    Timecop.freeze(current_time, &ex)
   end
 
   describe "#show" do

--- a/app/spec/factories/aggregator_report.rb
+++ b/app/spec/factories/aggregator_report.rb
@@ -1,8 +1,13 @@
 FactoryBot.define do
   factory :pinwheel_report, class: 'Aggregators::AggregatorReports::PinwheelReport' do
-    transient do
-      pinwheel_service { Aggregators::Sdk::PinwheelService.new(:sandbox) }
+    initialize_with do
+      Aggregators::AggregatorReports::PinwheelReport.new(
+        pinwheel_service: nil,
+        days_to_fetch_for_w2: 90,
+        days_to_fetch_for_gig: 90
+      )
     end
+
     identities do
       [
         Aggregators::ResponseObjects::Identity.new(
@@ -72,8 +77,6 @@ FactoryBot.define do
           )
       ])
     ] }
-    from_date { "2021-09-01" }
-    to_date { "2021-09-30" }
     payroll_accounts { [] }
 
     trait :no_paystubs do
@@ -86,9 +89,14 @@ FactoryBot.define do
       ] }
     end
   end
+
   factory :argyle_report, class: 'Aggregators::AggregatorReports::ArgyleReport' do
-    transient do
-      argyle_service { Aggregators::Sdk::ArgyleService.new(:sandbox) }
+    initialize_with do
+      Aggregators::AggregatorReports::ArgyleReport.new(
+        argyle_service: nil,
+        days_to_fetch_for_w2: 90,
+        days_to_fetch_for_gig: 90
+      )
     end
 
     identities { [
@@ -156,8 +164,6 @@ FactoryBot.define do
           )
       ])
     ] }
-    from_date { "2021-08-01" }
-    to_date { "2021-10-30" }
     payroll_accounts { [] }
 
     trait :no_paystubs do

--- a/app/spec/factories/webhook_request.rb
+++ b/app/spec/factories/webhook_request.rb
@@ -54,7 +54,7 @@ FactoryBot.define do
               }
             }
           when "paystubs.partially_synced"
-            days_synced = evaluator.variant == :six_months ? 182 : 30
+            days_synced = evaluator.variant == :six_months ? 182 : 90
 
             {
               "event" => evaluator.event_type,
@@ -81,7 +81,7 @@ FactoryBot.define do
               }
             }
           when "gigs.partially_synced"
-            days_synced = evaluator.variant == :six_months ? 182 : 30
+            days_synced = evaluator.variant == :six_months ? 182 : 90
 
             {
               "event" => evaluator.event_type,

--- a/app/spec/helpers/report_view_helper_spec.rb
+++ b/app/spec/helpers/report_view_helper_spec.rb
@@ -223,4 +223,37 @@ RSpec.describe ReportViewHelper, type: :helper do
       end
     end
   end
+
+  describe "#report_data_range" do
+    let(:report) { build(:argyle_report) }
+    let(:fetched_days) { 90 }
+
+    before do
+      allow(report)
+        .to receive(:fetched_days)
+        .and_return(fetched_days)
+    end
+
+    subject { helper.report_data_range(report) }
+
+    it "renders when 90 days of data were fetched" do
+      expect(subject).to eq(I18n.t("shared.report_data_range.ninety_days"))
+    end
+
+    context "when 182 days of data were fetched" do
+      let(:fetched_days) { 182 }
+
+      it "returns the string for six months" do
+        expect(subject).to eq(I18n.t("shared.report_data_range.six_months"))
+      end
+    end
+
+    context "when an invalid number of days were fetched" do
+      let(:fetched_days) { 0 }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(/Missing i18n key/)
+      end
+    end
+  end
 end

--- a/app/spec/jobs/client_agency/az_des/report_deliverer_job_spec.rb
+++ b/app/spec/jobs/client_agency/az_des/report_deliverer_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ClientAgency::AzDes::ReportDelivererJob, type: :job do
       expect(sftp_gateway).to receive(:upload_data) do |raw_csv, filename|
         expect(filename).to eq('test/20250401_summary.csv')
         csv = CSV.parse(raw_csv, headers: true)
-        expect(csv.headers).to eq([ "case_number", "confirmation_code", "cbv_link_created_timestamp", "cbv_link_clicked_timestamp", "report_created_timestamp", "report_date_start", "report_date_end", "consent_timestamp", "pdf_filename", "pdf_filetype", "language" ])
+        expect(csv.headers).to eq([ "case_number", "confirmation_code", "cbv_link_created_timestamp", "cbv_link_clicked_timestamp", "report_created_timestamp", "consent_timestamp", "pdf_filename", "pdf_filetype", "language" ])
         row = csv.first
         expect(row["case_number"]).to eq("12345")
         expect(row["consent_timestamp"]).to eq("01/01/2025 03:00:00")

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service do
   describe '#total_gross_income' do
+    let(:report) { build(:pinwheel_report) }
+
     it 'handles nil gross_pay_amount values' do
-      report = Aggregators::AggregatorReports::AggregatorReport.new
       report.paystubs = [
         Aggregators::ResponseObjects::Paystub.new(gross_pay_amount: 100),
         Aggregators::ResponseObjects::Paystub.new(gross_pay_amount: nil)

--- a/app/spec/services/aggregators/aggregator_reports/composite_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/composite_report_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe Aggregators::AggregatorReports::CompositeReport, type: :service d
   let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
   let(:argyle_report) { build(:argyle_report, :with_argyle_account) }
 
-  describe '#init' do
-    subject { Aggregators::AggregatorReports::CompositeReport.new([ pinwheel_report, argyle_report ]) }
+  describe '#initialize' do
+    subject do
+      Aggregators::AggregatorReports::CompositeReport.new(
+        [ pinwheel_report, argyle_report ],
+        days_to_fetch_for_w2: 90,
+        days_to_fetch_for_gig: 90
+      )
+    end
 
     it 'merges identities from both reports' do
       expect(subject.identities.length).to be(2)
@@ -31,14 +37,6 @@ RSpec.describe Aggregators::AggregatorReports::CompositeReport, type: :service d
       expect(subject.paystubs).to all(be_a(Aggregators::ResponseObjects::Paystub))
       expect(subject.paystubs.filter { |d| d.account_id == "account1" }.length).to be(2)
       expect(subject.paystubs.filter { |d| d.account_id == "argyle_report1" }.length).to be(2)
-    end
-
-    it 'sets the earliest from_date' do
-      expect(subject.from_date).to eq(Date.parse("2021-08-01"))
-    end
-
-    it 'sets the latest to_date' do
-      expect(subject.to_date).to eq(Date.parse("2021-10-30"))
     end
 
     it 'sets has_fetched to true' do

--- a/app/spec/services/aggregators/validators/useful_report_validator_spec.rb
+++ b/app/spec/services/aggregators/validators/useful_report_validator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Aggregators::Validators::UsefulReportValidator do
   let(:report) do
-    Aggregators::AggregatorReports::ArgyleReport.new(argyle_service: nil)
+    Aggregators::AggregatorReports::ArgyleReport.new(argyle_service: nil, days_to_fetch_for_w2: 90, days_to_fetch_for_gig: 90)
   end
   let(:identities) { [] }
   let(:employments) { [] }


### PR DESCRIPTION
## Ticket

Resolves [FFS-2875](https://jiraent.cms.gov/browse/FFS-2875).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Update Argyle partial sync to wait for `pay_income_days` of data**
> * Add `unknown` status for the gigs/paystubs webhooks that will be used
>   until they're known to have synced enough data for an agency.
> * Add special handling of the `gigs.partially_synced` and
>   `paystubs.partially_synced` webhooks to set the outcome to "success"
>   when enough data is synced for an agency.

**Improve validation of valid `pay_income_days` values**

**Use dynamic `pay_income_days` in report fetching**
> The report fetching, based off of CbvApplicant#paystubs_query_begins_at,
> was hardcoded to 90 days.

> This commit updates it to do so dynamically based on the
> `pay_income_days` configuration.

**Remove dynamic use of `pay_income_days` on /add_jobs**
> Per [this Slack conversation from collab time][1], we are going to
> hardcode 90 days as the configuration.

> [1]: https://cmsgov.slack.com/archives/C08B41CMECF/p1748541956884009

**Update copy on /payment_details, /summary, and PDF for AZ 6 months data**
> * Add a helper, `report_data_range` that returns the text representing
>   the duration of the employment objects in that report.
> * To handle cases where there may be both a W2 *and* Gig job (/summary,
>   and the PDF), remove the data range copy since both "90 days" and "6
>   months" will be wrong for one job if there is both a W2 and Gig job.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

### Test cases:
**Existing behavior**
- Pinwheel, sandbox agency, w2 -> uses 90 days ✅ 
- Pinwheel, az, w2 -> uses 90 days ✅ 
- Argyle, sandbox agency, w2 -> uses 90 days ✅ 
- Argyle, sandbox agency, gig -> uses 90 days ✅ 
- Argyle, az, w2 -> uses 90 days ✅ 

**Updated behavior:**
- Pinwheel, az, gig -> uses six months (⚠️ It is not possible to test, because the way we classify Gig jobs does not work with Pinwheel sandbox data)
- Argyle, az, gig -> uses six months ✅ 

**Payment Details (az, gig)**
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/77b19929-1294-492c-a2c7-3ab022b83dfc" />

**Summary (az, w2+gig)**
<img width="524" alt="image" src="https://github.com/user-attachments/assets/c29f259c-12bb-4fc7-baba-4a91b9ebac6e" />


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
