### PR TITLE
FFS-2983: Use "client" or "you" conditionally in monthly summary table

### DIFF
--- a/app/app/components/report/monthly_summary_table_component.erb
+++ b/app/app/components/report/monthly_summary_table_component.erb
@@ -60,7 +60,7 @@
     <% if show_payments? %>
       <div>
         <h2><%= I18n.t("components.report.monthly_summary_table.payments_from_header", employer_name: @employer_name) %></h2>
-        <div class="usa-prose"><p><%= I18n.t("components.report.monthly_summary_table.payments_from_text", employer_name: @employer_name) %></p></div>
+        <div class="usa-prose"><p><%= payments_from_text %></p></div>
 
         <ul class="usa-list">
           <% @paystubs.each do |paystub| %>

--- a/app/app/components/report/monthly_summary_table_component.rb
+++ b/app/app/components/report/monthly_summary_table_component.rb
@@ -4,7 +4,7 @@ class Report::MonthlySummaryTableComponent < ViewComponent::Base
 
   attr_reader :employer_name
 
-  def initialize(report, payroll_account, is_responsive: true, show_payments: true, show_footnote: true)
+  def initialize(report, payroll_account, is_responsive: true, is_caseworker: false, show_payments: true, show_footnote: true)
     @report = report
     @show_payments = show_payments
     @show_footnote = show_footnote
@@ -16,6 +16,7 @@ class Report::MonthlySummaryTableComponent < ViewComponent::Base
     @employer_name = account_report&.dig(:employment, :employer_name)
     @monthly_summary_data = report.summarize_by_month[@account_id]
     @is_responsive = is_responsive
+    @is_caseworker = is_caseworker
   end
 
   def before_render
@@ -40,6 +41,14 @@ class Report::MonthlySummaryTableComponent < ViewComponent::Base
 
   def show_footnote?
     @show_footnote
+  end
+
+  def payments_from_text
+    if @is_caseworker
+      I18n.t("components.report.monthly_summary_table.payments_from_text_caseworker", employer_name: @employer_name)
+    else
+      I18n.t("components.report.monthly_summary_table.payments_from_text", employer_name: @employer_name)
+    end
   end
 
   def table_colspan

--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -157,7 +157,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <%= render(Report::MonthlySummaryTableComponent.new(@aggregator_report, account_id, is_responsive: false)) %>
+    <%= render(Report::MonthlySummaryTableComponent.new(@aggregator_report, account_id, is_caseworker: is_caseworker, is_responsive: false)) %>
   <% end %>
 
   <% if @cbv_flow.additional_information.dig(account_id, "comment").present? %>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -138,6 +138,7 @@ ignore_missing:
     # Currently awaiting translation:
     # - "example.strings.*"   # Tag with ticket number that created or modified the string
     - "shared.footer.feedback" # [FFS-2922]
+    - "components.report.monthly_summary_table.payments_from_text"  # FFS-2983
 
 ## Consider these keys used:
 ignore_unused:
@@ -151,7 +152,6 @@ ignore_unused:
     - "help.show.credentials.security_message"  # dynamically looked up help translations
     - "cbv.submits.show.pdf.caseworker.*" #dynamically looked up translations
     - "cbv.submits.show.pdf.client.agency_id_number" #dynamically looked up translations
-    - "components.report.monthly_summary_table.*" # FFS-2668 - this should be removed when actually used
 
 csv:
   # see: https://github.com/glebm/i18n-tasks/wiki/Custom-CSV-import-and-export-tasks

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -533,7 +533,8 @@ en:
         monthly_summary: Monthly Summary
         partial_month_text: "(Partial month: from %{start_date}-%{end_date})"
         payments_from_header: Payments from %{employer_name}
-        payments_from_text: These were the dates that the client was paid for their work at %{employer_name} and the gross pay amount.
+        payments_from_text: These were the dates that you were paid for your work at %{employer_name} and the gross pay amount.
+        payments_from_text_caseworker: These were the dates that the client was paid for their work at %{employer_name} and the gross pay amount.
         total_gig_hours: Total hours worked
         verified_mileage_expenses: Verified mileage expenses
   continue: Continue

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -369,7 +369,7 @@ es:
         monthly_summary: Resumen mensual
         partial_month_text: "(Mes parcial: desde el %{start_date} y hasta el %{end_date})"
         payments_from_header: Pagos de %{employer_name}
-        payments_from_text: Estas son las fechas en las que se le pagó al cliente por su trabajo en %{employer_name} y el monto total del pago, antes de impuestos.
+        payments_from_text_caseworker: Estas son las fechas en las que se le pagó al cliente por su trabajo en %{employer_name} y el monto total del pago, antes de impuestos.
         total_gig_hours: Total de horas trabajadas
         verified_mileage_expenses: Gastos de millaje verificado
   continue: Continuar

--- a/app/spec/components/report/monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/monthly_summary_table_component_spec.rb
@@ -175,6 +175,10 @@ RSpec.describe Report::MonthlySummaryTableComponent, type: :component do
         expect(subject.to_html).to include '"Total hours worked" sums the time'
       end
 
+      it "renders the client-facing payments from text" do
+        expect(subject.to_html).to include(I18n.t("components.report.monthly_summary_table.payments_from_text", employer_name: "Lyft Driver"))
+      end
+
       describe "#find_employer_name" do
         it "returns the correct employer name for the specified account id" do
           # Initializing the component under test
@@ -198,7 +202,23 @@ RSpec.describe Report::MonthlySummaryTableComponent, type: :component do
           expect(employer_name).to be_nil
         end
       end
+
+      context "when rendering in a caseworker report" do
+        subject do
+          render_inline(described_class.new(
+            argyle_report,
+            payroll_account,
+            is_responsive: false,
+            is_caseworker: true
+          ))
+        end
+
+        it "renders the caseworker-facing payments from text" do
+          expect(subject.to_html).to include(I18n.t("components.report.monthly_summary_table.payments_from_text_caseworker", employer_name: "Lyft Driver"))
+        end
+      end
     end
+
     context "with John LoanSeeker, a gig-worker with no paystubs nor gigs" do
       let(:account_id) { "019755d1-6727-1f48-c35f-41bce3a6263c" }
       let(:argyle_report) { Aggregators::AggregatorReports::ArgyleReport.new(payroll_accounts: [ payroll_account ], argyle_service: argyle_service, days_to_fetch_for_w2: 90, days_to_fetch_for_gig: 182) }


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2983](https://jiraent.cms.gov/browse/FFS-2983).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-2983: Use "client" or "you" conditionally in monthly summary table**
> We want to render this component with different text when shown to an
> applicant ("you") versus caseworker ("client").

> I've introduced a new option for the report, `is_caseworker`, that will
> determine which variant of this component is being rendered.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

Payment details page:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/d3bcd832-7df1-4a25-aad3-4c92da5fc133" />

Client-facing income report:
<img width="845" alt="image" src="https://github.com/user-attachments/assets/affb348a-0b43-4abb-96da-181fa9e68f0a" />

Caseworker-facing report:
<img width="889" alt="image" src="https://github.com/user-attachments/assets/e01019d0-c5ca-4ba5-8f92-a852fe50a919" />



## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
