### PR TITLE
FFS-3206: Misaligned columns in W-2 job accordions and report

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -273,9 +273,13 @@ input#invitation_link{
 }
 
 /*
-* Payment details accordion table column adjustments for consistent display with different content
+* Payment details table column adjustments for consistent display with different content
 */
-.payment-details-accordion-table .subheader-row th {
+.payment-details-table {
+  table-layout: fixed;
+}
+
+.payment-details-table .subheader-row th {
   width: 50%;
 }
 

--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -273,6 +273,13 @@ input#invitation_link{
 }
 
 /*
+* Payment details accordion table column adjustments for consistent display with different content
+*/
+.payment-details-accordion-table .subheader-row th {
+  width: 50%;
+}
+
+/*
  * Utilities
  */
 .list-style-disc {

--- a/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
+++ b/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <% accordion.with_accordion_item do %>
         <% summary[:paystubs].each do |paystub| %>
-          <%= render(TableComponent.new(is_responsive: @is_responsive)) do |table| %>
+          <%= render(TableComponent.new(is_responsive: @is_responsive, class_names: "payment-details-accordion-table")) do |table| %>
             <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
               <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
                     .with_content(t("cbv.payment_details.show.pay_information")) %>

--- a/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
+++ b/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <% accordion.with_accordion_item do %>
         <% summary[:paystubs].each do |paystub| %>
-          <%= render(TableComponent.new(is_responsive: @is_responsive, class_names: "payment-details-accordion-table")) do |table| %>
+          <%= render(TableComponent.new(is_responsive: @is_responsive, class_names: "payment-details-table")) do |table| %>
             <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
               <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
                     .with_content(t("cbv.payment_details.show.pay_information")) %>

--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -115,7 +115,7 @@
 
   <% if is_w2_worker %>
     <% summary[:paystubs].each do |paystub| %>
-      <%= render(TableComponent.new) do |table| %>
+      <%= render(TableComponent.new(class_names: "payment-details-table")) do |table| %>
         <%= table.with_header do %>
           <h4 class="margin-0">
             <% if employer_name %>


### PR DESCRIPTION
## Ticket

Resolves [FFS-3206](https://jiraent.cms.gov/browse/FFS-3206).


## Changes
- Add column width for /payment_details accordion table and PDF

## Context
The problem is more apparent in Spanish, since the strings are much longer!

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
 ### /payment_details
<img width="935" height="798" alt="Screenshot 2025-08-06 at 11 56 08 AM" src="https://github.com/user-attachments/assets/992987f1-dd27-4267-82dc-33e5ab842469" />
 
 ### PDF
<img width="737" height="748" alt="Screenshot 2025-08-06 at 12 39 16 PM" src="https://github.com/user-attachments/assets/841301b6-6a7c-4b44-8fcd-16275e3b3e6e" />

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-883-app-dev-466876908.us-east-1.elb.amazonaws.com
- Deployed commit: 671ef03815a935a2dcc9235f44500296b207aad7
<!-- end PR environment info -->