### PR TITLE
FFS-3195: fix modals when visiting /employer_search a second time

### DIFF
--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%# Disabling Turbo because it makes the modals break the second time you view the page %>
+  <meta name="turbo-visit-control" content="reload">
+<% end %>
 <% content_for :title, t(".header") %>
 <h1>
   <%= t(".header") %>


### PR DESCRIPTION
## [FFS-3195](https://jiraent.cms.gov/browse/FFS-3195)

## Changes
Previously, if you went back to add a second (or more) job, the Argyle/Pinwheel modal would never open. You'd have to refresh the page to make it work.
Now, it works as you'd expect.

## Context for reviewers
This is caused by Turbo not updating nonces / other stuff that would allow Argyle or Pinwheel to pass our content security policy. I consulted with Tom who thought we'd already disabled Turbo on /employer_searches for another reason, so we decided to just officially disable it.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
