### PR TITLE
FFS-3135: Re-enable LA pilot

### DIFF
--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -47,7 +47,7 @@
   transmission_method_configuration:
     email: <%= ENV['LA_LDH_EMAIL'] %>
   staff_portal_enabled: false
-  pilot_ended: true
+  pilot_ended: <%= Rails.env.production? %>
   # sso:
   #   client_id:     <%= ENV["AZURE_LA_LDH_CLIENT_ID"] %>
   #   client_secret: <%= ENV["AZURE_LA_LDH_CLIENT_SECRET"] %>

--- a/app/spec/controllers/pages_controller_spec.rb
+++ b/app/spec/controllers/pages_controller_spec.rb
@@ -47,25 +47,6 @@ RSpec.describe PagesController do
         expect(response).to render_template("pages/_la_ldh_pilot_end")
       end
     end
-
-    context "when LA LDH pilot configuration is environment-based" do
-      before do
-        stub_client_agency_config_value("la_ldh", "agency_domain", "la.reportmyincome.org")
-        request.host = "la.reportmyincome.org"
-      end
-
-      it "enables pilot in test & development environments" do
-        stub_client_agency_config_value("la_ldh", "pilot_ended", false)
-        get :home
-        expect(response).to redirect_to(cbv_flow_new_path(client_agency_id: "la_ldh"))
-      end
-
-      it "disables pilot in production environment" do
-        stub_client_agency_config_value("la_ldh", "pilot_ended", true)
-        get :home
-        expect(response).to render_template("pages/_la_ldh_pilot_end")
-      end
-    end
   end
 
   describe "#error_404" do

--- a/app/spec/controllers/pages_controller_spec.rb
+++ b/app/spec/controllers/pages_controller_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe PagesController do
         expect(response).to render_template("pages/_la_ldh_pilot_end")
       end
     end
+
+    context "when LA LDH pilot configuration is environment-based" do
+      before do
+        stub_client_agency_config_value("la_ldh", "agency_domain", "la.reportmyincome.org")
+        request.host = "la.reportmyincome.org"
+      end
+
+      it "enables pilot in test & development environments" do
+        stub_client_agency_config_value("la_ldh", "pilot_ended", false)
+        get :home
+        expect(response).to redirect_to(cbv_flow_new_path(client_agency_id: "la_ldh"))
+      end
+
+      it "disables pilot in production environment" do
+        stub_client_agency_config_value("la_ldh", "pilot_ended", true)
+        get :home
+        expect(response).to render_template("pages/_la_ldh_pilot_end")
+      end
+    end
   end
 
   describe "#error_404" do


### PR DESCRIPTION
## Ticket

Resolves [FFS-3135](https://jiraent.cms.gov/browse/FFS-3135).


## Changes
- Pilot is enabled in dev/demo, but not production

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
