### PR TITLE
FFS-3138: Support tracking origin query parameter

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -51,7 +51,7 @@ class Cbv::BaseController < ApplicationController
     agency = agency_config[detect_client_agency_from_domain]
     origin = params.fetch(:origin, agency&.default_origin)
     if origin.present?
-      session[:cbv_origin] = origin.strip.downcase.gsub(/\s+/, "_")
+      session[:cbv_origin] = origin.strip.downcase.gsub(/\s+/, "_").first(64)
     end
   end
 

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -1,5 +1,5 @@
 class Cbv::BaseController < ApplicationController
-  before_action :set_cbv_flow, :ensure_cbv_flow_not_yet_complete, :prevent_back_after_complete, :capture_page_view
+  before_action :set_cbv_origin, :set_cbv_flow, :ensure_cbv_flow_not_yet_complete, :prevent_back_after_complete, :capture_page_view
   helper_method :agency_url, :next_path, :get_comment_by_account_id, :current_agency
 
   private
@@ -41,6 +41,17 @@ class Cbv::BaseController < ApplicationController
     else
       track_timeout_event
       redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
+    end
+  end
+
+  def set_cbv_origin
+    return if session[:cbv_origin].present?
+
+    # Running before set_cbv_flow so we need to use the domain
+    agency = agency_config[detect_client_agency_from_domain]
+    origin = params.fetch(:origin, agency&.default_origin)
+    if origin.present?
+      session[:cbv_origin] = origin.strip.downcase.gsub(" ", "_")
     end
   end
 
@@ -148,7 +159,8 @@ class Cbv::BaseController < ApplicationController
       seconds_since_invitation: (Time.now - invitation.created_at).to_i,
       household_member_count:  count_unique_members(invitation),
       completed_reports_count: invitation.cbv_flows.completed.count,
-      flows_started_count: invitation.cbv_flows.count
+      flows_started_count: invitation.cbv_flows.count,
+      origin: session[:cbv_origin]
     })
   rescue => ex
     Rails.logger.error "Unable to track event (ApplicantClickedCBVInvitationLink): #{ex}"

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -51,7 +51,7 @@ class Cbv::BaseController < ApplicationController
     agency = agency_config[detect_client_agency_from_domain]
     origin = params.fetch(:origin, agency&.default_origin)
     if origin.present?
-      session[:cbv_origin] = origin.strip.downcase.gsub(" ", "_")
+      session[:cbv_origin] = origin.strip.downcase.gsub(/\s+/, "_")
     end
   end
 

--- a/app/app/controllers/cbv/entries_controller.rb
+++ b/app/app/controllers/cbv/entries_controller.rb
@@ -6,7 +6,7 @@ class Cbv::EntriesController < Cbv::BaseController
       cbv_applicant_id: @cbv_flow.cbv_applicant_id,
       cbv_flow_id: @cbv_flow.id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id,
-      source: session[:cbv_source]
+      origin: session[:cbv_origin]
     })
   end
 
@@ -18,7 +18,7 @@ class Cbv::EntriesController < Cbv::BaseController
         cbv_applicant_id: @cbv_flow.cbv_applicant_id,
         cbv_flow_id: @cbv_flow.id,
         invitation_id: @cbv_flow.cbv_flow_invitation_id,
-        source: session[:cbv_source]
+        origin: session[:cbv_origin]
       })
       redirect_to next_path
     else

--- a/app/app/controllers/pages_controller.rb
+++ b/app/app/controllers/pages_controller.rb
@@ -32,7 +32,7 @@ class PagesController < ApplicationController
     client_agency_id = detect_client_agency_from_domain
     if client_agency_id.present?
       agency = agency_config[client_agency_id]
-      session[:cbv_source] = params[:source] || agency&.default_source
+      session[:cbv_origin] = params[:origin] || agency&.default_origin
       redirect_to cbv_flow_new_path(client_agency_id: client_agency_id)
     end
   end

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -38,7 +38,7 @@
   agency_domain: <%= ENV["LA_LDH_DOMAIN_NAME"] %>
   # caseworker_feedback_form: n/a
   logo_path: ldh_logo.svg
-  default_source: sms
+  default_origin: sms
   pinwheel:
     environment: <%= ENV["LA_LDH_PINWHEEL_ENVIRONMENT"] %>
   argyle:

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -25,8 +25,8 @@ Rails.application.routes.draw do
     # Feedback CTA
     get "/feedback", to: "feedbacks#show", as: :feedbacks
 
-    # RFI (mail) source tracking route for LA
-    get "/start", to: "pages#home", defaults: { source: "mail" }
+    # RFI (mail) origin tracking route for LA
+    get "/start", to: "pages#home", defaults: { origin: "mail" }
 
     scope "/cbv", as: :cbv_flow, module: :cbv do
       resource :entry, only: %i[show create]

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -40,7 +40,7 @@ class ClientAgencyConfig
       agency_domain
       authorized_emails
       caseworker_feedback_form
-      default_source
+      default_origin
       invitation_valid_days
       logo_path
       logo_square_path
