### PR TITLE
Expire sessions in Rails rather than via cookie `Expires`

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_if_maintenance_mode
   before_action :enable_mini_profiler_in_demo
   before_action :check_help_param
+  before_action :validate_session_expiration
 
   rescue_from ActionController::InvalidAuthenticityToken do
     redirect_to root_url, flash: { slim_alert: { type: "info", message_html:  t("cbv.error_missing_token_html") } }
@@ -124,5 +125,15 @@ class ApplicationController < ActionController::Base
       flash.now[:alert_heading] = t("help.alert.heading")
       flash.now[:alert_type] = "warning"
     end
+  end
+
+  def validate_session_expiration
+    if session[:expires_at].present? && Time.at(session[:expires_at]).past?
+      reset_session
+    end
+
+    expires_at = Rails.application.config.cbv_session_expires_after.from_now
+
+    session[:expires_at] = expires_at.to_i
   end
 end

--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
       <%= render "application/footer" %>
       <% if session[:cbv_flow_id] %>
         <%= render partial: "cbv/sessions/timeout_modal", locals: {
-          timeout: Rails.application.config.session_options[:expire_after]
+          timeout: Rails.application.config.cbv_session_expires_after
         } %>
       <% end %>
     </div>

--- a/app/config/application.rb
+++ b/app/config/application.rb
@@ -53,6 +53,7 @@ module IvCbvPayroll
       agency = config.client_agencies[agency_id]
       config.hosts << agency.agency_domain
     end
+    config.cbv_session_expires_after = 30.minutes
 
     # Health check endpoints should be accessible from any host
     config.host_authorization = {

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,3 +1,2 @@
 Rails.application.config.session_store :cookie_store,
-  key: "_iv_cbv_payroll_session",
-  expire_after: 30.minutes
+  key: "_iv_cbv_payroll_session"


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Related to [FFS-2687](https://jiraent.cms.gov/browse/FFS-2687).


## Changes
<!-- What was added, updated, or removed in this PR. -->


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This is motivated by the E2E test branch - in those tests we will be
stubbing the Rails Time.now (the basis for the cookies' `Expires`
attribute), but Chrome will happily invalidate the cookie based on the
real time the test is being run.

To eliminate this issue, this commit moves the session expiration into
the cookie's contents instead, by storing an `expires_at` value, where
Rails can exclusively determine whether 30 minutes has passed.

I tested this manually by advancing my system clock, and even once
waiting 30 minutes the long way.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
