### PR TITLE
FFS-3194: Correct caseworker highlighting on PDFs

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -134,7 +134,8 @@ html {
   @include u-margin-y(2);
 }
 
-.cbv-row-highlight td {
+.cbv-row-highlight td,
+.cbv-row-highlight th {
   @include u-bg('yellow-5v');
 }
 

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -25,7 +25,7 @@
 <table class="usa-table usa-table--borderless width-full" data-testid="paystub-table">
   <thead class="border-top-05">
     <tr>
-      <th class="padding-3 bg-primary-lighter" colspan="2">
+      <th class="bg-primary-lighter" colspan="2">
         <h4 class="margin-0" data-testid="paystub-total-income">
           <% if employer_name %>
             <%= t(".total_income_from", employer_name: employer_name, amount: format_money(summary[:total])) %>


### PR DESCRIPTION
## [FFS-3194](https://jiraent.cms.gov/browse/FFS-3194)


## Changes
1. The table header height on /summary is now the correct height (not in ticket -- ad-hoc fix)
2. Caseworker highlighting on the PDF now extends across the whole row again

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshots
### Table header height on /summary
<img width="532" height="145" alt="image" src="https://github.com/user-attachments/assets/f56e0c81-b794-4769-9310-a82ac73c60b2" />

### Caseworker row highlighting is now full-row again
<img width="731" height="165" alt="image" src="https://github.com/user-attachments/assets/0ef4c3ee-9440-455b-ab8c-d456192522b3" />
