### PR TITLE
FFS-3139: Save CBV Applicant ID into cookie

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -30,6 +30,7 @@ class Cbv::BaseController < ApplicationController
 
       @cbv_flow = CbvFlow.create_from_invitation(invitation)
       session[:cbv_flow_id] = @cbv_flow.id
+      cookies.permanent.encrypted[:cbv_applicant_id] = @cbv_flow.cbv_applicant_id
       track_invitation_clicked_event(invitation, @cbv_flow)
 
     elsif session[:cbv_flow_id]

--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -6,6 +6,7 @@ class Cbv::GenericLinksController < Cbv::BaseController
   def show
     @cbv_flow = CbvFlow.create_without_invitation(params[:client_agency_id])
     session[:cbv_flow_id] = @cbv_flow.id
+    cookies.permanent.encrypted[:cbv_applicant_id] = @cbv_flow.cbv_applicant_id
 
     redirect_to next_path
   end

--- a/app/spec/controllers/cbv/base_controller_spec.rb
+++ b/app/spec/controllers/cbv/base_controller_spec.rb
@@ -9,13 +9,24 @@ RSpec.describe Cbv::BaseController, type: :controller do
 
   let(:cbv_flow) { create(:cbv_flow, :invited, client_agency_id: "az_des") }
 
-  describe '#track_invitation_clicked_event' do
-    before do
-      routes.draw do
-        get 'show', controller: "cbv/base"
-      end
+  before do
+    routes.draw do
+      get 'show', controller: "cbv/base"
     end
+  end
 
+  describe '#set_cbv_flow' do
+    it "sets an encrypted permanent cookie with cbv_applicant_id for invitation-based flows" do
+      get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+
+      expect(cookies.encrypted[:cbv_applicant_id]).to eq(cbv_flow.cbv_applicant_id)
+
+      cookie_jar = response.cookies["cbv_applicant_id"]
+      expect(cookie_jar).to be_present
+    end
+  end
+
+  describe '#track_invitation_clicked_event' do
     let(:cbv_flow_2) { create(:cbv_flow, cbv_flow_invitation: cbv_flow.cbv_flow_invitation) }
 
     it "identifies multiple household members if income changes relevant" do

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -3,10 +3,22 @@ require "rails_helper"
 RSpec.describe Cbv::GenericLinksController do
   describe '#show' do
     context 'when the hostname matches a client agency domain and the pilot is active' do
-      it "starts a CBV flow" do
+      before do
         get :show, params: { client_agency_id: "sandbox" }
+      end
+
+      it "starts a CBV flow" do
         expect(response).to redirect_to(cbv_flow_entry_path)
         expect(assigns(:cbv_flow).client_agency_id).to eq("sandbox")
+      end
+
+      it "sets an encrypted permanent cookie with cbv_applicant_id" do
+        cbv_flow = assigns(:cbv_flow)
+
+        expect(cookies.encrypted[:cbv_applicant_id]).to eq(cbv_flow.cbv_applicant_id)
+
+        cookie_jar = response.cookies["cbv_applicant_id"]
+        expect(cookie_jar).to be_present
       end
     end
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3139](https://jiraent.cms.gov/browse/FFS-3139).


## Changes
Who put the cookie in the cookie jar. Me, it was me.

- Add cookie with cbv applicant ID for both generic and token flows
- Test!

## Context for reviewers
It's a permanent cookie for now, based on the spec, until we decide on something we like better. 

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
# Receipts for cookies in the cookie jar
<img width="1453" height="710" alt="Screenshot 2025-07-25 at 2 26 34 PM" src="https://github.com/user-attachments/assets/f259e200-a4ea-40c1-9059-5af466e713b4" />
<img width="1456" height="699" alt="Screenshot 2025-07-25 at 2 25 53 PM" src="https://github.com/user-attachments/assets/61193dc9-6971-4e34-978b-4edc7eca671f" />
