### PR TITLE
FFS-3381: Create reference implementation of JSON API receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ To run locally, use `bin/dev`
 
 To run database migrations on the test environment that is used by rpec tests, run `RAILS_ENV=test bin/rails db:schema:load`
 
+### JSON API Receiver (for testing)
+
+To test the JSON Push API integration, you can run a simple receiver:
+
+```bash
+cd app
+bin/api-test
+```
+
+This starts a test server on port 4567 that logs incoming JSON data.
+
 ## Branching model
 When beginning work on a feature, create a new branch based off of `main` and make the commits for that feature there.
 

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -136,3 +136,6 @@ gem "wkhtmltopdf-binary"
 
 gem "net-sftp"
 gem "net-ssh"
+
+# Sinatra for JSON API reference implementation
+gem "sinatra", "~> 4.0"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -286,6 +286,8 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
     net-http (0.4.1)
       uri
@@ -365,19 +367,20 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (3.1.16)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
-    rack-protection (3.2.0)
+    rack-protection (4.1.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.2.1)
+      rack (>= 3)
     rails (7.2.2.2)
       actioncable (= 7.2.2.2)
       actionmailbox (= 7.2.2.2)
@@ -484,6 +487,7 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
+    ruby2_keywords (0.0.5)
     rubyzip (3.1.0)
     securerandom (0.4.1)
     selenium-webdriver (4.35.0)
@@ -492,6 +496,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
@@ -518,6 +529,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.4.0)
     thread_safe (0.3.6)
+    tilt (2.6.1)
     timecop (0.9.10)
     timeout (0.4.3)
     ttfunk (1.8.0)
@@ -552,7 +564,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -627,6 +638,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   selenium-webdriver (>= 4.26.0)
+  sinatra (~> 4.0)
   solid_queue (>= 0.3.0)
   sprockets-rails
   stackprof

--- a/app/bin/api-test
+++ b/app/bin/api-test
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/json_api_receiver"
+
+puts "Starting JSON API receiver on port #{ENV.fetch('JSON_API_PORT', 4567)}"
+puts "Ready to receive JSON Push API requests at /"
+puts ""
+
+JsonApiReceiver.run!

--- a/app/lib/json_api_receiver.rb
+++ b/app/lib/json_api_receiver.rb
@@ -1,0 +1,21 @@
+require "sinatra"
+require "json"
+
+class JsonApiReceiver < Sinatra::Base
+  post "/" do
+    content_type :json
+
+    request.body.rewind
+    body = request.body.read
+
+    puts "Received JSON: #{body}"
+
+    begin
+      JSON.parse(body)
+      { status: "success" }.to_json
+    rescue JSON::ParserError
+      status 400
+      { error: "Invalid JSON" }.to_json
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3381](https://jiraent.cms.gov/browse/FFS-3381).


## Changes
- Add Sinatra to gemfile + dependencies in lockfile
- Super simple receiver that prints out JSON received + a little check to see if it's valid JSON
- Script to startup receiver similar to how we start our app
- README.md update with instructions on how to run

## Context for reviewers
This ticket originally had API key work in it, but that was pulled out into a separate ticket

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)