### PR TITLE
FFS-3140: Use CBV Applicant ID cookie for generic links

### DIFF
--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -63,5 +63,6 @@ class Cbv::GenericLinksController < Cbv::BaseController
     })
   rescue => ex
     Rails.logger.error "Unable to track event (ApplicantClickedGenericLink): #{ex}"
+    raise unless Rails.env.production?
   end
 end

--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -4,10 +4,12 @@ class Cbv::GenericLinksController < Cbv::BaseController
   before_action :check_if_pilot_ended_for_agency
 
   def show
-    @cbv_flow = CbvFlow.create_without_invitation(params[:client_agency_id])
+    @cbv_flow, is_new_session = find_or_create_cbv_flow
+
     session[:cbv_flow_id] = @cbv_flow.id
     cookies.permanent.encrypted[:cbv_applicant_id] = @cbv_flow.cbv_applicant_id
 
+    track_generic_link_clicked_event(@cbv_flow, is_new_session)
     redirect_to next_path
   end
 
@@ -24,5 +26,42 @@ class Cbv::GenericLinksController < Cbv::BaseController
     if agency&.pilot_ended
       redirect_to root_url
     end
+  end
+
+  def find_or_create_cbv_flow
+    existing_applicant_id = cookies.encrypted[:cbv_applicant_id]
+    existing_applicant = find_existing_applicant(existing_applicant_id) if existing_applicant_id.present?
+
+    if existing_applicant
+      clear_applicant_information(existing_applicant)
+      cbv_flow = CbvFlow.create(cbv_applicant: existing_applicant, client_agency_id: params[:client_agency_id])
+      is_new_session = false
+    else
+      cbv_flow = CbvFlow.create_without_invitation(params[:client_agency_id])
+      is_new_session = true
+    end
+
+    [ cbv_flow, is_new_session ]
+  end
+
+  def find_existing_applicant(applicant_id)
+    CbvApplicant.find_by(id: applicant_id, client_agency_id: params[:client_agency_id])
+  end
+
+  def clear_applicant_information(applicant)
+    clear_attributes = applicant.applicant_attributes.index_with(nil)
+    applicant.update!(clear_attributes)
+  end
+
+  def track_generic_link_clicked_event(cbv_flow, is_new_session)
+    event_logger.track("ApplicantClickedGenericLink", request, {
+      cbv_applicant_id: cbv_flow.cbv_applicant_id,
+      cbv_flow_id: cbv_flow.id,
+      client_agency_id: cbv_flow.client_agency_id,
+      origin: params[:origin],
+      is_new_session: is_new_session
+    })
+  rescue => ex
+    Rails.logger.error "Unable to track event (ApplicantClickedGenericLink): #{ex}"
   end
 end

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -1,24 +1,106 @@
 require "rails_helper"
 
 RSpec.describe Cbv::GenericLinksController do
+  before do
+    allow(EventTrackingJob).to receive(:perform_later)
+  end
   describe '#show' do
     context 'when the hostname matches a client agency domain and the pilot is active' do
-      before do
-        get :show, params: { client_agency_id: "sandbox" }
+      context 'when no existing CBV applicant cookie exists' do
+        before do
+          get :show, params: { client_agency_id: "sandbox" }
+        end
+
+        it "starts a CBV flow with new applicant" do
+          expect(response).to redirect_to(cbv_flow_entry_path)
+          expect(assigns(:cbv_flow).client_agency_id).to eq("sandbox")
+        end
+
+        it "sets an encrypted permanent cookie with cbv_applicant_id" do
+          cbv_flow = assigns(:cbv_flow)
+
+          expect(cookies.encrypted[:cbv_applicant_id]).to eq(cbv_flow.cbv_applicant_id)
+
+          cookie_jar = response.cookies["cbv_applicant_id"]
+          expect(cookie_jar).to be_present
+        end
+
+        it "tracks ApplicantClickedGenericLink event with is_new_session: true" do
+          expect(EventTrackingJob).to have_received(:perform_later).with(
+            "ApplicantClickedGenericLink",
+            anything,
+            hash_including(
+              cbv_applicant_id: assigns(:cbv_flow).cbv_applicant_id,
+              cbv_flow_id: assigns(:cbv_flow).id,
+              client_agency_id: "sandbox",
+              is_new_session: true
+            )
+          )
+        end
       end
 
