### PR TITLE
[FFS-3223] propose additional newrelic alert to run alongside current

### DIFF
--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -4,7 +4,7 @@
 resource "aws_sns_topic" "this" {
   name = "${var.service_name}-monitoring"
 
-  # checkov:skip=CKV_AWS_26:SNS encryption for alerts is unnecessary 
+  # checkov:skip=CKV_AWS_26:SNS encryption for alerts is unnecessary
 }
 
 # Create CloudWatch alarms for the service
@@ -57,6 +57,42 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   statistic           = "Average"
   threshold           = 0.2
   alarm_description   = "High target latency alert"
+  alarm_actions       = [aws_sns_topic.this.arn]
+  ok_actions          = [aws_sns_topic.this.arn]
+
+  dimensions = {
+    LoadBalancer = var.load_balancer_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_alb_response_time" {
+  alarm_name          = "${var.service_name}-high-alb-response-time"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 0.2
+  alarm_description   = "High target latency alert"
+  alarm_actions       = [aws_sns_topic.this.arn]
+  ok_actions          = [aws_sns_topic.this.arn]
+
+  dimensions = {
+    LoadBalancer = var.load_balancer_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_alb_p95_response_time" {
+  alarm_name          = "${var.service_name}-high-alb-p95-response-time"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "p95"
+  threshold           = 4
+  alarm_description   = "High latency for p95 alert"
   alarm_actions       = [aws_sns_topic.this.arn]
   ok_actions          = [aws_sns_topic.this.arn]
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3223](https://jiraent.cms.gov/browse/FFS-3223).


## Changes

 I misunderstood how some of our setup works and we can close the ticket--> I thought because I didn't trigger any issues that the monitoring was just on the application and not the load balancer. looking into this further, it's because it's configured to only alert if we have ALB issues for more than 5 minutes, which is why i didn't see it trigger despite the performance metrics I recorded.

So while we don't need the ALB alert originally proposed, the current one to protect against noise has a pretty high sampling rate--> so this is an optional idea to capture the edges of the performance as well as the average, since one could be doing well while the other is suffering.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ X ] Acceptance testing prior to merge
  Apply terraform change, compare it sets up new alert as expected.