### PR TITLE
FFS-2937: Fix age range parsing to require YYYY-mm-dd format

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
   end
 
   def date_string_to_date(date_string)
-    date_string.is_a?(Date) ? date_string : Date.parse(date_string)
+    date_string.is_a?(Date) ? date_string : Date.strptime(date_string, "%Y-%m-%d")
   rescue
     nil
   end
@@ -113,7 +113,7 @@ module ApplicationHelper
     when 70..74 then "70-74"
     when 75..79 then "75-79"
     when 80..89 then "80-89"
-    else "90+"
+    when 90.. then "90+"
     end
   end
 end

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -137,6 +137,14 @@ RSpec.describe ApplicationHelper do
       expect(helper.get_age_range("invalid-date")).to be_nil
     end
 
+    it "returns nil for invalid date input (from paylocity) before the current day of year" do
+      expect(helper.get_age_range("--01-02", now: now)).to be_nil
+    end
+
+    it "returns nil for invalid date input (from paylocity)" do
+      expect(helper.get_age_range("--12-30", now: now)).to be_nil
+    end
+
     it "returns age range when the date of birth is a string" do
       expect(helper.get_age_range("1990-01-01", now: now)).to eq("30-39")
     end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2937](https://jiraent.cms.gov/browse/FFS-2937).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2937: Fix age range parsing to require YYYY-mm-dd format**
> We've been seeing an abnormal number of people categorized as "90+".
> Upon further inspection, this is due to hiting the `else` in the case
> statement when the payroll aggregator returns us bad data (of the form
> "--09-04"). Paylocity and Paycor seem to be the culprits.

> To handle this, let's return `nil` from the `get_age_range` function
> when the date is not of the form "YYYY-mm-dd". This will prevent our
> analytics from being polluted.

> I also updated the `case` statement to not fall back to "90+" as the
> `else` as an extra line of defense against other logic bugs later.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
This will be so hard to reproduce that I suggest we just skip acceptance
testing.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