-      it "starts a CBV flow" do
-        expect(response).to redirect_to(cbv_flow_entry_path)
-        expect(assigns(:cbv_flow).client_agency_id).to eq("sandbox")
+      context 'when existing CBV applicant cookie exists' do
+        let!(:existing_applicant) { create(:cbv_applicant, :sandbox, case_number: "12345", first_name: "John") }
+
+        before do
+          cookies.encrypted[:cbv_applicant_id] = existing_applicant.id
+          get :show, params: { client_agency_id: "sandbox" }
+        end
+
+        it "reuses existing applicant" do
+          expect(assigns(:cbv_flow).cbv_applicant_id).to eq(existing_applicant.id)
+        end
+
+        it "clears applicant information fields" do
+          existing_applicant.reload
+          expect(existing_applicant.case_number).to be_nil
+          expect(existing_applicant.first_name).to be_nil
+        end
+
+        it "tracks ApplicantClickedGenericLink event with is_new_session: false" do
+          expect(EventTrackingJob).to have_received(:perform_later).with(
+            "ApplicantClickedGenericLink",
+            anything,
+            hash_including(
+              cbv_applicant_id: existing_applicant.id,
+              is_new_session: false
+            )
+          )
+        end
       end
 
-      it "sets an encrypted permanent cookie with cbv_applicant_id" do
-        cbv_flow = assigns(:cbv_flow)
+      context 'when existing CBV applicant cookie exists but applicant not found' do
+        before do
+          cookies.encrypted[:cbv_applicant_id] = 99999
+          get :show, params: { client_agency_id: "sandbox" }
+        end
 
-        expect(cookies.encrypted[:cbv_applicant_id]).to eq(cbv_flow.cbv_applicant_id)
+        it "creates new applicant instead of reusing" do
+          expect(assigns(:cbv_flow).cbv_applicant_id).not_to eq(99999)
+          expect(assigns(:cbv_flow).client_agency_id).to eq("sandbox")
+        end
 
-        cookie_jar = response.cookies["cbv_applicant_id"]
-        expect(cookie_jar).to be_present
+        it "tracks event with is_new_session: true" do
+          expect(EventTrackingJob).to have_received(:perform_later).with(
+            "ApplicantClickedGenericLink",
+            anything,
+            hash_including(is_new_session: true)
+          )
+        end
+      end
+
+      context 'when origin parameter is provided' do
+        before do
+          get :show, params: { client_agency_id: "sandbox", origin: "mail" }
+        end
+
+        it "includes origin in tracking event" do
+          expect(EventTrackingJob).to have_received(:perform_later).with(
+            "ApplicantClickedGenericLink",
+            anything,
+            hash_including(origin: "mail")
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3140](https://jiraent.cms.gov/browse/FFS-3140).


## Changes
- Implemented usage of CBV applicant id in generic link flow according to spec
- `ApplicantClickedGenericLink` tracking event with session info
- Testing

## Context

### Testing Instructions
*Clear cookies*

- Visit generic link
http://localhost:3000/cbv/links/sandbox
- Check browser cookies -- should see:
`cbv_applicant_id: [encrypted value]`
- Visit same link again -- should reuse same applicant ID (different encrypted value)
- Check Mixpanel for "ApplicantClickedGenericLink" event

### Using Rails console
```
CbvApplicant.last # Check new or existing applicant, attributes reset
CbvApplicant.count # Should not increment with cookie in same browser
```

### Things to Verify
- Cookie appears after first visit
- Cookie persists across page refreshes  
- Same browser = same applicant ID
- Different browser = different applicant ID
- Mixpanel event fires correctly

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
 ### New Event
<img width="1489" height="78" alt="Screenshot 2025-07-30 at 10 25 56 AM" src="https://github.com/user-attachments/assets/cc4f0618-69d1-436a-b4c9-15350e097fcd" />

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-864-app-dev-2097476120.us-east-1.elb.amazonaws.com
- Deployed commit: 14af1a4051415c3717242635adb02e1bba294c69
<!-- end PR environment info -->