### PR TITLE
FFS-3375: Allow for redacting case_number in AZ

### DIFF
--- a/app/app/models/cbv_applicant/az_des.rb
+++ b/app/app/models/cbv_applicant/az_des.rb
@@ -17,9 +17,9 @@ class CbvApplicant::AzDes < CbvApplicant
 
   validates :case_number, presence: true
 
-  def redact!
+  def redact!(fields = nil)
     self[:income_changes] = redact_member_names_in_json(self[:income_changes])
-    super
+    super(fields)
   end
 
   def agency_expected_names

--- a/app/app/models/concerns/redactable.rb
+++ b/app/app/models/concerns/redactable.rb
@@ -41,8 +41,8 @@ module Redactable
     end
   end
 
-  def redact!
-    fields_to_redact = self.class.fields_to_redact || self.class.superclass.fields_to_redact
+  def redact!(fields = nil)
+    fields_to_redact = fields || self.class.fields_to_redact || self.class.superclass.fields_to_redact
     raise "No fields to redact in #{self.class} (or its superclass)" unless fields_to_redact.present?
 
     fields_to_redact.each do |field, type|

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -83,8 +83,9 @@ class DataRetentionService
 
   def self.redact_case_numbers_by_agency(agency_id)
     applicants = CbvApplicant.where(client_agency_id: agency_id)
-    applicants.find_each do |applicant|
+    applicants.find_each(batch_size: 200) do |applicant|
       applicant.redact!({ case_number: :string })
     end
+    puts "Redacted #{applicants.length} applicants"
   end
 end

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -80,4 +80,11 @@ class DataRetentionService
     applicant.cbv_flows.map(&:redact!)
     applicant.cbv_flows.each { |cbv_flow| cbv_flow.payroll_accounts.each(&:redact!) }
   end
+
+  def self.redact_case_numbers_by_agency(agency_id)
+    applicants = CbvApplicant.where(client_agency_id: agency_id)
+    applicants.find_each do |applicant|
+      applicant.redact!({ case_number: :string })
+    end
+  end
 end

--- a/app/lib/tasks/az_des.rake
+++ b/app/lib/tasks/az_des.rake
@@ -44,6 +44,5 @@ namespace :az_des do
   task redact_case_numbers: :environment do
     puts "Redacting case-numbers..."
     DataRetentionService.redact_case_numbers_by_agency("az_des")
-    puts "Done!"
   end
 end

--- a/app/lib/tasks/az_des.rake
+++ b/app/lib/tasks/az_des.rake
@@ -39,4 +39,11 @@ namespace :az_des do
       MatchAgencyNamesJob.perform_now(cbv_flow.id)
     end
   end
+
+  desc "redact case numbers"
+  task redact_case_numbers: :environment do
+    puts "Redacting case-numbers..."
+    DataRetentionService.redact_case_numbers_by_agency("az_des")
+    puts "Done!"
+  end
 end

--- a/app/spec/models/cbv_applicant/az_des_spec.rb
+++ b/app/spec/models/cbv_applicant/az_des_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe CbvApplicant::AzDes, type: :model do
           expect(income_change["change_type"]).not_to eq("REDACTED")
         end
       end
+
+      it "redacts specific fields when given" do
+        applicant = CbvApplicant.create(az_attributes)
+        applicant.redact!({ case_number: :string })
+
+        expect(applicant).to have_attributes(
+          case_number: "REDACTED"
+        )
+      end
     end
 
     context 'when income_changes is not an array' do

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -312,4 +312,24 @@ RSpec.describe DataRetentionService do
       )
     end
   end
+
+  describe ".redact_case_numbers!" do
+    let(:agency_to_redact) { "sandbox" }
+    let!(:cbv_flow_invitation) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME001", client_agency_id: agency_to_redact }) }
+    let!(:cbv_flow_invitation2) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME002", client_agency_id: agency_to_redact }) }
+    let!(:cbv_flow) { CbvFlow.create_from_invitation(cbv_flow_invitation) }
+    let!(:cbv_flow2) { CbvFlow.create_from_invitation(cbv_flow_invitation2) }
+
+    it "redacts all case numbers for a given agency" do
+      DataRetentionService.redact_case_numbers_by_agency(agency_to_redact)
+      expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+        case_number: "REDACTED",
+        redacted_at: within(1.second).of(Time.now)
+      )
+      expect(cbv_flow2.cbv_applicant.reload).to have_attributes(
+        case_number: "REDACTED",
+        redacted_at: within(1.second).of(Time.now)
+      )
+    end
+  end
 end

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe DataRetentionService do
     end
   end
 
-  describe ".redact_case_numbers!" do
+  describe ".redact_case_numbers_by_agency" do
     let(:agency_to_redact) { "sandbox" }
     let!(:cbv_flow_invitation) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME001", client_agency_id: agency_to_redact }) }
     let!(:cbv_flow_invitation2) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME002", client_agency_id: agency_to_redact }) }


### PR DESCRIPTION
## Ticket

Resolves [FFS-3375](https://jiraent.cms.gov/browse/FFS-3375).


## Changes
Running `rake az_des:redact_case_numbers` will redact all the `case_number` for all applicants in the AZ Pilot.


## Context for reviewers
- Accepted locally by running task and changing the task to run against `sandbox` but decided to make it an az specific task just to cut down on any potential for user error when run on higher environments. 


## Acceptance testing
- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
N/A