### PR TITLE
FFS-3197: Reenable turbo on /employer_search by fixing style issue in CSP

### DIFF
--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -1,6 +1,4 @@
 class Cbv::EmployerSearchesController < Cbv::BaseController
-  # Disable CSP since Pinwheel relies on inline styles
-  content_security_policy false, only: :show
   before_action :check_webhooks_initialization_in_development
   after_action :track_accessed_search_event, only: :show
   after_action :track_applicant_searched_event, only: :show

--- a/app/app/javascript/utilities/loadProviderResources.ts
+++ b/app/app/javascript/utilities/loadProviderResources.ts
@@ -2,6 +2,9 @@ import loadScript from "load-script"
 
 export const loadArgyleResource = async () => {
   return await new Promise((resolve, reject) => {
+    // Note: When upgrading this version, make sure to test that the modal
+    // works and there are no Content Security Policy errors related to the
+    // updated styling. See: config/initializers/content_security_policy.rb.
     loadScript("https://plugin.argyle.com/argyle.web.v5.js", (err, script) => {
       if (err) {
         reject(err)
@@ -14,6 +17,9 @@ export const loadArgyleResource = async () => {
 
 export const loadPinwheelResource = async () => {
   return await new Promise((resolve, reject) => {
+    // Note: When upgrading this version, make sure to test that the modal
+    // works and there are no Content Security Policy errors related to the
+    // updated styling. See: config/initializers/content_security_policy.rb.
     loadScript("https://cdn.getpinwheel.com/pinwheel-v3.0.js", (err, script) => {
       if (err) {
         reject(err)

--- a/app/app/views/cbv/add_jobs/show.html.erb
+++ b/app/app/views/cbv/add_jobs/show.html.erb
@@ -12,7 +12,7 @@
   <li><%= t(".header_2_bullet_3") %></li>
 </ul>
 
-<%= form_with(url: cbv_flow_add_job_path, builder: UswdsFormBuilder, id: "add_job_form", data: { turbo: "false" }) do |f| %>
+<%= form_with(url: cbv_flow_add_job_path, builder: UswdsFormBuilder, id: "add_job_form") do |f| %>
   <%= f.radio_button(:additional_jobs, true, { label: t(".radio_yes") }) %>
   <%= f.radio_button(:additional_jobs, false, { label: t(".radio_no") }) %>
 

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -20,7 +20,7 @@
     </li>
   </ol>
 
-  <%= form_with(url: cbv_flow_entry_path, builder: UswdsFormBuilder, data: { turbo: "false" }) do |f| %>
+  <%= form_with(url: cbv_flow_entry_path, builder: UswdsFormBuilder) do |f| %>
     <%= f.check_box(:agreement, { label: agency_translation(".checkbox", agency_full_name: agency_translation("shared.agency_full_name")), "data-action": "cbv-entry-page#consent", "data-cbv-entry-page-target": "consentCheckbox" }) %>
     <%= f.submit t(".continue") %>
   <% end %>

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -22,6 +22,6 @@
 <hr class="margin-top-5 margin-bottom-5 border-base-light border-top-0">
 <h2><%= t(".more_jobs") %></h2>
 <p><%= t(".you_can_search") %></p>
-<%= link_to cbv_flow_employer_search_path, class: "usa-button usa-button--outline", data: { turbo: "false" } do %>
+<%= link_to cbv_flow_employer_search_path, class: "usa-button usa-button--outline" do %>
   <%= t(".back_button") %>
 <% end %>

--- a/app/app/views/cbv/synchronization_failures/show.html.erb
+++ b/app/app/views/cbv/synchronization_failures/show.html.erb
@@ -15,7 +15,7 @@
 
 <ul class="usa-button-group margin-top-5">
   <li class="usa-button-group__item">
-    <%= link_to t(".back_to_search"), cbv_flow_employer_search_path, class: "usa-button usa-button--outline", data: { turbo: "false" } %>
+    <%= link_to t(".back_to_search"), cbv_flow_employer_search_path, class: "usa-button usa-button--outline" %>
   </li>
   <li class="usa-button-group__item">
     <% if @cbv_flow.has_account_with_required_data? %>

--- a/app/config/initializers/content_security_policy.rb
+++ b/app/config/initializers/content_security_policy.rb
@@ -7,24 +7,41 @@
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
-    policy.font_src :self
+    policy.font_src :self, "https://*.cloudinary.com"
     policy.form_action :self, "https://login.microsoftonline.com"
     policy.frame_ancestors :self
     policy.img_src :self, :data, "https://*.cloudinary.com", "https://cdn.getpinwheel.com"
     policy.object_src :none
-    policy.script_src :self, "https://js-agent.newrelic.com", "https://*.nr-data.net", "https://cdn.getpinwheel.com"
-    policy.connect_src :self, "https://*.nr-data.net"
+    policy.script_src :self, *%w[
+      https://js-agent.newrelic.com
+      https://*.nr-data.net
+      https://cdn.getpinwheel.com
+      https://*.argyle.com
+    ]
+    policy.connect_src :self, "https://*.nr-data.net", "https://*.argyle.com"
     policy.worker_src :self, "blob:"
     policy.frame_src :self, "https://cdn.getpinwheel.com"
-    policy.style_src_elem :self
-    # Allow inline styles as we have some on the payment_details page:
-    policy.style_src_attr "'unsafe-inline'"
+
+    # Allow <style> tags used by Aggregator SDKs by explicitly allowing their
+    # hashes.
+    #
+    # When upgrading Pinwheel or Argyle JS SDKs, update these hashes by
+    # attempting to open each modal. If the <style> tag has changed, and we
+    # need to update the hash, then the JS console will show you the new hashes
+    # when it blocks adding the <style> tag to the page.
+    #
+    # The error will say "Refused ... Either ... a hash ('sha256-[blahblah]') ...
+    # is required." Replace the hash value(s) here from that message.
+    policy.style_src :self,
+      "'sha256-WAyOw4V+FqDc35lQPyRADLBWbuNK8ahvYEaQIYF1+Ps='", # Pinwheel
+      "'sha256-8Fd8AAaNByYvS/HuItVFketOItMHf2YiH+wvh8OVQOA='", # Pinwheel
+      "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"  # Argyle
   end
 
   #
   #   # Generate session nonces for permitted importmap and inline scripts
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w[script-src style-src-elem]
+  config.content_security_policy_nonce_directives = %w[script-src]
   #
   #   # Report violations without enforcing the policy.
   #   # config.content_security_policy_report_only = true


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-3197](https://jiraent.cms.gov/browse/FFS-3197).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-3197: Reenable turbo on /employer_search by fixing style issue in CSP**
> We've had to special-case the /employer_search page from the rest of our
> page navigations due to the Content Security Policy. Since Argyle and
> Pinwheel both add `<style>` tags to the page, we need some way to ensure
> those are allowed.

> Previously, we just made sure the page was served without a CSP header.
> This was brittle (we had to remember to disable turbo navigation on any
> link that led to /employer_search so that the page would actually be
> re-requested without the header) and less secure than just properly
> allowing these `<style>` tags through the CSP.

> The most straightforward way is to just pin the hash of the `<style>`
> tag contents. This commit, primarily, does that. (This will break
> whenever we update the Pinwheel/Argyle SDKs, but I've provided
> instructions on how to get the new hashes at that time.) I also had to
> add Argyle's domain to the script-src and connect-src.

> Since that allows for re-enabling of Turbo, this commit also does that,
> resulting in a much faster and smooth experience going between these
> pages.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

I tested this locally:
* Arriving at the /employer_search page via Turbo -> both modals work ✅ 
* Refreshing the /employer_search page (no Turbo) -> both modals work ✅ 
* Arriving at the /employer_search page from /add_jobs -> both modals work ✅ 

Since this is pretty hard to write an automated test to capture, I propose we lean on our smoke testing process to catch any potential issues with this.

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
