### PR TITLE
FFS-3220: Use most recent source for origin tracking

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -46,9 +46,22 @@ class Cbv::BaseController < ApplicationController
   end
 
   def set_cbv_origin
-    # Running before set_cbv_flow so we need to use the domain
-    agency = agency_config[detect_client_agency_from_domain]
-    origin = params.fetch(:origin, agency&.default_origin)
+    origin_param = params.fetch(:origin, "")
+    if origin_param.present?
+      # If we get a param, use it to overwrite the origin.
+      # This helps us meet the state expectation that somebody who clicks a second link should switch to that origin in our tracking.
+      origin = origin_param
+    elsif origin_param.blank? and session[:cbv_origin].blank?
+      # If we don't get a param, and if we don't already have an origin, regress to the default.
+      # This preserves defaulting behavior.
+      agency = agency_config[detect_client_agency_from_domain]
+      origin = agency&.default_origin
+    else
+      # Otherwise, do not change the origin.
+      # This allows LA /start to preserve the initial 'email' origin specified in our routes
+      return
+    end
+
     if origin.present?
       session[:cbv_origin] = origin.strip.downcase.gsub(/\s+/, "_").first(64)
     end

--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -46,8 +46,6 @@ class Cbv::BaseController < ApplicationController
   end
 
   def set_cbv_origin
-    return if session[:cbv_origin].present?
-
     # Running before set_cbv_flow so we need to use the domain
     agency = agency_config[detect_client_agency_from_domain]
     origin = params.fetch(:origin, agency&.default_origin)

--- a/app/spec/controllers/cbv/base_controller_spec.rb
+++ b/app/spec/controllers/cbv/base_controller_spec.rb
@@ -127,6 +127,18 @@ RSpec.describe Cbv::BaseController, type: :controller do
         expect(session[:cbv_flow_id]).to be_a(Integer)
         expect(session[:cbv_origin]).to be_nil
       end
+
+      it "does set an origin if no parameter is supplied but agency default exists" do
+        stub_client_agency_config_value("la_ldh", "default_origin", "sms")
+        expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
+          origin: "sms"
+        ))
+        get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token }
+        expect(response).to be_successful
+        expect(session[:cbv_flow_id]).to be_a(Integer)
+        expect(session[:cbv_origin]).to eq "sms"
+      end
     end
   end
 end

--- a/app/spec/controllers/cbv/base_controller_spec.rb
+++ b/app/spec/controllers/cbv/base_controller_spec.rb
@@ -104,16 +104,16 @@ RSpec.describe Cbv::BaseController, type: :controller do
         expect(session[:cbv_origin]).to eq "mfb_dashboard"
       end
 
-      it "does not reset the origin if it is already present" do
+      it "resets the origin if it is already present" do
         session[:cbv_origin] = "test"
         expect(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
         expect(EventTrackingJob).to receive(:perform_later).with("ApplicantClickedCBVInvitationLink", anything, hash_including(
-          origin: "test"
+          origin: "email"
         ))
         get :show, params: { token: cbv_flow.cbv_flow_invitation.auth_token, origin: "email" }
         expect(response).to be_successful
         expect(session[:cbv_flow_id]).to be_a(Integer)
-        expect(session[:cbv_origin]).to eq "test"
+        expect(session[:cbv_origin]).to eq "email"
       end
 
       it "does not set an origin if no parameter or agency default are supplied" do


### PR DESCRIPTION
## [FFS-3220](https://jiraent.cms.gov/browse/FFS-3220)


## Changes
Origin tracking used to keep the first received origin and persist it throughout the session, rejecting any subsequent origins. This was found to be unacceptable for go-live, and now we will update the origin any time we receive a different one.


## Context for reviewers
I'm a little paranoid about this change because rejecting future origin differences seems to have been a purposeful decision made by Pat when he implemented [FFS-3138](https://github.com/DSACMS/iv-cbv-payroll/pull/850). Can anyone think of a reason this might have undesirable consequences? Maybe in other workflows? Pat is back tomorrow so I plan to ask for his input on this. I wonder why rejecting origin differences was so important.


## Testing instructions
### General testing
0. Use the preview environment link below to construct a generic link by appending /en/cbv/links/sandbox to the end of it
1. Then, add an origin by appending ?origin=email
2. Visit our site
3. Check Mixpanel (preview environment events file to the demo instance, not development). Check that your ApplicantClickedGenericLink event has an origin property that matches your origin parameter.
4. Now update your generic link with a different origin, like mfb_documents, and visit again.
5. Check Mixpanel to make sure you get a new ApplicantClickedGenericLink event on the same profile and that its origin matches your updated origin (it should NOT match the first origin from the first link -- previously, it would have).

### Defaults testing
0. Running locally, access http://la.localhost:3000/en/start and verify that the generated events have the origin "mail", not "sms".

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-885-app-dev-2118289484.us-east-1.elb.amazonaws.com
- Deployed commit: bd562394debbce0c2fa1e8cf4d12a4dfcdc09637
<!-- end PR environment info -->