### PR TITLE
FFS-3287: Remove "Prompt" row from applicant info table on /summary

### DIFF
--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -46,14 +46,18 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
     redirect_to next_path if @cbv_flow.cbv_flow_invitation.present?
   end
 
-  def applicant_params
-    params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {}).permit(
-      cbv_applicant: @cbv_applicant.applicant_attributes
-    )
-  end
-
   def set_cbv_applicant
     @cbv_applicant = @cbv_flow.cbv_applicant
+  end
+
+  private
+
+  def applicant_params
+    permitted = @cbv_applicant.applicant_attributes.map { |attr|
+      attr == :date_of_birth ? { date_of_birth: [ :day, :month, :year ] } : attr
+    }
+
+    params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {}).permit(cbv_applicant: permitted)
   end
 
   def track_applicant_information_access_event

--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -36,6 +36,16 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
     redirect_to cbv_flow_applicant_information_path
   end
 
+  private
+
+  def applicant_params
+    permitted = @cbv_applicant.applicant_attributes.map { |attr|
+      attr == :date_of_birth ? { date_of_birth: [ :day, :month, :year ] } : attr
+    }
+
+    params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {}).permit(cbv_applicant: permitted)
+  end
+
   def redirect_when_info_present
     return if params[:force_show] == "true"
 
@@ -48,16 +58,6 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
 
   def set_cbv_applicant
     @cbv_applicant = @cbv_flow.cbv_applicant
-  end
-
-  private
-
-  def applicant_params
-    permitted = @cbv_applicant.applicant_attributes.map { |attr|
-      attr == :date_of_birth ? { date_of_birth: [ :day, :month, :year ] } : attr
-    }
-
-    params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {}).permit(cbv_applicant: permitted)
   end
 
   def track_applicant_information_access_event

--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -95,7 +95,6 @@ class CbvApplicant < ApplicationRecord
 
   def set_applicant_attributes
     @applicant_attributes = agency_config&.applicant_attributes&.compact&.keys&.map(&:to_sym) || []
-    @applicant_attributes << { date_of_birth: [ :day, :month, :year ] } if @applicant_attributes.include?(:date_of_birth)
 
     @required_applicant_attributes = get_required_applicant_attributes
   end

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -72,15 +72,15 @@
     <% row.with_data_cell(is_header: true).with_content(t(".your_answer")) %>
   <% end %>
   <% @cbv_flow.cbv_applicant.applicant_attributes.each do |item| %>
-      <% table.with_row do |row| %>
-        <% row.with_data_cell(data_label: t(".question"), class_names: "text-bold").with_content(t("cbv.applicant_informations.#{@cbv_flow.client_agency_id}.fields.#{item}.prompt")) %>
-        <% row.with_data_cell(data_label: t(".your_answer")) do %>
-          <% if item == :date_of_birth %>
-            <%= format_date(@cbv_flow.cbv_applicant[item]) %>
-          <% else %>
-            <%= @cbv_flow.cbv_applicant[item] %>
-          <% end %>
+    <% table.with_row do |row| %>
+      <% row.with_data_cell(data_label: t(".question"), class_names: "text-bold").with_content(t("cbv.applicant_informations.#{@cbv_flow.client_agency_id}.fields.#{item}.prompt")) %>
+      <% row.with_data_cell(data_label: t(".your_answer")) do %>
+        <% if item == :date_of_birth %>
+          <%= format_date(@cbv_flow.cbv_applicant[item]) %>
+        <% else %>
+          <%= @cbv_flow.cbv_applicant[item] %>
         <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/spec/controllers/cbv/applicant_informations_controller_spec.rb
+++ b/app/spec/controllers/cbv/applicant_informations_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cbv::ApplicantInformationsController, type: :controller do
               first_name: "Daph", # required
               middle_name: "",
               last_name: "", # required
-              date_of_birth: "", # required
+              date_of_birth: { month: "", day: "", year: "" }, # required
               case_number: "" # required
             }
           }

--- a/app/spec/models/cbv_applicant_spec.rb
+++ b/app/spec/models/cbv_applicant_spec.rb
@@ -1,151 +1,165 @@
 require 'rails_helper'
 
 RSpec.describe CbvApplicant, type: :model do
