### PR TITLE
FFS-2980: Inconsistent hours format in gig summary table

### DIFF
--- a/app/app/components/report/monthly_summary_table_component.erb
+++ b/app/app/components/report/monthly_summary_table_component.erb
@@ -28,7 +28,7 @@
           <%= row.with_data_cell
                  .with_content(format_money(summary[:accrued_gross_earnings])) %>
           <%= row.with_data_cell
-                 .with_content(summary[:total_gig_hours]) %>
+                 .with_content(format_hours(summary[:total_gig_hours])) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/spec/components/report/monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/monthly_summary_table_component_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe Report::MonthlySummaryTableComponent, type: :component do
         subject = render_inline(described_class.new(argyle_report, payroll_account))
 
         expect(subject.css("thead tr.subheader-row th:nth-child(3)").to_html).to include "Total hours worked"
-        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "3.61"
-        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "21.82"
-        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "4.74"
+        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "3.6"
+        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "21.8"
+        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "4.7"
       end
 
       describe "#find_employer_name" do


### PR DESCRIPTION
## Ticket

Resolves [FFS-2980](https://jiraent.cms.gov/browse/FFS-2980).


## Changes
- Gig hours rounded to the nearest tenth using `format_hours`
- Tests updated to check for rounding success

## Context
[Slack thread about tenths vs hundredths](https://cmsgov.slack.com/archives/C066XS5543S/p1749494135599339)

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
Lookin' good
<img width="992" alt="Screenshot 2025-06-09 at 11 36 43 AM" src="https://github.com/user-attachments/assets/14c578d2-6629-4328-84bc-b2aa73b9a2b9" />
