### PR TITLE
FFS-N/A: Update Docker PostgreSQL

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -88,7 +88,7 @@ ENV TMPDIR="/rails/tmp"
 # Install packages needed for development
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-      postgresql-client=15+248 \
+      postgresql-client-15 \
       graphviz=2.42.2-7+b3 \
       && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
@@ -147,7 +147,7 @@ RUN apt-get update -qq && \
         libgpgme11=1.18.0-3+b1 \
         libvips42=8.14.1-3+deb12u2 \
         openssl=3.0.16-1~deb12u1 \
-        postgresql-client=15+248 \
+        postgresql-client-15 \
         python-is-python3=3.11.2-1+deb12u1 \
         python3-venv=3.11.2-1+b1 \
         python3-pip=23.0.1+dfsg-1 \


### PR DESCRIPTION
## Ticket
N/A

## Changes
The build failed because we pinned a debian meta package version `postgresql-client=15+248`. That exact meta version is no longer available in Debian’s repos (see screenshot below). I switched to the actual package name: `postgresql-client-15` (no version pin). In general, it seems like we should avoid referencing meta package versions as that can be brittle.

<img width="639" height="309" alt="Screenshot 2025-09-08 at 12 10 34 PM" src="https://github.com/user-attachments/assets/6173a6bb-4bb8-40cd-9190-3b32277e1f23" />

## Context for reviewers
😢 Failing build: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/17559988568
😄 Passing build: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/17561049535

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)