-    describe "all valid types of agencies" do
-      ClientAgencyConfig.client_agencies.client_agency_ids.each do |client_agency_id|
-        it "has a list of VALID_ATTRIBUTES for #{client_agency_id}" do
-          expect(CbvApplicant.valid_attributes_for_agency(client_agency_id)).to be_present
-        end
+  describe "all valid types of agencies" do
+    ClientAgencyConfig.client_agencies.client_agency_ids.each do |client_agency_id|
+      it "has a list of VALID_ATTRIBUTES for #{client_agency_id}" do
+        expect(CbvApplicant.valid_attributes_for_agency(client_agency_id)).to be_present
+      end
+    end
+  end
+
+  describe "#has_applicant_attribute_missing?" do
+    before do
+      allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
+        { first_name: "required" }
+      )
+    end
+
+    let(:cbv_applicant) { create(:cbv_applicant, first_name: nil) }
+    it "returns true if a field missing" do
+      cbv_applicant.set_applicant_attributes
+      expect(cbv_applicant.required_applicant_attributes).to be_present
+      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(true)
+    end
+
+    it "returns false if a field not missing" do
+      cbv_applicant.set_applicant_attributes
+      cbv_applicant.first_name = "Dean Venture"
+      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(false)
+    end
+  end
+
+  describe "#validate_required_applicant_attributes" do
+    let(:date_of_birth) { build(:cbv_applicant).date_of_birth }
+
+    it "returns an array of symbols containing the missing field keys" do
+      cbv_applicant_without_case_number = build(:cbv_applicant, :sandbox, middle_name: nil)
+      cbv_applicant_without_case_number.set_applicant_attributes
+      expect(cbv_applicant_without_case_number.required_applicant_attributes).to be_present
+      expect(cbv_applicant_without_case_number.case_number).to be_nil
+      expect(cbv_applicant_without_case_number.validate_required_applicant_attributes).to eq([ :case_number ])
+    end
+
+    it "is adds errors to the model instance when required field is missing" do
+      cbv_applicant_without_dob = build(:cbv_applicant, :sandbox, date_of_birth: nil)
+      cbv_applicant_without_dob.set_applicant_attributes
+      cbv_applicant_without_dob.validate_required_applicant_attributes
+      expect(cbv_applicant_without_dob.errors[:date_of_birth]).to include(I18n.t("cbv.applicant_informations.sandbox.fields.date_of_birth.blank"))
+    end
+
+    it "it returns an empty array when validation constraints are met" do
+      valid_cbv_applicant = build(:cbv_applicant, :sandbox, date_of_birth: date_of_birth, case_number: '123')
+      valid_cbv_applicant.set_applicant_attributes
+      valid_cbv_applicant.validate_required_applicant_attributes
+      expect(valid_cbv_applicant.errors).to be_empty
+    end
+  end
+
+  describe "#validate_base_and_applicant_attributes?" do
+    let(:valid_applicant) { build(:cbv_applicant, :sandbox, case_number: '123') }
+    let(:invalid_applicant) { build(:cbv_applicant, :sandbox, date_of_birth: nil, case_number: nil) }
+
+    it "returns true when all validation methods pass" do
+      valid_applicant.set_applicant_attributes
+      expect(valid_applicant.validate_base_and_applicant_attributes?).to be true
+    end
+
+    it "returns false when validate_required_applicant_attributes contains entries" do
+      invalid_applicant.set_applicant_attributes
+      expect(invalid_applicant.validate_base_and_applicant_attributes?).to be false
+    end
+  end
+
+  describe "#set_applicant_attributes" do
+    let(:cbv_applicant) { build(:cbv_applicant, :sandbox) }
+
+    it "sets applicant and required attributes based on agency config" do
+      cbv_applicant.set_applicant_attributes
+
+      expect(cbv_applicant.applicant_attributes).to include(:first_name, :middle_name, :date_of_birth)
+      expect(cbv_applicant.applicant_attributes).to all(be_a(Symbol))
+
+      expect(cbv_applicant.required_applicant_attributes).to include(:first_name, :date_of_birth)
+      expect(cbv_applicant.required_applicant_attributes).not_to include(:middle_name)
+    end
+  end
+
+  describe "ActiveRecord::Base validations" do
+    let(:valid_attributes) { attributes_for(:cbv_applicant, :sandbox) }
+
+    describe "middle_name" do
+      it "allows middle_name to be optional" do
+        applicant = create(:cbv_applicant, middle_name: nil)
+        expect(applicant).to be_valid
       end
     end
 
