### PR TITLE
[FFS-2854] delete finished jobs from solidqueue on regular basis

### DIFF
--- a/app/config/initializers/solid_queue.rb
+++ b/app/config/initializers/solid_queue.rb
@@ -1,0 +1,1 @@
+SolidQueue.clear_finished_jobs_after = 7.days

--- a/app/lib/tasks/data_deletion.rake
+++ b/app/lib/tasks/data_deletion.rake
@@ -4,4 +4,11 @@ namespace :data_deletion do
     service = DataRetentionService.new
     service.redact_all!
   end
+
+  desc "clear background jobs older than expiration days"
+  task clear_old_background_jobs: :environment do
+  	SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)
+  end
 end
+
+

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -23,5 +23,10 @@ locals {
       task_command        = ["bin/rails", "data_deletion:redact_all"]
       schedule_expression = "cron(0 14 ? * * *)" # Every day at 2pm UTC (9am EST / 10am EDT)
     }
+
+    clear_old_background_jobs = {
+      task_command = ["bin/rails", "data_deletion:clear_old_background_jobs"]
+      schedule_expression = "cron(*/12 * * * * *)" # once every 12 minutes
+    }
   }
 }


### PR DESCRIPTION

--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-2854](https://jiraent.cms.gov/browse/FFS-2854).


## Changes
chose to use our technique of jobs from the background rake tasks, though we may want to consider activejob in the future (see https://github.com/rails/solid_queue/blob/e04c1f969e3c9775abf85472b04622f21fa5ef27/lib/generators/solid_queue/install/templates/config/recurring.yml#L12)

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ X ] Acceptance testing after merge
  * Will confirm that the background job runner is running after, though did run the rake task locally. 
