### PR TITLE
Patch CVE-2025-22113 vulnerability

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       # CVE-2025-55154 CVE-2025-55298 \
       imagemagick \
+      # CVE-2025-22113 \
+      linux-libc-dev \
       && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 


### PR DESCRIPTION
## Ticket

N/A


## Changes
Updated `linux-libc-dev` to patch CVE-2025-22113 which was failing our [trivy scan.](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/17935461736/job/51001075289?pr=964)


## Context for reviewers



## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
N/A