### PR TITLE
FFS-3207: spanish translation for footer

### DIFF
--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -35,7 +35,7 @@ class Cbv::SubmitsController < Cbv::BaseController
             is_caseworker: allow_caseworker_override_param? && params[:is_caseworker],
             aggregator_report: @aggregator_report
           },
-          footer: { right: "Income Verification Report | Page [page] of [topage]", font_size: 10 },
+          footer: { right: t(".pdf.footer.page_footer"), font_size: 10 },
           margin:  {
             top:               10,
             bottom:            10,

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -403,6 +403,8 @@ en:
             description: We have collected your income information with your consent and sent it to %{agency_acronym}. Any additional income that you weren't able to add to this report should be shared separately with %{agency_acronym}.
             employment_payment_details: Employment and Payment details
             header: Income Verification Report
+          footer:
+            page_footer: Income Verification Report | Page [page] of [topage]
           shared:
             additional_jobs_to_report: Does the client have additional jobs they will report separately?
             additional_jobs_to_report_html: Does the client have additional jobs they will report separately?<sup>1</sup>

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -284,6 +284,8 @@ es:
             description: Hemos recopilado información de sus ingresos con su consentimiento y la hemos enviado a %{agency_acronym}. Cualquier ingreso adicional que no pudo añadir a este informe debe compartirse por separado con %{agency_acronym}.
             employment_payment_details: Detalles de empleo y pago
             header: Informe de verificación de ingresos
+          footer:
+            page_footer: Informe de verificación de ingresos | Página [page] de [topage]
           shared:
             additional_jobs_to_report: "¿El cliente tiene trabajos adicionales que informará por separado?"
             additional_jobs_to_report_html: "¿El cliente tiene trabajos adicionales que informará por separado? <sup>1</sup>"


### PR DESCRIPTION
## [FFS-3207](https://jiraent.cms.gov/browse/FFS-3207).

## Changes
The footer of the PDF is now in Spanish if your locale is es.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)