### PR TITLE
FFS-3201: no longer show two 'no results' banners

### DIFF
--- a/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
+++ b/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
@@ -1,5 +1,5 @@
-<h3 class="margin-top-5"><%= t("cbv.payment_details.show.payments_and_deductions_table_header") %></h3>
 <% if has_monthly_summary_results? %>
+  <h3 class="margin-top-5"><%= t("cbv.payment_details.show.payments_and_deductions_table_header") %></h3>
   <% @monthly_summary_data.each do |(month_string, summary)| %>
     <%= render AccordionComponent.new(id: "#{month_string}-accordion") do |accordion| %>
       <% accordion.with_title do %>
@@ -31,9 +31,5 @@
         <% end %>
       <% end %>
     <% end %>
-  <% end %>
-<% else %>
-  <%= render AlertComponent.new(type: :info, heading: t("cbv.payment_details.show.none_found", report_data_range: report_data_range(@aggregator_report, @account_id)), class: "margin-top-5") do %>
-    <%= t("cbv.payment_details.show.none_found_description", report_data_range: report_data_range(@aggregator_report, @account_id)) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## [FFS-3201](https://jiraent.cms.gov/browse/FFS-3201)

## Changes
Previously, if there were no results on /payment_details, you could see two banners warning you of that fact. Now, you'll just see one.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Screenshots
<img width="1135" height="1336" alt="image" src="https://github.com/user-attachments/assets/cf2c3093-9574-44e4-b6b1-7df2c468ebb4" />