@@ -65,7 +65,7 @@ class ClientAgencyConfig
       @agency_domain = yaml["agency_domain"]
       @authorized_emails = yaml["authorized_emails"] || ""
       @caseworker_feedback_form = yaml["caseworker_feedback_form"]
-      @default_source = yaml["default_source"]
+      @default_origin = yaml["default_origin"]
       @invitation_valid_days = yaml["invitation_valid_days"]
       @logo_path = yaml["logo_path"]
       @logo_square_path = yaml["logo_square_path"]

--- a/app/spec/controllers/cbv/base_controller_spec.rb
+++ b/app/spec/controllers/cbv/base_controller_spec.rb
@@ -64,5 +64,58 @@ RSpec.describe Cbv::BaseController, type: :controller do
       expect(response).to be_successful
       expect(response.body).to eq("hello world")
     end
+
+    context "when handling origin parameters" do
+      before do
+        stub_client_agency_config_value("la_ldh", "agency_domain", "la.reportmyincome.org")
+        request.host = "la.reportmyincome.org"
+      end
+
+      it "sets the origin in the clicked invitation event" do
+        expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          origin: "email"
+        ))
+        get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token, origin: "email" }
+        expect(response).to be_successful
+        expect(session[:cbv_flow_id]).to be_a(Integer)
+        expect(session[:cbv_origin]).to eq "email"
+      end
+
+      it "cleans the supplied origin parameter if set" do
+        expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          origin: "mfb_dashboard"
+        ))
+        get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token, origin: " MFB dashboard" }
+        expect(response).to be_successful
+        expect(session[:cbv_flow_id]).to be_a(Integer)
+        expect(session[:cbv_origin]).to eq "mfb_dashboard"
+      end
+
+      it "does not reset the origin if it is already present" do
+        session[:cbv_origin] = "test"
+        expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          origin: "test"
+        ))
+        get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token, origin: "email" }
+        expect(response).to be_successful
+        expect(session[:cbv_flow_id]).to be_a(Integer)
+        expect(session[:cbv_origin]).to eq "test"
+      end
+
+      it "does not set an origin if no parameter or agency default are supplied" do
+        request.host = nil
+        expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          origin: nil
+        ))
+        get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+        expect(response).to be_successful
+        expect(session[:cbv_flow_id]).to be_a(Integer)
+        expect(session[:cbv_origin]).to be_nil
+      end
+    end
   end
 end

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -119,23 +119,23 @@ RSpec.describe Cbv::EntriesController do
         get :show, params: { token: invitation.auth_token }
       end
 
-      it "includes source information in ApplicantViewedAgreement event when set" do
-        session[:cbv_source] = "mail"
+      it "includes origin information in ApplicantViewedAgreement event when set" do
+        session[:cbv_origin] = "mail"
 
         allow(EventTrackingJob).to receive(:perform_later)
         expect(EventTrackingJob).to receive(:perform_later).with("ApplicantViewedAgreement", anything, hash_including(
-          source: "mail"
+          origin: "mail"
         ))
 
         get :show, params: { token: invitation.auth_token }
       end
 
-      it "includes source information in ApplicantAgreed event when agreeing" do
-        session[:cbv_source] = "sms"
+      it "includes origin information in ApplicantAgreed event when agreeing" do
+        session[:cbv_origin] = "sms"
 
         allow(EventTrackingJob).to receive(:perform_later)
         expect(EventTrackingJob).to receive(:perform_later).with("ApplicantAgreed", anything, hash_including(
-          source: "sms"
+          origin: "sms"
         ))
 
         post :create, params: { token: invitation.auth_token, agreement: "1" }

--- a/app/spec/controllers/pages_controller_spec.rb
+++ b/app/spec/controllers/pages_controller_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe PagesController do
         expect(response).to redirect_to(cbv_flow_new_path(client_agency_id: "la_ldh"))
       end
 
-      it "defaults to sms source for LA when no source provided" do
+      it "defaults to sms origin for LA when no origin provided" do
         request.host = "la.reportmyincome.org"
         get :home
-        expect(session[:cbv_source]).to eq("sms")
+        expect(session[:cbv_origin]).to eq("sms")
       end
 
-      it "uses provided source parameter when given" do
+      it "uses provided origin parameter when given" do
         request.host = "la.reportmyincome.org"
-        get :home, params: { source: "mail" }
-        expect(session[:cbv_source]).to eq("mail")
+        get :home, params: { origin: "mail" }
+        expect(session[:cbv_origin]).to eq("mail")
       end
     end
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3138](https://jiraent.cms.gov/browse/FFS-3138).

## Changes

- Renames `source` query parameter to `origin` from the /start URL
- Add `origin` query parameter to `ApplicantClickedCBVInvitationLink` event metadata when present
  - Only updates this specific event as well as events that were previously using `source`, but this could be expanded since this is being set on the session

## Context for reviewers

- We had talked about how validation should work in the ticket, but I'm keeping it light for now to just standardizing casing and spaces. Happy to tighten that up, but if we have existing processes for deleting PII from Mixpanel I think the flexibility across deployments is a benefit

## Acceptance testing

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
