### PR TITLE
FFS-3073: Bugfix for tracking referer

### DIFF
--- a/app/app/controllers/feedbacks_controller.rb
+++ b/app/app/controllers/feedbacks_controller.rb
@@ -6,7 +6,7 @@ class FeedbacksController < ApplicationController
     begin
       event_logger.track("ApplicantClickedFeedbackLink", request, {
         timestamp: Time.now.to_i,
-        referer: request.referer,
+        referer: params[:referer],
         cbv_flow_id: cbv_flow&.id,
         client_agency_id: cbv_flow&.client_agency_id
       })

--- a/app/app/views/application/_footer.html.erb
+++ b/app/app/views/application/_footer.html.erb
@@ -8,7 +8,7 @@
     <div class="cbv-footer__item grid-col-12 tablet:grid-col-4">
       <%= render LinkWithIconComponent.new(
             t("shared.footer.feedback"),
-            url: feedbacks_path,
+            url: feedbacks_path(referer: request.original_url),
             icon: "forum",
             class: "usa-button usa-button--outline usa-button--inverse maxw-mobile",
             target: "_blank"

--- a/app/spec/controllers/feedbacks_controller_spec.rb
+++ b/app/spec/controllers/feedbacks_controller_spec.rb
@@ -14,16 +14,14 @@ RSpec.describe FeedbacksController, type: :controller do
     end
 
     it "redirects to the feedback form and tracks the event with source" do
-      # see https://github.com/rspec/rspec-rails/issues/1655#issuecomment-250418438
-      request.headers.merge!('HTTP_REFERER' => cbv_flow_entry_path(locale: :en))
-
-      get :show
+      referer_url = cbv_flow_employer_search_path(locale: :en)
+      get :show, params: { referer: referer_url }
 
       expect(event_logger).to have_received(:track).with(
         "ApplicantClickedFeedbackLink",
         kind_of(ActionDispatch::Request),
         hash_including(
-          referer: cbv_flow_entry_path(locale: :en),
+          referer: referer_url,
           client_agency_id: cbv_flow.client_agency_id,
           cbv_flow_id: cbv_flow.id
         )


### PR DESCRIPTION
Resolves [FFS-3073](https://jiraent.cms.gov/browse/FFS-3073).


## Changes

- [x] Update footer view template to pass the current full URL to the feedback controller
- [x] Update the feedbacks_controller to utilize the query parameters
- [x] Updated test assertions

## Context for reviewers
In the previous implementation we relied on the `Referer` header to track which link/webpage the user clicked the feedback link on. This method proved to be inconsistent (more information available in this [Slack thread](https://cmsgov.slack.com/archives/C066XS5543S/p1752167652855989)). This PR appends the current page to the link via a query parameter instead.

## Acceptance testing
```bash
12:04:03 web.1    | [ActiveJob] Enqueued EventTrackingJob (Job ID: 9ebc1ca2-4027-431f-9ec6-a433c4bfacf6) to 
SolidQueue(default) with arguments: "ApplicantClickedFeedbackLink", {headers: {"User-Agent": "Mozilla/5.0 (Macintosh; 
Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0"}, remote_ip: "127.0.0.1"}, {timestamp: 1752249843, ip: 
"127.0.0.1", cbv_flow_id: 417, client_agency_id: "sandbox", locale: "en", user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 
10.15; rv:139.0) Gecko/20100101 Firefox/139.0", referer: "http://localhost:3000/en/cbv/employer_search" 👈🏾}
```
- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
