### PR TITLE
FFS-3231: Default to a "Select" option for the memorable date month

### DIFF
--- a/app/app/components/memorable_date_component.html.erb
+++ b/app/app/components/memorable_date_component.html.erb
@@ -13,7 +13,8 @@
               {
                 field_name: "month",
                 id: "#{field_name}_#{attribute}_month",
-                prefix: "#{field_name}[#{attribute}]"
+                prefix: "#{field_name}[#{attribute}]",
+                prompt: t("shared.select_placeholder")
               },
               { class: "usa-select" },
             ) %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -693,6 +693,7 @@ en:
       az_des: Mid Approval Contact form
       la_ldh: benefits
       sandbox: benefits
+    select_placeholder: "- Select -"
     skip_link: Skip to main content
   time:
     formats:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -618,6 +618,7 @@ es:
       az_des: Formulario de contacto para aprobaciones intermedias
       la_ldh: beneficios
       sandbox: beneficios
+    select_placeholder: "- Seleccione -"
     skip_link: Saltar al contenido principal
   time:
     formats:

--- a/app/spec/helpers/uswds_form_builder_spec.rb
+++ b/app/spec/helpers/uswds_form_builder_spec.rb
@@ -280,6 +280,18 @@ RSpec.describe UswdsFormBuilder do
       end
     end
 
+    context 'when no date is set' do
+      let(:object) { TestModel.new(start_date: nil) }
+
+      it 'renders placeholder option with empty value for month' do
+        expect(result).to have_element(:option, value: '', text: I18n.t('shared.select_placeholder'))
+      end
+
+      it 'does not preselect any month' do
+        expect(result).not_to have_element(:option, selected: 'selected')
+      end
+    end
+
     context 'with errors' do
       before do
         object.errors.add(:start_date, 'is invalid')
@@ -291,11 +303,16 @@ RSpec.describe UswdsFormBuilder do
       end
     end
 
-    context 'with existing date value' do
+    context 'when a date is set' do
       let(:object) { TestModel.new(start_date: Date.new(2024, 2, 28)) }
 
-      it 'sets the month value' do
+      it 'selects the existing month value' do
         expect(result).to have_element(:option, value: '2', selected: 'selected')
+      end
+
+      it 'keeps placeholder present but unselected when month is set' do
+        expect(result).to have_element(:option, value: '', text: I18n.t('shared.select_placeholder'))
+        expect(result).not_to have_element(:option, value: '', selected: 'selected')
       end
 
       it 'sets the day value' do


### PR DESCRIPTION
## Ticket

Resolves [FFS-3231](https://jiraent.cms.gov/browse/FFS-3231).


## Changes
- "Select" prompt as default in memorable date picker
- en/es strings
- Testing

## Context for reviewers
Design requested the little dashes in `- Select -` to match how USWDS does it

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
