### PR TITLE
FFS-3200: Mobile scaling issue: submit button overflows when in Spanish

### DIFF
--- a/app/app/views/cbv/submits/show.html.erb
+++ b/app/app/views/cbv/submits/show.html.erb
@@ -13,6 +13,6 @@
 <div class="usa-prose">
   <%= form_with model: @cbv_flow, url: cbv_flow_submit_path, html: { class: "usa-form maxw-full" }, builder: UswdsFormBuilder, method: "patch" do |f| %>
   <%= f.check_box :consent_to_authorized_use, { 'label': agency_translation(".consent_checkbox_label_html", agency_full_name: agency_translation("shared.agency_full_name"), agency_acronym: agency_translation("shared.agency_acronym")) } %>
-  <%= f.submit t(".share_report_button", agency_acronym: agency_translation("shared.agency_acronym")), class: "margin-top-5" %>
+  <%= f.submit t(".share_report_button", agency_acronym: agency_translation("shared.agency_acronym")), class: "margin-top-5 display-block" %>
   <% end %>
 </div>


### PR DESCRIPTION
## Ticket

Resolves [FFS-3200](https://jiraent.cms.gov/browse/FFS-3200).

## Changes
Add display-block class to allow for `white-space: normal` and handle any overflow case, including responsiveness

## Context for reviewers
I chose to just adjust this one button, rather than anything global, since this is where the problematic string is and to focus on the bug/move quickly.

Wrapping text approved by design. Spanish translation for this string is significantly longer than English and our other strings.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
 ### She's beauty, she's grace
<img width="500" height="561" alt="Screenshot 2025-08-05 at 1 55 03 PM" src="https://github.com/user-attachments/assets/395b9234-8070-4d7a-a20a-3316379f6a0b" />

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-881-app-dev-280374369.us-east-1.elb.amazonaws.com
- Deployed commit: e35b0c0deba6c1160a4bd13b3aa69b117fff84bc
<!-- end PR environment info -->