### PR TITLE
No ticket: remove Rainbow to fix auto-deploy

### DIFF
--- a/app/lib/translation_diff_generator.rb
+++ b/app/lib/translation_diff_generator.rb
@@ -1,6 +1,5 @@
 require "yaml"
 require "csv"
-require "rainbow"
 
 require_relative "../services/locale_diff_service"
 
@@ -12,10 +11,10 @@ class TranslationDiffGenerator
     @locale_diff_service = LocaleDiffService.new
     @project_root = @locale_diff_service.project_root
 
-    puts Rainbow("Configuration:").bright
-    puts " - Comparing against branch: #{Rainbow(LocaleDiffService::BASE_BRANCH).cyan}"
-    puts " - English locale: #{Rainbow(LocaleDiffService::EN_LOCALE_PATH).cyan}"
-    puts " - Output file: #{Rainbow(OUTPUT_CSV_PATH).cyan}"
+    puts "Configuration:"
+    puts " - Comparing against branch: #{LocaleDiffService::BASE_BRANCH}"
+    puts " - English locale: #{LocaleDiffService::EN_LOCALE_PATH}"
+    puts " - Output file: #{OUTPUT_CSV_PATH}"
     puts "--------------------------------------------------"
   end
 
@@ -37,19 +36,19 @@ class TranslationDiffGenerator
     keys_to_translate = @locale_diff_service.find_changed_keys(flat_old_en, flat_current_en)
 
     if keys_to_translate.empty?
-      puts Rainbow("✅ No new or modified English keys found. You're all set!").green
+      puts "✅ No new or modified English keys found. You're all set!"
       return
     end
 
-    puts Rainbow("Found #{keys_to_translate.count} keys that are new or modified.").yellow
+    puts "Found #{keys_to_translate.count} keys that are new or modified."
 
     puts "4. Translating strings to `#{TARGET_LANGUAGE_CODE}` and generating CSV..."
     create_csv(keys_to_translate, flat_current_en)
 
-    puts Rainbow("\n🎉 Success! CSV file created at: #{OUTPUT_CSV_PATH}").green
+    puts "\n🎉 Success! CSV file created at: #{OUTPUT_CSV_PATH}"
     puts "Please review the file and send it to your translation service."
   rescue StandardError => e
-    puts Rainbow("\n💥 An unexpected error occurred:").red
+    puts "\n💥 An unexpected error occurred:"
     puts e.message
     puts e.backtrace
   end
@@ -68,7 +67,7 @@ class TranslationDiffGenerator
 
         # Skip non-string values (e.g., YAML aliases, booleans)
         unless english_text.is_a?(String) && !english_text.empty?
-          puts Rainbow("Skipping non-string or empty key: #{key}").magenta
+          puts "Skipping non-string or empty key: #{key}"
           next
         end
 
@@ -80,7 +79,7 @@ class TranslationDiffGenerator
         progress = (index + 1).to_f / total_keys
         filled_length = (progress * progress_bar_length).to_i
         bar = "█" * filled_length + "-" * (progress_bar_length - filled_length)
-        print "\rProgress: [#{Rainbow(bar).green}] #{(progress * 100).to_i}%"
+        print "\rProgress: [#{bar}] #{(progress * 100).to_i}%"
       end
     end
   end


### PR DESCRIPTION
## No ticket

## Changes
I wrote a script that demanded Rainbow pretty frivolously. I didn't added it to our Gemfile and it broke auto-deploys. I've decided I'd rather just omit Rainbow than add it.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