-    describe "#has_applicant_attribute_missing?" do
-      before do
-        allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
-          { first_name: "required" }
+    describe "snap_application_date" do
+      it "does not require snap_application_date in the generic link workflow, sets default" do
+        applicant = CbvApplicant.new(valid_attributes)
+        expect(applicant).to be_valid
+        expect(applicant.snap_application_date).to eq(Date.current)
+      end
+
+      it "requires a snap_application_date in the caseworker workflow" do
+        applicant = CbvApplicant.new(valid_attributes)
+        applicant.snap_application_date = nil
+        expect(applicant).not_to be_valid
+      end
+
+      it "allows snap_application_date in the future for sandbox agency" do
+        applicant = CbvApplicant.new(valid_attributes)
+        applicant.snap_application_date = Date.tomorrow
+        expect(applicant).to be_valid
+      end
+
+      it "parses snap_application_date strings correctly" do
+        applicant = CbvApplicant.new(valid_attributes)
+        applicant.snap_application_date = "08/15/2023"
+        expect(applicant).to be_valid
+        expect(applicant.snap_application_date).to eq(Date.new(2023, 8, 15))
+      end
+
+      it "adds an error when snap_application_date is not a valid date in a caseworker workflow" do
+        applicant = CbvApplicant.new(valid_attributes)
+        applicant.snap_application_date = "invalid"
+        expect(applicant).not_to be_valid
+        expect(applicant.errors[:snap_application_date]).to include(
+          I18n.t('activerecord.errors.models.cbv_applicant.attributes.snap_application_date.invalid_date')
         )
       end
-
-      let(:cbv_applicant) { create(:cbv_applicant, first_name: nil) }
-      it "returns true if a field missing" do
-        cbv_applicant.set_applicant_attributes
-        expect(cbv_applicant.required_applicant_attributes).to be_present
-        expect(cbv_applicant.has_applicant_attribute_missing?).to eq(true)
-      end
-
-      it "returns false if a field not missing" do
-        cbv_applicant.set_applicant_attributes
-        cbv_applicant.first_name = "Dean Venture"
-        expect(cbv_applicant.has_applicant_attribute_missing?).to eq(false)
-      end
     end
 
-    describe "#validate_required_applicant_attributes" do
-      let(:date_of_birth) { build(:cbv_applicant).date_of_birth }
+    describe "date_of_birth" do
+      let(:date_of_birth) { Date.new(1980, 1, 1) }
 
-      it "returns an array of symbols containing the missing field keys" do
-        cbv_applicant_without_case_number = build(:cbv_applicant, :sandbox, middle_name: nil)
-        cbv_applicant_without_case_number.set_applicant_attributes
-        expect(cbv_applicant_without_case_number.required_applicant_attributes).to be_present
-        expect(cbv_applicant_without_case_number.case_number).to be_nil
-        expect(cbv_applicant_without_case_number.validate_required_applicant_attributes).to eq([ :case_number ])
-      end
-
-      it "is adds errors to the model instance when required field is missing" do
-        cbv_applicant_without_dob = build(:cbv_applicant, :sandbox, date_of_birth: nil)
-        cbv_applicant_without_dob.set_applicant_attributes
-        cbv_applicant_without_dob.validate_required_applicant_attributes
-        expect(cbv_applicant_without_dob.errors[:date_of_birth]).to include(I18n.t("cbv.applicant_informations.sandbox.fields.date_of_birth.blank"))
-      end
-
-      it "it returns an empty array when validation constraints are met" do
-        valid_cbv_applicant = build(:cbv_applicant, :sandbox, date_of_birth: date_of_birth, case_number: '123')
-        valid_cbv_applicant.set_applicant_attributes
-        valid_cbv_applicant.validate_required_applicant_attributes
-        expect(valid_cbv_applicant.errors).to be_empty
-      end
-    end
-
-    describe "#validate_base_and_applicant_attributes?" do
-      let(:valid_applicant) { build(:cbv_applicant, :sandbox, case_number: '123') }
-      let(:invalid_applicant) { build(:cbv_applicant, :sandbox, date_of_birth: nil, case_number: nil) }
-
-      it "returns true when all validation methods pass" do
-        valid_applicant.set_applicant_attributes
-        expect(valid_applicant.validate_base_and_applicant_attributes?).to be true
-      end
-
-      it "returns false when validate_required_applicant_attributes contains entries" do
-        invalid_applicant.set_applicant_attributes
-        expect(invalid_applicant.validate_base_and_applicant_attributes?).to be false
-      end
-    end
-
-    describe "ActiveRecord::Base validations" do
-      let(:valid_attributes) { attributes_for(:cbv_applicant, :sandbox) }
-
-      describe "middle_name" do
-        it "allows middle_name to be optional" do
-          applicant = create(:cbv_applicant, middle_name: nil)
-          expect(applicant).to be_valid
-        end
-      end
-
-      describe "snap_application_date" do
-        it "does not require snap_application_date in the generic link workflow, sets default" do
-          applicant = CbvApplicant.new(valid_attributes)
-          expect(applicant).to be_valid
-          expect(applicant.snap_application_date).to eq(Date.current)
-        end
-
-        it "requires a snap_application_date in the caseworker workflow" do
-          applicant = CbvApplicant.new(valid_attributes)
-          applicant.snap_application_date = nil
-          expect(applicant).not_to be_valid
-        end
-
-        it "allows snap_application_date in the future for sandbox agency" do
-          applicant = CbvApplicant.new(valid_attributes)
-          applicant.snap_application_date = Date.tomorrow
-          expect(applicant).to be_valid
-        end
-
-        it "parses snap_application_date strings correctly" do
-          applicant = CbvApplicant.new(valid_attributes)
-          applicant.snap_application_date = "08/15/2023"
-          expect(applicant).to be_valid
-          expect(applicant.snap_application_date).to eq(Date.new(2023, 8, 15))
-        end
-
-        it "adds an error when snap_application_date is not a valid date in a caseworker workflow" do
-          applicant = CbvApplicant.new(valid_attributes)
-          applicant.snap_application_date = "invalid"
-          expect(applicant).not_to be_valid
-          expect(applicant.errors[:snap_application_date]).to include(
-            I18n.t('activerecord.errors.models.cbv_applicant.attributes.snap_application_date.invalid_date')
+      context "agency with date_of_birth required" do
+        before do
+          allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
+            {
+              first_name: { "required" => true },
+              date_of_birth: { "required" => true, "type" => "date" }
+            }
           )
         end
