### PR TITLE
[FFS-3085] support pinwheel with partial income support

### DIFF
--- a/app/app/models/payroll_account/pinwheel.rb
+++ b/app/app/models/payroll_account/pinwheel.rb
@@ -34,7 +34,7 @@ class PayrollAccount::Pinwheel < PayrollAccount
   end
 
   def necessary_jobs_succeeded?
-    job_succeeded?("paystubs")
+    job_succeeded?("paystubs") || (job_succeeded?("employment") && job_succeeded?("identity"))
   end
 
   def redact!

--- a/app/spec/controllers/cbv/synchronization_failures_controller_spec.rb
+++ b/app/spec/controllers/cbv/synchronization_failures_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Cbv::SynchronizationFailuresController do
     end
 
     context "when the user has no successful payroll_accounts" do
-      let!(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, with_errored_jobs: [ "paystubs" ], cbv_flow: cbv_flow) }
+      let!(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, with_errored_jobs: %w[paystubs identity], cbv_flow: cbv_flow) }
 
       it "shows cta button" do
         get :show

--- a/app/spec/helpers/aggregator_data_helper_spec.rb
+++ b/app/spec/helpers/aggregator_data_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Cbv::AggregatorDataHelper do
 
   describe "#filter_payroll_accounts" do
     it "does not include payroll accounts that are not fully synced" do
-      _errored_account = create(:payroll_account, :pinwheel_fully_synced, cbv_flow: cbv_flow, pinwheel_account_id: "account2", with_errored_jobs: %w[income paystubs])
+      _errored_account = create(:payroll_account, :pinwheel_fully_synced, cbv_flow: cbv_flow, pinwheel_account_id: "account2", with_errored_jobs: %w[income paystubs identity])
       fully_synced_account = create(:payroll_account, :pinwheel_fully_synced, cbv_flow: cbv_flow, pinwheel_account_id: "account1")
       expect(report.filter_payroll_accounts("pinwheel")).to match_array([ fully_synced_account ])
     end

--- a/app/spec/models/payroll_account/pinwheel_spec.rb
+++ b/app/spec/models/payroll_account/pinwheel_spec.rb
@@ -152,6 +152,15 @@ RSpec.describe PayrollAccount::Pinwheel, type: :model do
     end
   end
 
+  describe "#necessary_jobs_succeeded?" do
+    let!(:payroll_account) do
+       create(:payroll_account, :pinwheel_fully_synced, with_errored_jobs: %w[income])
+     end
+    it "supports a case where they have no reported income so long as we can scan their identities for unemployment" do
+         expect(payroll_account.necessary_jobs_succeeded?).to eq(true)
+       end
+  end
+
   describe "#redact!" do
     it "updates the redacted_at timestamp" do
       expect { payroll_account.redact! }


### PR DESCRIPTION


Resolves [FFS-3085](https://jiraent.cms.gov/browse/FFS-3085).


## Changes
when pinwheel does an 'errored' job it most frequently means that no data is available on the sync, especially with income hook.

this expands the definition to be flexible in a way that still avoids errors from crashing out but allows UsefulReportValidator to be the main gateway of blocking report flow, as opposed to getting lost in the gap between (since we don't check necessary_jobs_succeeded? when we redirect onto payment_details_controller.

## Question for reviewers?

_should_ payment details controller redirect if aggregator_report.valid?(:useful_report) returns true but necessary_jobs_succeeded? returns false? (how we got into the current user flow state as reported by the ticket).

## Context for reviewers

example for our [voe_and_voie_available_no_paystubs](https://docs.pinwheelapi.com/public/docs/sandbox#getting-started-2)
  Parameters: {"event_id" => "d4696c12-2d65-4cdb-ba36-02971b13b975", "event" => "paystubs.fully_synced", "payload" => {"id" => "0ee926c5-e549-408c-9f4e-2e65e015c7ce", "name" => "paystubs", "timestamp" => "2025-07-22T14:13:25.563743+00:00", "outcome" => "error", "error_code" => "dataNotAvailable", "error_type" => "platformError", "link_token_id" => "[FILTERED]", "params" => {}, "account_id" => "e5b59ecc-cfad-47b3-9ff7-ff2bec76f9df", "end_user_id" => "410164d6-197d-4d66-a2b3-972353db3700"}}

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
