### PR TITLE
Skip tracking ApplicantClickedGenericLink for Go user agent

### DIFF
--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -61,6 +61,10 @@ class Cbv::GenericLinksController < Cbv::BaseController
   end
 
   def track_generic_link_clicked_event(cbv_flow, is_new_session)
+    # Skip tracking this event for a specific user agent, since we tend
+    # to get a ton of traffic from it during LA SMS sends
+    return if request.user_agent.match?(/go-http-client/i)
+
     event_logger.track("ApplicantClickedGenericLink", request, {
       time: Time.now.to_i,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Cbv::GenericLinksController do
   describe '#show' do
     context 'when the hostname matches a client agency domain and the pilot is active' do
       context 'when no existing CBV applicant cookie exists' do
+        let(:headers) { {} }
         before do
+          request.headers.merge!(headers)
           get :show, params: { client_agency_id: "sandbox" }
         end
 
@@ -36,6 +38,16 @@ RSpec.describe Cbv::GenericLinksController do
               is_new_session: true
             )
           )
+        end
+
+        context "when the User Agent is Go-Http-Client" do
+          let(:headers) { { "User-Agent" => "Go-http-client/1.1" } }
+
+          it "does not track the ApplicantClickedGenericLink event" do
+            expect(EventTrackingJob)
+              .not_to have_received(:perform_later)
+              .with("ApplicantClickedGenericLink", anything, anything)
+          end
         end
       end
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A - On call.


## Changes
<!-- What was added, updated, or removed in this PR. -->

We're still not exactly sure what this traffic is from, but we tend to
get about 80k requests from a Go-Http-Client user agent when the LA SMS
messages go out.

These events clutter up the Mixpanel account and delay other async jobs
from succeeding.

Until we figure out a more effective rate limiting strategy, let's at
least stop tracking these useless bot events.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
