### PR TITLE
No ticket: rename straggling pinwheel_account variable

### DIFF
--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -38,7 +38,7 @@
 <% end %>
 
 <% if @is_w2_worker %>
-  <%= render(Report::PaymentsDeductionsMonthlySummaryComponent.new(@aggregator_report, @pinwheel_account, is_w2_worker: @is_w2_worker, pay_frequency_text: pay_frequency)) %>
+  <%= render(Report::PaymentsDeductionsMonthlySummaryComponent.new(@aggregator_report, @payroll_account, is_w2_worker: @is_w2_worker, pay_frequency_text: pay_frequency)) %>
 <% else %>
   <%= render(Report::MonthlySummaryTableComponent.new(@aggregator_report, @payroll_account)) %>
 <% end %>


### PR DESCRIPTION
## No Ticket

## Changes
Now, our rspec tests pass correctly and the /payment_details page renders appropriately again.

## Context for reviewers
There was a straggler pinwheel_account reference due to different PRs merging automatically. #856 failed to get them all because I added another in the payment details show.erb. Now, that variable is renamed correctly.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
