### PR TITLE
FFS-3254: Make CSV file generation agency configurable and disable for AZ

### DIFF
--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -14,6 +14,7 @@
     password: <%= ENV['AZ_DES_SFTP_PASSWORD'] %>
     url: <%= ENV['AZ_DES_SFTP_URL'] %>
     sftp_directory: <%= ENV['AZ_DES_SFTP_DIRECTORY'] %>
+    csv_summary_reports_enabled: false
   staff_portal_enabled: false
   pilot_ended: false
   generic_links_disabled: true

--- a/app/lib/tasks/az_des.rake
+++ b/app/lib/tasks/az_des.rake
@@ -14,6 +14,12 @@ namespace :az_des do
 
   desc "deliver csv summary of cases sent to az_des"
   task deliver_csv_reports: :environment do
+    config = ClientAgency::AzDes::Configuration.sftp_transmission_configuration
+    unless config.fetch("csv_summary_reports_enabled", true)
+      puts "AZ DES CSV summary delivery disabled, not enqueuing job"
+      next
+    end
+
     time_zone = "America/Phoenix"
     now = Time.find_zone(time_zone).now
     start_time = now.yesterday.change(hour: 8)

--- a/app/spec/lib/az_des_rake_spec.rb
+++ b/app/spec/lib/az_des_rake_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "az_des.rake" do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    Rake::Task["az_des:deliver_csv_reports"].reenable
+  end
+
+  it "does not enqueue the CSV job when csv_summary_reports_enabled is false" do
+    allow(ClientAgency::AzDes::Configuration).to receive(:sftp_transmission_configuration).and_return(
+      { "csv_summary_reports_enabled" => false }
+    )
+
+    expect { Rake::Task["az_des:deliver_csv_reports"].execute }.
+      not_to have_enqueued_job(ClientAgency::AzDes::ReportDelivererJob)
+  end
+
+  it "enqueues the CSV job when csv_summary_reports_enabled is true" do
+    allow(ClientAgency::AzDes::Configuration).to receive(:sftp_transmission_configuration).and_return(
+      { "csv_summary_reports_enabled" => true }
+    )
+
+    expect { Rake::Task["az_des:deliver_csv_reports"].execute }.
+      to have_enqueued_job(ClientAgency::AzDes::ReportDelivererJob)
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3254](https://jiraent.cms.gov/browse/FFS-3254).


## Changes
- Agency configuration toggle for CSV generation
- Rake task will abort for AZ
- Tests

## Context for reviewers
There isn't really an earlier, centralized point to intercept these rake tasks and make something that is more generic while being agency configurable. This is a reusable pattern though. AZ is currently the only pilot sending CSVs.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
<img width="463" height="48" alt="Screenshot 2025-08-20 at 3 43 11 PM" src="https://github.com/user-attachments/assets/9d5519cf-f396-46d7-a24a-e4b58c009ec3" />
 