### PR TITLE
Bring back manual package upgrades

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -27,8 +27,6 @@ FROM registry.docker.com/library/ruby:$RUBY_VERSION AS base
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-      # CVE-2025-7424 \
-      libxslt1-dev \
       # CVE-2025-55154 CVE-2025-55298 \
       imagemagick \
       && \


### PR DESCRIPTION
## Changes
We can't rely on getting the CVEE's fixed quickly enough in Docker's ruby image so we're bringing back manual updates to keep us secure. 

## Context for reviewers
- First time I've done this so lmk if I'm missing something about the infra. 
- Only thing that I didn't just unwind from #847 was moving changing libicu72  to libicu76. Somehow it could no longer find the 72 package just a few days later.
## Acceptance testing
- [x] No acceptance testing needed
