### PR TITLE
FFS-3135: Re-enable LA pilot (part deux)

### DIFF
--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -47,7 +47,7 @@
   transmission_method_configuration:
     email: <%= ENV['LA_LDH_EMAIL'] %>
   staff_portal_enabled: false
-  pilot_ended: <%= Rails.env.production? %>
+  pilot_ended: <%= ENV["LA_LDH_PILOT_ENABLED"] != "true" %>
   # sso:
   #   client_id:     <%= ENV["AZURE_LA_LDH_CLIENT_ID"] %>
   #   client_secret: <%= ENV["AZURE_LA_LDH_CLIENT_SECRET"] %>

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -35,4 +35,7 @@ module "dev_config" {
 
   # NewRelic configuration for metrics
   newrelic_account_id = "4619676"
+
+  # Enable LA LDH pilot in dev environment
+  la_ldh_pilot_enabled = true
 }

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -12,6 +12,9 @@ locals {
     DOCKERIZED = "true"
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+
+    # LA LDH pilot configuration
+    LA_LDH_PILOT_ENABLED = tostring(var.la_ldh_pilot_enabled)
   }
 
   # Configuration for secrets

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -129,3 +129,9 @@ variable "database_serverless_max_capacity" {
   type        = number
   default     = 1.0
 }
+
+variable "la_ldh_pilot_enabled" {
+  description = "Whether the LA LDH pilot is enabled"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Ticket

Resolves [FFS-3135](https://jiraent.cms.gov/browse/FFS-3135).


## Changes
- Pilot is enabled in dev/demo, but not production
- Terraform config that is easy to clean up if we don't want it later, but this might be nice to have as a convention for enabling and disabling pilots going forward 🤷‍♀️ 

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
