### PR TITLE
FFS-3007-1: Fix CbvApplicant instantiation and add first/last names to Identity object

### DIFF
--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -16,8 +16,8 @@ class CbvApplicant < ApplicationRecord
   self.inheritance_column = "client_agency_id"
 
   def self.sti_name
-    # "CbvApplicant::Sandbox" => "sandbox"
-    name.demodulize.downcase
+    # "CbvApplicant::AzDes" => "az_des"
+    name.demodulize.underscore
   end
 
   def self.sti_class_for(type_name)

--- a/app/app/models/payroll_account.rb
+++ b/app/app/models/payroll_account.rb
@@ -1,7 +1,7 @@
 class PayrollAccount < ApplicationRecord
   def self.sti_name
     # "PayrollAccount::Pinwheel" => "pinwheel"
-    name.demodulize.downcase
+    name.demodulize.underscore
   end
 
   def self.sti_class_for(type_name)

--- a/app/app/services/aggregators/response_objects/identity.rb
+++ b/app/app/services/aggregators/response_objects/identity.rb
@@ -1,6 +1,8 @@
 module Aggregators::ResponseObjects
   IDENTITY_FIELDS = %i[
     account_id
+    first_name
+    last_name
     full_name
     date_of_birth
     emails
@@ -13,6 +15,8 @@ module Aggregators::ResponseObjects
     def self.from_pinwheel(response_body)
       new(
         account_id: response_body["account_id"],
+        first_name: (response_body["full_name"].split(" ", 2).first if response_body["full_name"].present?),
+        last_name: (response_body["full_name"].split(" ", 2).last if response_body["full_name"].present?),
         full_name: response_body["full_name"],
         date_of_birth: response_body["date_of_birth"],
         emails: response_body["emails"],
@@ -25,6 +29,8 @@ module Aggregators::ResponseObjects
     def self.from_argyle(identity_response_body)
       new(
         account_id: identity_response_body["account"],
+        first_name: identity_response_body["first_name"],
+        last_name: identity_response_body["last_name"],
         full_name: identity_response_body["full_name"],
         date_of_birth: identity_response_body["birth_date"],
         emails: [ identity_response_body["email"] ],

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -52,8 +52,11 @@ RSpec.describe Api::InvitationsController do
 
         invitation = CbvFlowInvitation.last
         expect(invitation.client_agency_id).to eq(client_agency_id.to_s)
-        expect(invitation.cbv_applicant.income_changes.length).to eq(2)
-        expect(invitation.cbv_applicant.income_changes[0]["member_name"]).to eq("Mark Scout")
+
+        applicant = invitation.cbv_applicant
+        expect(applicant.client_agency_id).to eq("az_des")
+        expect(applicant.income_changes.length).to eq(2)
+        expect(applicant.income_changes[0]["member_name"]).to eq("Mark Scout")
       end
     end
 

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Cbv::EntriesController do
 
         cbv_flow = invitation.cbv_flows.first
         expect(cbv_flow).to have_attributes(
-          cbv_applicant: have_attributes(case_number: "ABC1234"),
+          cbv_applicant: have_attributes(client_agency_id: "sandbox", case_number: "ABC1234"),
           cbv_flow_invitation: invitation
         )
       end

--- a/app/spec/factories/cbv_applicant.rb
+++ b/app/spec/factories/cbv_applicant.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
     created_at { Date.current.strftime("%m/%d/%Y") }
     snap_application_date { Date.current.strftime("%m/%d/%Y") }
 
+    # Instantiate the proper subclass:
+    # @see https://stackoverflow.com/questions/57504422/how-to-make-factorybot-return-the-right-sti-sub-class
+    initialize_with { CbvApplicant.sti_class_for(client_agency_id).new }
+
     trait :sandbox do
       client_agency_id { "sandbox" }
     end

--- a/app/spec/services/aggregators/response_objects/identity_spec.rb
+++ b/app/spec/services/aggregators/response_objects/identity_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Aggregators::ResponseObjects::Identity do
     it 'creates an Identity object from pinwheel response' do
       identity = described_class.from_pinwheel(pinwheel_response)
       expect(identity.account_id).to eq("03e29160-f7e7-4a28-b2d8-813640e030d3")
+      expect(identity.first_name).to eq("Ash")
+      expect(identity.last_name).to eq("Userton")
       expect(identity.full_name).to eq("Ash Userton")
       expect(identity.emails).to eq([ "user_good@example.com" ])
       expect(identity.phone_numbers).to eq([ { "type" => nil, "value" => "+12345556789" } ])
@@ -28,6 +30,8 @@ RSpec.describe Aggregators::ResponseObjects::Identity do
     it 'creates an Identity object from argyle response' do
       identity = described_class.from_argyle(argyle_response)
       expect(identity.account_id).to eq("019571bc-2f60-3955-d972-dbadfe0913a8")
+      expect(identity.first_name).to eq("Bob")
+      expect(identity.last_name).to eq("Jones")
       expect(identity.full_name).to eq("Bob Jones")
       expect(identity.emails).to eq([ "test1@argyle.com" ])
       expect(identity.phone_numbers).to eq([ "+18009000010" ])


### PR DESCRIPTION
## Ticket

Precursor to [FFS-3007](https://jiraent.cms.gov/browse/FFS-3007).


## Changes
<!-- What was added, updated, or removed in this PR. -->
Two unrelated things necessary for FFS-3007. (I plan to rebase this on main since these are unrelated).

1. **Fix factories not instantiating CbvApplicant STI subclasses**
Due to the lack of `initialize_with` in the CbvApplicant factory,
FactoryBot always was instantiating a base CbvApplicant rather than the
desired subclass.
There was one spec failure, in the WeeklyReportMailer spec. Somewhere
deep within ActiveRecord, objects for this spec were getting created
with a `client_agency_id` being produced by the `.sti_name` method. This
method was not symmetric with `.sti_class_for`, as it should be, when
the name has a capital letter within it.
This also makes the same change to our other usage of STI, in
PayrollAccount, although that should be a noop since we don't have any
subclasses of PayrollAccount with capital letters within them.
2. **Add `first_name` / `last_name` to ResponseObjects::Identity**
This ticket calls for using these fields, which are only provided by
Argyle. Since Argyle is more common, this implements a hacky backfill
for Pinwheel, assuming single-part first names.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
Plan is to merge this one first, without acceptance testing, and then get acceptance testing on the overall feature subsequently.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
