### PR TITLE
FFS-2430: Remove inline HTML styles

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -138,13 +138,6 @@ html {
   @include u-bg('yellow-5v');
 }
 
-// Addressing USWDS utilities specificity
-.usa-table {
-  td.text-bold {
-    font-weight: bold;
-  }
-}
-
 .rotate {
   animation: 1s linear infinite rotate-con;
 }
@@ -268,4 +261,15 @@ input#invitation_link{
   // This is one additional 9 beyond Argyle's modal z-index to make sure
   // the timeout modal is always visible if displayed
   z-index: 9999999999;
+}
+
+/*
+ * Utilities
+ */
+.list-style-disc {
+  list-style-type: disc !important;
+}
+
+.display-contents {
+  display: contents !important;
 }

--- a/app/app/assets/stylesheets/uswds-settings.scss
+++ b/app/app/assets/stylesheets/uswds-settings.scss
@@ -12,5 +12,6 @@
   $theme-header-logo-text-width: 100%,
   $theme-header-min-width: "tablet",
   $theme-site-margins-breakpoint: "tablet",
-  $theme-step-indicator-segment-height: 0
+  $theme-step-indicator-segment-height: 0,
+  $utilities-use-important: true
 );

--- a/app/app/components/table_header_component.html.erb
+++ b/app/app/components/table_header_component.html.erb
@@ -1,3 +1,3 @@
-<th scope="row" class="padding-3" style="background-color: #d9e8f6;" colspan="<%= @colspan %>">
+<th scope="row" class="padding-3 bg-primary-lighter" colspan="<%= @colspan %>">
   <%= content %>
 </th>

--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -13,7 +13,7 @@
         <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path) %>
       </div>
     <% else %>
-      <span class="text-middle font-sans-md" style="white-space: nowrap;"><%= agency_translation(".pdf.agency_header_name") %></span>
+      <span class="text-middle font-sans-md text-no-wrap"><%= agency_translation(".pdf.agency_header_name") %></span>
     <% end %>
   <% end %>
 </strong>

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -22,7 +22,7 @@
   <ul class="line-height-sans-5">
     <li>
       <strong><%= t(".whats_next_1_title") %></strong>
-      <ul style="list-style-type: disc;">
+      <ul class="list-style-disc">
         <li><%= t(".whats_next_1_li_1", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
         <li><%= t(".whats_next_1_li_2_html", agency_acronym: agency_translation("shared.agency_acronym"), agency_website: current_agency.agency_contact_website) %></li>
       </ul>
@@ -32,7 +32,7 @@
   <ul class="line-height-sans-5">
     <li>
       <strong><%= t(".whats_next_2_title") %></strong>
-      <ul style="list-style-type: disc;">
+      <ul class="list-style-disc">
         <li><%= t(".whats_next_2_li_1_html", agency_feedback_form: feedback_form_url) %></li>
       </ul>
     </li>
@@ -43,9 +43,9 @@
     <p><%= t(".share_invitation_link_content") %></p>
 
     <div class="display-flex flex-align-center" data-controller="copy-link">
-      <%= form_with(builder: UswdsFormBuilder, html: { style: "display: contents;", class: "" }) do |f| %>
+      <%= form_with(builder: UswdsFormBuilder, html: { class: "display-contents" }) do |f| %>
         <%= f.label :invitation_link, t(".invitation_link_label"), class: "usa-sr-only" %>
-        <input value="<%= @invitation_link %>" autocomplete="off" readonly class="usa-input margin-top-0" style="flex: 1;" data-copy-link-target="input" type="text" name="invitation_link" id="invitation_link">
+        <input value="<%= @invitation_link %>" autocomplete="off" readonly class="usa-input margin-top-0 flex-1" data-copy-link-target="input" type="text" name="invitation_link" id="invitation_link">
         <%# default button variant %>
         <%= f.button_with_icon(t(".copy_link"),
               class: "copy-link-button",

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -25,7 +25,7 @@
       <table class="usa-table usa-table--borderless width-full" data-testid="paystub-table">
         <thead class="border-top-05">
             <tr>
-              <th class="padding-3" style="background-color: #d9e8f6;" colspan="2">
+              <th class="padding-3 bg-primary-lighter" colspan="2">
                 <h4 class="margin-0" data-testid="paystub-total-income">
                   <% if employer_name %>
                     <%= t(".total_income_from", employer_name: employer_name, amount: format_money(summary[:total])) %>


### PR DESCRIPTION
## Ticket

Resolves [FFS-2430](https://jiraent.cms.gov/browse/FFS-2430).


## Changes

- Enables `!important` for USWDS utilities so that we can use them for overrides instead of inline styles
- Adds two utility classes for setting specific properties not included in USWDS
- Replaces inline styles with USWDS or custom utility classes
- Removes a small amount of CSS previously used only because `!important` wasn't enabled for utilities

## Context for reviewers

- The ticket mentions eventually updating the content security policy to disallow inline styles, but I think that could be more complicated here and might require some digging
- The [sessions controller for Pinwheel](https://github.com/DSACMS/iv-cbv-payroll/blob/595407fc0a86ea99283e190e567b68c982e8b76d/app/app/javascript/controllers/cbv/sessions_controller.js#L50-L66) also relies on inline styles, but I left that alone since we're [disabling the CSP for Pinwheel](https://github.com/DSACMS/iv-cbv-payroll/blob/f73a3e5f1f7c74c2d8c9eb8c8e8fc5ef68935930/app/app/controllers/cbv/employer_searches_controller.rb#L2-L3) anyway


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<img width="986" height="429" alt="Screenshot 2025-07-16 at 9 54 24 AM" src="https://github.com/user-attachments/assets/d0c74c10-7565-41ac-b6e5-daeeb08f5ccf" />
<img width="831" height="425" alt="Screenshot 2025-07-16 at 9 47 21 AM" src="https://github.com/user-attachments/assets/3e596b84-e828-4f0d-aee0-e4c4ccd4107d" />

