### PR TITLE
Track `accountId` and `userId` for Argyle modal events

### DIFF
--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -26,13 +26,13 @@ export default class ArgyleModalAdapter extends ModalAdapter {
         onAccountConnected: this.onSuccess.bind(this),
         onTokenExpired: this.onTokenExpired.bind(this),
         onAccountCreated: async (payload) => {
-          await trackUserAction("ArgyleAccountCreated", this.sanitizePayload(payload))
+          await trackUserAction("ArgyleAccountCreated", payload)
         },
         onAccountError: async (payload) => {
-          await trackUserAction("ArgyleAccountError", this.sanitizePayload(payload))
+          await trackUserAction("ArgyleAccountError", payload)
         },
         onAccountRemoved: async (payload) => {
-          await trackUserAction("ArgyleAccountRemoved", this.sanitizePayload(payload))
+          await trackUserAction("ArgyleAccountRemoved", payload)
         },
         onUIEvent: async (payload) => {
           await this.onUIEvent(payload)
@@ -63,59 +63,38 @@ export default class ArgyleModalAdapter extends ModalAdapter {
   async onUIEvent(payload: ArgyeUIEvent) {
     switch (payload.name) {
       case "search - opened":
-        await trackUserAction(
-          "ApplicantViewedArgyleDefaultProviderSearch",
-          this.sanitizePayload(payload)
-        )
+        await trackUserAction("ApplicantViewedArgyleDefaultProviderSearch", payload)
         break
       case "login - opened":
         switch (payload.properties.errorCode) {
           case "auth_required":
-            await trackUserAction(
-              "ApplicantEncounteredArgyleAuthRequiredLoginError",
-              this.sanitizePayload(payload)
-            )
+            await trackUserAction("ApplicantEncounteredArgyleAuthRequiredLoginError", payload)
             break
           case "connection_unavailable":
             await trackUserAction(
               "ApplicantEncounteredArgyleConnectionUnavailableLoginError",
-              this.sanitizePayload(payload)
+              payload
             )
             break
           case "expired_credentials":
-            await trackUserAction(
-              "ApplicantEncounteredArgyleExpiredCredentialsLoginError",
-              this.sanitizePayload(payload)
-            )
+            await trackUserAction("ApplicantEncounteredArgyleExpiredCredentialsLoginError", payload)
             break
           case "invalid_auth":
-            await trackUserAction(
-              "ApplicantEncounteredArgyleInvalidAuthLoginError",
-              this.sanitizePayload(payload)
-            )
+            await trackUserAction("ApplicantEncounteredArgyleInvalidAuthLoginError", payload)
             break
           case "invalid_credentials":
-            await trackUserAction(
-              "ApplicantEncounteredArgyleInvalidCredentialsLoginError",
-              this.sanitizePayload(payload)
-            )
+            await trackUserAction("ApplicantEncounteredArgyleInvalidCredentialsLoginError", payload)
             break
           case "mfa_cancelled_by_the_user":
-            await trackUserAction(
-              "ApplicantEncounteredArgyleMfaCanceledLoginError",
-              this.sanitizePayload(payload)
-            )
+            await trackUserAction("ApplicantEncounteredArgyleMfaCanceledLoginError", payload)
             break
           default:
-            await trackUserAction("ApplicantViewedArgyleLoginPage", this.sanitizePayload(payload))
+            await trackUserAction("ApplicantViewedArgyleLoginPage", payload)
             break
         }
         break
       case "search - link item selected":
-        await trackUserAction(
-          "ApplicantViewedArgyleProviderConfirmation",
-          this.sanitizePayload(payload)
-        )
+        await trackUserAction("ApplicantViewedArgyleProviderConfirmation", payload)
         break
       case "search - term updated":
         await trackUserAction("ApplicantUpdatedArgyleSearchTerm", {
@@ -125,13 +104,10 @@ export default class ArgyleModalAdapter extends ModalAdapter {
         })
         break
       case "login - form submitted":
-        await trackUserAction("ApplicantAttemptedArgyleLogin", this.sanitizePayload(payload))
+        await trackUserAction("ApplicantAttemptedArgyleLogin", payload)
         break
       case "mfa - opened":
-        await trackUserAction(
-          "ApplicantAccessedArgyleModalMFAScreen",
-          this.sanitizePayload(payload)
-        )
+        await trackUserAction("ApplicantAccessedArgyleModalMFAScreen", payload)
         break
       default:
         break
@@ -155,16 +131,5 @@ export default class ArgyleModalAdapter extends ModalAdapter {
     await trackUserAction("ArgyleTokenExpired")
     const { user } = await fetchArgyleToken()
     updateToken(user.user_token)
-  }
-
-  sanitizePayload(payload: any): any {
-    let sanitizedPayload = { ...payload }
-
-    if (sanitizedPayload.properties) {
-      delete sanitizedPayload.properties.accountId
-      delete sanitizedPayload.properties.userId
-    }
-
-    return sanitizedPayload
   }
 }


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - Fix to improve investigation capability that would have helped me.


## Changes
<!-- What was added, updated, or removed in this PR. -->

* **Track `accountId` and `userId` for Argyle modal events**


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

When we initially implemented these in FFS-2652, we were treating these
IDs as PII. After implementing that ticket, we redefined our definition
of PII to exclude non-sensitive identifiers such as these.

Since these will greatly help us investigate odd connection behavior in
the Argyle modal, let's stop sanitizing them.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
