### PR TITLE
FFs-3205: Empty accordion when gig user has partial payment data

### DIFF
--- a/app/app/components/report/gig_monthly_summary_table_component.erb
+++ b/app/app/components/report/gig_monthly_summary_table_component.erb
@@ -72,16 +72,18 @@
           </ul>
         <% else %>
           <% @monthly_summary_data.each_with_index do |(month_string, summary), index| %>
-            <%= render AccordionComponent.new(id: "#{month_string}-accordion") do |accordion| %>
-              <% accordion.with_title do %>
-                <%= format_month_string(month_string, summary) %>
-              <% end %>
-              <% accordion.with_accordion_item do %>
-                <ul class="usa-list">
-                  <% summary[:paystubs].each do |paystub| %>
-                    <li><%= format_date(paystub.pay_date, :long) %> - <%= format_money(paystub.gross_pay_amount) %></li>
-                  <% end %>
-                </ul>
+            <% if summary[:paystubs].any? %>
+              <%= render AccordionComponent.new(id: "#{month_string}-accordion") do |accordion| %>
+                <% accordion.with_title do %>
+                  <%= format_month_string(month_string, summary) %>
+                <% end %>
+                <% accordion.with_accordion_item do %>
+                  <ul class="usa-list">
+                    <% summary[:paystubs].each do |paystub| %>
+                      <li><%= format_date(paystub.pay_date, :long) %> - <%= format_money(paystub.gross_pay_amount) %></li>
+                    <% end %>
+                  </ul>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -379,5 +379,30 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
         expect(subject.to_html).to include '"Total hours worked" sums the time'
       end
     end
+
+    context "with gig hours but no paystubs" do
+  let(:argyle_report) { Aggregators::AggregatorReports::ArgyleReport.new(payroll_accounts: [ payroll_account ], argyle_service: argyle_service, days_to_fetch_for_w2: 90, days_to_fetch_for_gig: 182) }
+
+  before do
+    argyle_stub_request_identities_response("bob")
+    argyle_stub_request_gigs_response("bob")
+    argyle_stub_request_account_response("bob")
+    argyle_stub_request_paystubs_response("empty")
+    argyle_report.fetch
+  end
+
+  around do |ex|
+    Timecop.freeze(Time.local(2025, 04, 1, 0, 0), &ex)
+  end
+
+  subject { render_inline(described_class.new(argyle_report, payroll_account)) }
+
+  it "shows hours in monthly summary but no payment accordion" do
+    expect(subject.css('h3').text).to include("Monthly Summary")
+    expect(subject.css('tbody tr').length).to be > 0
+
+    expect(subject.css('button.usa-accordion__button')).to be_empty
+  end
+end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3205](https://jiraent.cms.gov/browse/FFS-3205).


## Changes
- Accordion checks presence of paystubs before rendering
- Test

## Context for reviewers
This is difficult to reproduce with randomized data. However, we are requesting a dedicated sandbox test user from Argyle.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
