### PR TITLE
[FFS-2686] introduce measurements for household level analytics

### DIFF
--- a/app/spec/controllers/cbv/base_controller_spec.rb
+++ b/app/spec/controllers/cbv/base_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Cbv::BaseController, type: :controller do
+  controller(described_class) do
+    def show
+      render plain: "hello world"
+    end
+  end
+
+  let(:cbv_flow) { create(:cbv_flow, :invited, client_agency_id: "az_des") }
+
+  describe '#track_invitation_clicked_event' do
+    before do
+      routes.draw do
+        get 'show', controller: "cbv/base"
+      end
+    end
+
+    let(:cbv_flow_2) { create(:cbv_flow, cbv_flow_invitation: cbv_flow.cbv_flow_invitation) }
+
+    it "identifies multiple household members if income changes relevant" do
+      cbv_flow.cbv_flow_invitation.cbv_applicant.update!(
+        income_changes: [
+        {
+            member_name: "Dean Venture"
+          },
+        {
+            member_name: "Hank Venture"
+          },
+         {
+            member_name: "Hank Venture"
+          },
+         {
+            member_name: "Dr Venture"
+          } ]
+        )
+      expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          number_household_members: 3
+          ))
+      get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+      expect(response).to be_successful
+      expect(response.body).to eq("hello world")
+    end
+
+    it "identifies one household member if no income changes relevant" do
+      create(:cbv_flow, cbv_flow_invitation: cbv_flow.cbv_flow_invitation)
+      expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          number_household_members: 1
+          ))
+      get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+      expect(response).to be_successful
+      expect(response.body).to eq("hello world")
+    end
+
+    it "identifies number_links_started from cbv flows generated" do
+      create(:cbv_flow, cbv_flow_invitation: cbv_flow.cbv_flow_invitation)
+      expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+      expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          number_links_started: 3
+          ))
+      get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+      expect(response).to be_successful
+      expect(response.body).to eq("hello world")
+    end
+  end
+end

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -45,6 +45,36 @@ RSpec.describe Cbv::EntriesController do
         )
       end
 
+      context "with multiple cbv flows" do
+        it "does the thing" do
+          expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+            cbv_flow_id: be_a(Integer),
+            timestamp: be_a(Integer),
+            invitation_id: invitation.id,
+            client_agency_id: invitation.client_agency_id,
+            seconds_since_invitation: seconds_since_invitation
+          ))
+
+          expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, hash_including(
+            user_agent: be_a(String),
+            invitation_id: invitation.id,
+            cbv_flow_id: be_a(Integer),
+            client_agency_id: invitation.client_agency_id,
+            path: "/cbv/entry"
+          ))
+
+          expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedAgreement", anything, hash_including(
+            cbv_flow_id: be_a(Integer),
+            timestamp: be_a(Integer),
+            invitation_id: invitation.id,
+            client_agency_id: invitation.client_agency_id
+          ))
+
+          get :show, params: { token: invitation.auth_token }
+        end
+      end
+
+
       it "sends events with metadata" do
         request.headers["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2686](https://jiraent.cms.gov/browse/FFS-XXXX).


## Changes

Introduces metrics to count number of household members, number of reports completed, and number of links started. 

## Context for reviewers

This is likely a hack for count_unique_members, but its a starting point before doing further investigation and negotiation with product.

## Acceptance testing
  * Check mixpanel events are firing as expected while walking through as an AZ user, including using the same invitation to do multiple report flows.


- [ X ] Acceptance testing prior to merge
  * Check mixpanel events are firing as expected while walking through as an AZ user, including using the same invitation to do multiple report flows.
