### PR TITLE
Allow `is_caseworker` override param in demo environment

### DIFF
--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -32,7 +32,7 @@ class Cbv::SubmitsController < Cbv::BaseController
         render pdf: "#{@cbv_flow.id}",
           layout: "pdf",
           locals: {
-            is_caseworker: (Rails.env.development? || Rails.env.test?) && params[:is_caseworker],
+            is_caseworker: allow_caseworker_override_param? && params[:is_caseworker],
             aggregator_report: @aggregator_report
           },
           footer: { right: "Income Verification Report | Page [page] of [topage]", font_size: 10 },
@@ -103,5 +103,9 @@ class Cbv::SubmitsController < Cbv::BaseController
       (Time.now.to_i % 36 ** 3).to_s(36).tr("OISB", "0158").rjust(3, "0"),
       cbv_flow.id.to_s.rjust(4, "0")
     ].compact.join.upcase
+  end
+
+  def allow_caseworker_override_param?
+    Rails.env.development? || Rails.env.test? || demo_mode?
   end
 end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - Request via Slack.


## Changes
<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

We only allow this in local development presently. Since AZ makes it
difficult to see the rendered caseworker report (as it is immediately
uploaded to SFTP, where we are unable to retrieve it), let's enable the
caseworker param in our demo mode as well.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
