### PR TITLE
FFS-2973: Investigate 'undefined method 'paystubs' for nil' error on summary page

### DIFF
--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -12,6 +12,7 @@ class Cbv::SummariesController < Cbv::BaseController
 
   def check_aggregator_report
     if @aggregator_report.nil?
+      Rails.logger.error "Aggregator report nil for #{@cbv_flow.id}. User reached summary page without successfully synced payroll accounts."
       redirect_to cbv_flow_synchronization_failures_path
     end
   end

--- a/app/app/controllers/cbv/summaries_controller.rb
+++ b/app/app/controllers/cbv/summaries_controller.rb
@@ -2,9 +2,18 @@ class Cbv::SummariesController < Cbv::BaseController
   include Cbv::AggregatorDataHelper
 
   before_action :set_aggregator_report, only: %i[show]
+  before_action :check_aggregator_report, only: %i[show]
 
   def show
     track_accessed_income_summary_event(@cbv_flow, @aggregator_report.paystubs)
+  end
+
+  private
+
+  def check_aggregator_report
+    if @aggregator_report.nil?
+      redirect_to cbv_flow_synchronization_failures_path
+    end
   end
 
   def track_accessed_income_summary_event(cbv_flow, payments)

--- a/app/spec/controllers/cbv/summaries_controller_spec.rb
+++ b/app/spec/controllers/cbv/summaries_controller_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Cbv::SummariesController do
       pinwheel_stub_request_shifts_response
     end
 
+    context "when user has no successfully synced accounts" do
+  it "redirects to synchronization failures page" do
+    cbv_flow.payroll_accounts.update_all(synchronization_status: :failed)
+
+    get :show
+
+    expect(response).to redirect_to(cbv_flow_synchronization_failures_path)
+  end
+end
+
     context "when rendering views" do
       render_views
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-2973](https://jiraent.cms.gov/browse/FFS-2973).


## Changes
- Added `check_aggregator_report` `before_action` to `SummariesController` to handle nil aggregator report
- Test case for scenario when user has no successfully synced accounts
- Redirect to synchronization failures page instead of crashing with `NoMethodError` (mimics `SubmitsController`)
- Helpful logging

## Context for reviewers
### Root cause

The flow's next_path logic allows users to go directly from `/applicant_information` to `/summary page`, even when they've never connected any employers. This leaves us without successful data to generate a report from.

Users shouldn't be able to reach the `/summary page` when there's no income data to summarize. The summary page assumes there's at least one successfully synced employer account to display paystubs from. 👍 

To replicate:

- Visit http://localhost:3000/cbv/links/la_ldh
- Click "I Agree", then manually navigate to `/cbv/applicant_information`
- Fill out form and click "Continue" (crashes before fix, redirects after)

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
