### PR TITLE
FFS-3109: Client-entered age range property not set after client submits /applicant_info form

### DIFF
--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -1,4 +1,6 @@
 class Cbv::ApplicantInformationsController < Cbv::BaseController
+  include ApplicationHelper
+
   before_action :set_cbv_applicant, only: %i[show update]
   before_action :redirect_when_in_invitation_flow, :redirect_when_info_present, only: :show
 
@@ -10,6 +12,7 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
     @cbv_applicant.assign_attributes(applicant_params[:cbv_applicant])
 
     if  @cbv_applicant.validate_base_and_applicant_attributes? && @cbv_applicant.save
+      track_applicant_submitted_information_page_event
       return redirect_to next_path
     end
 
@@ -83,5 +86,19 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
     })
   rescue => ex
     Rails.logger.error "Unable to track event (ApplicantEncounteredInformationPageError): #{ex}"
+  end
+
+  def track_applicant_submitted_information_page_event
+    event_logger.track("ApplicantSubmittedInformationPage", request, {
+      timestamp: Time.now.to_i,
+      cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+      cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      identity_age_range_applicant: get_age_range(@cbv_applicant.date_of_birth)
+    })
+  rescue => ex
+    Rails.logger.error "Unable to track event (ApplicantSubmittedInformationPage): #{ex}"
+    raise unless Rails.env.production?
   end
 end

--- a/app/app/controllers/webhooks/argyle/events_controller.rb
+++ b/app/app/controllers/webhooks/argyle/events_controller.rb
@@ -217,7 +217,6 @@ class Webhooks::Argyle::EventsController < ApplicationController
         identity_phone_numbers_count: report.identities.sum { |i| i.phone_numbers.length },
         identity_zip_code: report.identities.first&.zip_code,
         identity_age_range: get_age_range(report.identities.first&.date_of_birth),
-        identity_age_range_applicant: get_age_range(@cbv_flow.cbv_applicant.date_of_birth),
         identity_account_id: report.identities.first&.account_id,
 
         # Income fields (originally from "identities" endpoint)

--- a/app/app/controllers/webhooks/pinwheel/events_controller.rb
+++ b/app/app/controllers/webhooks/pinwheel/events_controller.rb
@@ -107,7 +107,6 @@ class Webhooks::Pinwheel::EventsController < ApplicationController
         identity_phone_numbers_count: report.identities.sum { |i| i.phone_numbers.length },
         identity_zip_code: report.identities.first&.zip_code,
         identity_age_range: get_age_range(report.identities.first&.date_of_birth),
-        identity_age_range_applicant: get_age_range(@cbv_flow.cbv_applicant.date_of_birth),
         identity_account_id: report.identities.first&.account_id,
 
         # Income fields

--- a/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/argyle/events_controller_spec.rb
@@ -193,7 +193,6 @@ RSpec.describe Webhooks::Argyle::EventsController, type: :controller do
           identity_emails_count: 1,
           identity_phone_numbers_count: 1,
           identity_age_range: "40-49",
-          identity_age_range_applicant: "30-39",
           identity_zip_code: "10281",
           identity_account_id: "01956d5f-cb8d-af2f-9232-38bce8531f58",
 

--- a/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
+++ b/app/spec/controllers/webhooks/pinwheel/events_controller_spec.rb
@@ -152,7 +152,6 @@ RSpec.describe Webhooks::Pinwheel::EventsController do
               identity_emails_count: 1,
               identity_phone_numbers_count: 1,
               identity_age_range: "30-39",
-              identity_age_range_applicant: "30-39",
               identity_zip_code: "99999",
               identity_account_id: "03e29160-f7e7-4a28-b2d8-813640e030d3",
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3109](https://jiraent.cms.gov/browse/FFS-3109).


## Changes
- Added `identity_age_range_applicant` when users submit applicant info form
- Removed `identity_age_range_applicant` from Argyle/Pinwheel "mega" events
- Age range now tracked when user enters DOB (not during payroll sync)
- Testing!

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

**BeFoRe**
<img width="1497" height="325" alt="Screenshot 2025-08-01 at 10 26 41 AM" src="https://github.com/user-attachments/assets/be4c6002-b74e-4056-b2d7-7c3bc90c9207" />

**aFtEr**
<img width="1493" height="322" alt="Screenshot 2025-08-01 at 1 26 36 PM" src="https://github.com/user-attachments/assets/df76b7b9-6238-4251-8d81-a86889fec5f3" />
<img width="1490" height="103" alt="Screenshot 2025-08-01 at 1 27 30 PM" src="https://github.com/user-attachments/assets/af72bd02-1309-43d6-a2cf-97cb15b5ef67" />

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-874-app-dev-483845342.us-east-1.elb.amazonaws.com
- Deployed commit: 864e28a5ab50858fc585ecb2d8bc96819668e63f
<!-- end PR environment info -->