### PR TITLE
FFS-3219: Payment Details displays empty accordions when a Pinwheel user has no paystubs

### DIFF
--- a/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
+++ b/app/app/components/report/payments_deductions_monthly_summary_component.html.erb
@@ -1,12 +1,13 @@
-<% if has_monthly_summary_results? %>
+<% if has_monthly_summary_results? && has_any_paystubs? %>
   <h3 class="margin-top-5"><%= t("cbv.payment_details.show.payments_and_deductions_table_header") %></h3>
   <% @monthly_summary_data.each do |(month_string, summary)| %>
-    <%= render AccordionComponent.new(id: "#{month_string}-accordion") do |accordion| %>
-      <% accordion.with_title do %>
-        <%= format_month_string(month_string, summary) %>
-      <% end %>
-      <% accordion.with_accordion_item do %>
-        <% summary[:paystubs].each do |paystub| %>
+    <% if summary[:paystubs].any? %>
+      <%= render AccordionComponent.new(id: "#{month_string}-accordion") do |accordion| %>
+        <% accordion.with_title do %>
+          <%= format_month_string(month_string, summary) %>
+        <% end %>
+        <% accordion.with_accordion_item do %>
+          <% summary[:paystubs].each do |paystub| %>
           <%= render(TableComponent.new(is_responsive: @is_responsive, class_names: "payment-details-table")) do |table| %>
             <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
               <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
@@ -27,6 +28,7 @@
             <% if paystub.gross_pay_ytd.to_f > 0 %>
               <%= table.with_data_point(:pay_gross_ytd, paystub.gross_pay_ytd) %>
             <% end %>
+          <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/app/components/report/payments_deductions_monthly_summary_component.rb
+++ b/app/app/components/report/payments_deductions_monthly_summary_component.rb
@@ -29,4 +29,8 @@ class Report::PaymentsDeductionsMonthlySummaryComponent < ViewComponent::Base
   def has_monthly_summary_results?
     @monthly_summary_data.present?
   end
+
+  def has_any_paystubs?
+    @monthly_summary_data.any? { |month_string, summary| summary[:paystubs].any? }
+  end
 end

--- a/app/spec/components/report/payments_deductions_monthly_summary_component_spec.rb
+++ b/app/spec/components/report/payments_deductions_monthly_summary_component_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe Report::PaymentsDeductionsMonthlySummaryComponent, type: :compone
           heading = subject.at_css('h2.usa-alert__heading')
           expect(heading).to be_nil
         end
+
+        it "does not render empty accordions when there are no paystubs" do
+          accordion_buttons = subject.css('button.usa-accordion__button')
+          expect(accordion_buttons).to be_empty
+
+          payments_header = subject.at_css('h3')
+          expect(payments_header).to be_nil
+        end
       end
     end
   end
@@ -152,6 +160,14 @@ RSpec.describe Report::PaymentsDeductionsMonthlySummaryComponent, type: :compone
       it "renders nothing without the paystubs data" do
         heading = subject.at_css('h2.usa-alert__heading')
         expect(heading).to be_nil
+      end
+
+      it "does not render empty accordions when there are no paystubs" do
+        accordion_buttons = subject.css('button.usa-accordion__button')
+        expect(accordion_buttons).to be_empty
+
+        payments_header = subject.at_css('h3')
+        expect(payments_header).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3219](https://jiraent.cms.gov/browse/FFS-3219).

## Changes
- Only show section header when any month has paystubs
- Only render an accordion for a month when there are paystubs
- Testing

## Context
Please see testing instructions inside ticket :D 

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
<img width="800" height="789" alt="Screenshot 2025-08-07 at 1 18 47 PM" src="https://github.com/user-attachments/assets/eebb304b-d1fd-49aa-93e5-2d43a26959f8" />
