### PR TITLE
Fix timeout modal being hidden behind Argyle

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -263,3 +263,9 @@ input#invitation_link{
     background-color: color('gray-cool-10');
   }
 }
+
+#session-timeout-modal.is-visible {
+  // This is one additional 9 beyond Argyle's modal z-index to make sure
+  // the timeout modal is always visible if displayed
+  z-index: 9999999999;
+}


### PR DESCRIPTION
## Ticket

Resolves [FFS-3038](https://jiraent.cms.gov/browse/FFS-3038).

## Changes

Updates `z-index` of session timeout modal to a somewhat-absurd number so that it always shows in front of Argyle and Pinwheel modals.

## Context for reviewers

- Because we're using `fixed` position on the session timeout modal all we need to do is this update
- I added a single 9 above the highest Argyle/Pinwheel `z-index`, but if there's a different preference for how to display higher let me know

<img width="966" height="893" alt="Screenshot 2025-07-15 at 1 44 10 PM" src="https://github.com/user-attachments/assets/0f0b3eb0-09c7-4d0d-b1f8-aaf7619c10cf" />

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
