### PR TITLE
FFS-3007-3: Improve agency name match logic and add backfill script

### DIFF
--- a/app/app/services/agency_name_matching_service.rb
+++ b/app/app/services/agency_name_matching_service.rb
@@ -46,8 +46,15 @@ class AgencyNameMatchingService
   private
 
   def match_names(name_one, name_two)
+    # If either name includes all parts of the other name, it's an exact match.
     if (name_one & name_two) == name_one || (name_two & name_one) == name_two
       :exact
+    # If the names are equal after removing whitespace/special characters, it's
+    # also an exact match.
+    elsif name_one.join == name_two.join
+      :exact
+    # Otherwise, it's a close/approximate/no match depending on how many name
+    # segments overlap.
     elsif (name_one & name_two).length >= 2
       :close
     elsif (name_one & name_two).length == 1

--- a/app/app/services/agency_name_matching_service.rb
+++ b/app/app/services/agency_name_matching_service.rb
@@ -60,6 +60,7 @@ class AgencyNameMatchingService
   def normalize_name_list(name_list)
     name_list.uniq.map do |name|
       name
+        .downcase
         .split(/[^a-z]+/i)
         .keep_if { |s| s.length > 1 }
     end

--- a/app/lib/tasks/az_des.rake
+++ b/app/lib/tasks/az_des.rake
@@ -20,4 +20,17 @@ namespace :az_des do
     end_time = now.change(hour: 8)
     ClientAgency::AzDes::ReportDelivererJob.perform_later(start_time, end_time)
   end
+
+  desc "backfill agency name matches"
+  task backfill_agency_name_matches: :environment do
+    puts "Backfilling agency name matches:"
+    CbvFlow
+      .completed
+      .unredacted
+      .where(client_agency_id: "az_des")
+      .find_each do |cbv_flow|
+      puts "  CbvFlow id = #{cbv_flow.id}"
+      MatchAgencyNamesJob.perform_now(cbv_flow.id)
+    end
+  end
 end

--- a/app/spec/services/agency_name_matching_service_spec.rb
+++ b/app/spec/services/agency_name_matching_service_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe AgencyNameMatchingService do
       end
     end
 
+    context "when there are exact name matches differing by capitalization" do
+      let(:second_name_list) { [ "cassian andor" ] }
+
+      it "returns them as exact matches" do
+        expect(subject).to eq(
+          exact_match_count: 1,
+          close_match_count: 0,
+          approximate_match_count: 0,
+          none_match_count: 0
+        )
+      end
+    end
+
     context "when there are hyphenated surnames" do
       let(:second_name_list) { [ "Cassian Andor-Erso" ] }
 
@@ -116,7 +129,7 @@ RSpec.describe AgencyNameMatchingService do
           "Cassian Andor",       # exact match to "Cassian Caleen-Andor"
           "Kleya R. Marki",      # exact match to "Kleya Marki"
           "Senator Bail Organa", # close match to "Senator Leia Organa"
-          "Galen Erso",          # approx match to "Jyn Erso"
+          "Galen Erso",          # approx match to "jyn erso"
           "Vel Kaz-Sartha",      # approx match to "Cinta Kaz"
           "Saw Gerrera"          # no match
         ]
@@ -126,7 +139,7 @@ RSpec.describe AgencyNameMatchingService do
           "Cassian Caleen-Andor",
           "Kleya Marki",
           "Senator Leia Organa",
-          "Jyn Erso",
+          "jyn erso",
           "Cinta Kaz"
         ]
       end

--- a/app/spec/services/agency_name_matching_service_spec.rb
+++ b/app/spec/services/agency_name_matching_service_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe AgencyNameMatchingService do
       end
     end
 
+    context "when there are exact name matches based on whitespace" do
+      let(:second_name_list) { [ "Cassian And Or" ] }
+
+      it "returns them as exact matches" do
+        expect(subject).to eq(
+          exact_match_count: 1,
+          close_match_count: 0,
+          approximate_match_count: 0,
+          none_match_count: 0
+        )
+      end
+    end
+
     context "when there are hyphenated surnames" do
       let(:second_name_list) { [ "Cassian Andor-Erso" ] }
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-3007](https://jiraent.cms.gov/browse/FFS-3007).


## Changes
<!-- What was added, updated, or removed in this PR. -->

- **Update agency name matcher to ignore capitalization**
- **Update agency name matching to be "exact" when only whitespace differs**
- **Add rake task to backfill agency name matches**


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

The last bit of this PR.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
