### PR TITLE
Adding mutex_m gem since rails 7.2 removes it

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -97,6 +97,7 @@ group :development, :test do
   gem "rubocop-rails-omakase"
   gem "selenium-webdriver"
   gem "timecop"
+  gem "mutex_m"
 end
 
 group :development do

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    mutex_m (0.3.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.20)
@@ -603,6 +604,7 @@ DEPENDENCIES
   jsbundling-rails
   mission_control-jobs
   mixpanel-ruby
+  mutex_m
   net-imap (= 0.4.20)
   net-sftp
   net-ssh


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

n/a

## Changes
Manually adds the `mutex_m` gem which is required for Rubymine and debase to be able to debug the application. 

## Context for reviewers
We [recently upgraded to Rails 7.2](https://github.com/DSACMS/iv-cbv-payroll/pull/878/files#diff-df49f2d9b819903541ac07251361bf63bbd5349ea3e5dcaf052403f0baed4965L83) which does not automatically include the `mutex_m` gem.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
