### PR TITLE
Only login on Docker CI if secret present

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Ticket

No ticket

## Changes

- Updates the vulnerability scanning PR to only log into Docker Hub if the PR is from a branch on this repo and not a fork

## Context for reviewers

Now that we have more PRs like #853 coming from external forks we're seeing errors on some of the vulnerability scanning tickets that require the use of secrets which PRs from forks don't have access to

Logging in isn't required and was originally introduced in #743 to clean up some flaky results. It seems like the simplest way to get the best of both worlds is to scope that to PRs that are not on forks


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
