### PR TITLE
No ticket: fix i18n tasks failing inappropriately

### DIFF
--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -6,7 +6,6 @@ on:
       - 'app/config/locales/**'
   push:
     branches:
-      - main
       - develop
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
     language: ruby
     files: '^app/.*\.erb$'
 
+  - id: i18n-unused
+    name: i18n-unused
+    entry: bin/run-linter --cd app -- bundle exec i18n-tasks unused
+    language: ruby
+    files: '^app/config/locales/.*\.yml$'
+    pass_filenames: false
+
   - id: i18n-normalize
     name: i18n-normalize
     entry: bin/run-linter --cd app -- bundle exec i18n-tasks normalize

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -134,6 +134,8 @@ ignore_missing:
     - "caseworker_mailer.summary_email.*"
     # Caseworker PDF strings that are only supported in English:
     - "cbv.submits.show.pdf.caseworker.*"
+    # LA wind down content
+    - "pages.home.pilot_ended.la_ldh.*"
 
     # Currently awaiting translation:
     # - "example.strings.*"   # Tag with ticket number that created or modified the string

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -437,7 +437,6 @@ en:
         must_match:
           default: This must match what is shown on your %{agency_acronym} application.
           la_ldh: This must match what is shown on your Medicaid benefits.
-        none_found: We didn't find any payments from this employer.
         payment: Payment of %{amount} before taxes on %{date}
         phone_number: Employer phone
         table_caption: 'Employer %{number}: %{employer_name}'
@@ -475,8 +474,6 @@ en:
             definition_total_hours_worked: '"Total hours worked" sums the time it took to complete every gig worked in that month. There may be gigs worked in a month that were paid in the following month.'
             definition_verified_mileage_expenses: '"Verified mileage expenses" uses mileage from the Platform/App. We multiply this by the federal mileage rate ($.70 for 2025), which covers all costs related to a car. These can be costs like gas, car payments or leasing fees, car insurance, repairs, and maintenance.'
             what_does_this_mean: What does this information mean?
-          month_income: "%{month} gross earnings: %{accrued_gross_earnings}"
-          total_income_header: 'Total income from %{employer_name} before taxes: %{accrued_gross_earnings}'
         dollars_times_miles: "(%{dollar_amount} x %{number_of_miles} miles)"
         month: Month
         monthly_summary: Monthly Summary

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -318,7 +318,6 @@ es:
         must_match:
           default: Esto debe coincidir con lo que se muestra en su solicitud de %{agency_acronym}.
           la_ldh: Esto debe coincidir con lo que se muestra en sus beneficios de Medicaid.
-        none_found: No encontramos ningún pago de este empleador.
         payment: Pago de %{amount} antes de pago impuestos en %{date}
         phone_number: Teléfono del empleador
         table_caption: 'Empleador %{number}: %{employer_name}'
@@ -356,8 +355,6 @@ es:
             definition_total_hours_worked: El total de horas trabajadas se calculan sumando el tiempo que demoró en finalizar cada trabajo completado durante ese mes. Es posible que algunos trabajos realizados en un mes que se le hayan pagado en el mes siguiente.
             definition_verified_mileage_expenses: Los gastos de millaje verificados se calculan utilizando el millaje de la plataforma o aplicación. Multiplicamos el millaje total por la tarifa federal de millaje ($0.70 para 2025), que cubre todos los costos relacionados con un automóvil. Estos pueden ser costos como gasolina, pagos de automóvil o tarifas de arrendamiento, seguro de automóvil, reparaciones y mantenimiento.
             what_does_this_mean: "¿Qué significa esta información?"
-          month_income: 'Ganancias brutas de %{month}: %{accrued_gross_earnings}'
-          total_income_header: 'Ingreso total de %{employer_name} antes de impuestos: %{accrued_gross_earnings}'
         dollars_times_miles: "(%{dollar_amount} x %{number_of_miles} millas)"
         month: Mes
         monthly_summary: Resumen mensual


### PR DESCRIPTION
## No ticket

## Changes
There were a few problems:
1. The Check Locale Sync GitHub Action was breaking on main, but we don't want it to run on main. This ticket disables it on main, but it will still run on PRs.
2. The i18n-tasks health GitHub Action was breaking on main because there were several unused strings in our locale files, and there were several en strings that will never be translated to es (LA wind down copy). Now, the unused strings are deleted, and the LA wind down copy is listed as an exception in i18n-tasks.yml.
3. It was easy to commit problems like in 2 above because we never call the i18n-tasks unused check in our pre-commit hooks. Now, we do.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
