### PR TITLE
FFS-3229: make page footer not scrolled off the end of the page

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -8,6 +8,12 @@ html {
   min-width: 320px;
 }
 
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .usa-button--outline-email {
   // Because css rendering in email is fraught, we must replace the default
   // USWDS strategy of using a box-shadow (it doesn't appear at all in gmail).
@@ -21,7 +27,7 @@ html {
   // at the bottom of the screen by default.
   $header-height: 4.5rem;
   $footer-height: 5rem;
-  min-height: calc(100vh - $header-height - $footer-height);
+  flex-grow: 1;
 }
 
 /*

--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -8,10 +8,18 @@ html {
   min-width: 320px;
 }
 
+/*
+ * These comprise our strategy for making sure the footer stays put
+ * at the foot of the site.
+ */
 #root {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+}
+
+#main-content {
+  flex-grow: 1;
 }
 
 .usa-button--outline-email {
@@ -20,14 +28,6 @@ html {
   background-color: transparent;
   border: 2px solid #005ea2;
   color: #005ea2;
-}
-
-#main-content {
-  // These are rough approximations just to roughly get the footer to show up
-  // at the bottom of the screen by default.
-  $header-height: 4.5rem;
-  $footer-height: 5rem;
-  flex-grow: 1;
 }
 
 /*


### PR DESCRIPTION
## [FFS-3229](https://jiraent.cms.gov/browse/FFS-3229)


## Changes
Footer used to be cut off at the bottom of the page. Now, it won't be.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)