### PR TITLE
No ticket: final string translations required for AZ go-live

### DIFF
--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -137,8 +137,6 @@ ignore_missing:
 
     # Currently awaiting translation:
     # - "example.strings.*"   # Tag with ticket number that created or modified the string
-    - "shared.footer.feedback" # [FFS-2922]
-    - "components.report.monthly_summary_table.payments_from_text"  # FFS-2983
 
 ## Consider these keys used:
 ignore_unused:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -369,6 +369,7 @@ es:
         monthly_summary: Resumen mensual
         partial_month_text: "(Mes parcial: desde el %{start_date} y hasta el %{end_date})"
         payments_from_header: Pagos de %{employer_name}
+        payments_from_text: Estas fueron las fechas en las que le pagaron por su trabajo en %{employer_name} y el monto del salario bruto.
         payments_from_text_caseworker: Estas son las fechas en las que se le pagó al cliente por su trabajo en %{employer_name} y el monto total del pago, antes de impuestos.
         total_gig_hours: Total de horas trabajadas
         verified_mileage_expenses: Gastos de millaje verificado
@@ -572,6 +573,8 @@ es:
       nyc: SNAP
       sandbox: SNAP
     error_unauthorized: La URL a la que estás accediendo está prohibida para el usuario actual. Verifique que está conectado como el usuario correcto e intente acceder de nuevo a la URL.
+    footer:
+      feedback: Compartir comentarios
     header:
       aria_label: Menú principal
       cbv_flow_title:


### PR DESCRIPTION
## No Ticket

## Changes
Adds two string translations for English strings that are currently in main. These are required for AZ go-live and were approved by Patricia.

## Context for reviewers
The two new strings are:
FFS-2983 added a new string on the report for payments from text.
There's also a new button in the footer that reads "Share feedback".

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
