### PR TITLE
FFS-3047: Update DB backups to run daily with a 21 day retention

### DIFF
--- a/infra/modules/database/backups.tf
+++ b/infra/modules/database/backups.tf
@@ -9,7 +9,11 @@ resource "aws_backup_plan" "backup_plan" {
   rule {
     rule_name         = "${var.name}-db-backup-rule"
     target_vault_name = aws_backup_vault.backup_vault.name
-    schedule          = "cron(0 7 ? * SUN *)" # Run Sundays at 12pm (EST)
+    schedule          = "cron(30 0 * * ? *)" # Run daily at 12:30am (UTC)
+
+    lifecycle {
+      delete_after = 21
+    }
   }
 }
 

--- a/infra/modules/database/backups.tf
+++ b/infra/modules/database/backups.tf
@@ -9,7 +9,7 @@ resource "aws_backup_plan" "backup_plan" {
   rule {
     rule_name         = "${var.name}-db-backup-rule"
     target_vault_name = aws_backup_vault.backup_vault.name
-    schedule          = "cron(30 0 * * ? *)" # Run daily at 12:30am (UTC)
+    schedule          = "cron(0 7 * * ? *)" # Run daily at 7am UTC (2am EST)
 
     lifecycle {
       delete_after = 21


### PR DESCRIPTION
## Ticket

Resolves [FFS-3047](https://jiraent.cms.gov/browse/FFS-3047).


## Changes
- Updated the database backup plan to run daily at 12:30AM (UTC) with a 21 day retention period for snapshots.

```terraform
Terraform will perform the following actions:

  # module.database.aws_backup_plan.backup_plan will be updated in-place
  ~ resource "aws_backup_plan" "backup_plan" {
        id       = "c17c8b4b-86f4-41c4-b2d1-ccb5a99176b5"
        name     = "app-dev-db-backup-plan"
        tags     = {}
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 180 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "app-dev-db-backup-rule" -> null
          - schedule                 = "cron(0 7 ? * SUN *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "app-dev-db-backup-vault" -> null
        }
      + rule {
          + completion_window        = 180
          + enable_continuous_backup = false
          + rule_name                = "app-dev-db-backup-rule"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "app-dev-db-backup-vault"

          + lifecycle {
              + delete_after = 21
            }
        }
    }
```

## Context for reviewers
Refer to his [Slack thread](https://cmsgov.slack.com/archives/C066XS5543S/p1751315570024329) for more information

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