-      end
 
-      describe "date_of_birth" do
-        let(:date_of_birth) { Date.new(1980, 1, 1) }
+        it "adds an error when date_of_birth is in the future" do
+          applicant = build(:cbv_applicant, :sandbox, date_of_birth: Date.tomorrow)
+          applicant.valid?
+          expect(applicant.errors[:date_of_birth]).to include(
+            I18n.t('activerecord.errors.models.cbv_applicant/sandbox.attributes.date_of_birth.future_date')
+          )
+        end
 
-        context "agency with date_of_birth required" do
-          before do
-            allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
-              {
-                first_name: { "required" => true },
-                date_of_birth: { "required" => true, "type" => "date" }
-              }
-            )
-          end
-
-          it "adds an error when date_of_birth is in the future" do
-            applicant = build(:cbv_applicant, :sandbox, date_of_birth: Date.tomorrow)
-            applicant.valid?
-            expect(applicant.errors[:date_of_birth]).to include(
-              I18n.t('activerecord.errors.models.cbv_applicant/sandbox.attributes.date_of_birth.future_date')
-            )
-          end
-
-          it "adds an error when date_of_birth is more than 110 years in the past" do
-            applicant = build(:cbv_applicant, :sandbox, date_of_birth: 111.years.ago.to_date)
-            applicant.valid?
-            expect(applicant.errors[:date_of_birth]).to include(
-              I18n.t('activerecord.errors.models.cbv_applicant/sandbox.attributes.date_of_birth.invalid_date')
-            )
-          end
+        it "adds an error when date_of_birth is more than 110 years in the past" do
+          applicant = build(:cbv_applicant, :sandbox, date_of_birth: 111.years.ago.to_date)
+          applicant.valid?
+          expect(applicant.errors[:date_of_birth]).to include(
+            I18n.t('activerecord.errors.models.cbv_applicant/sandbox.attributes.date_of_birth.invalid_date')
+          )
         end
       end
     end
   end
+end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3287](https://jiraent.cms.gov/browse/FFS-3287).

## Changes
Move param concerns to controller, separate from display concerns

## Context for reviewers
The summary page loop included a non symbol date of birth entry meant only for params validation. The translation looked up an invalid key and fell back to the string "Prompt," causing it to show up as a row label.

I think we should follow the convention of separating params and visual going forward, as a rule of thumb.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

### Before
<img width="988" height="384" alt="Screenshot 2025-08-22 at 12 45 17 PM" src="https://github.com/user-attachments/assets/72ef32c2-c75b-40b4-b1d6-ff6ed5cbd2f0" />

### After
<img width="983" height="344" alt="Screenshot 2025-08-22 at 2 41 04 PM" src="https://github.com/user-attachments/assets/aa68965c-ca45-49bb-ba7c-a598c2d2b420" />

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-920-app-dev-733372590.us-east-1.elb.amazonaws.com
- Deployed commit: c7f845b38792fccf467b3d5dbea03e735fbe010b
<!-- end PR environment info -->