### PR TITLE
FFS 3356: Set account_count field based only on fully synchronized payroll accounts

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -47,7 +47,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
       cbv_flow_id: cbv_flow.id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,
-      account_count: cbv_flow.payroll_accounts.count,
+      account_count: cbv_flow.fully_synced_payroll_accounts.count,
       paystub_count: payments.count,
       account_count_with_additional_information:
         cbv_flow.additional_information.values.count { |info| info["comment"].present? },

--- a/app/app/models/cbv_flow.rb
+++ b/app/app/models/cbv_flow.rb
@@ -38,6 +38,10 @@ class CbvFlow < ApplicationRecord
     payroll_accounts.any?(&:sync_succeeded?)
   end
 
+  def fully_synced_payroll_accounts
+    payroll_accounts.select { |account| account.has_fully_synced? }
+  end
+
   def to_generic_url(origin: nil)
     client_agency = Rails.application.config.client_agencies[client_agency_id]
     raise ArgumentError.new("Client Agency #{client_agency_id} not found") unless client_agency

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
       expect(fake_event_logger).to have_received(:track)
         .with("ApplicantSharedIncomeSummary", anything, include(
-          cbv_flow_id: cbv_flow.id,
-          flow_started_seconds_ago: 10.minutes.to_i,
+                cbv_flow_id: cbv_flow.id,
+                flow_started_seconds_ago: 10.minutes.to_i,
+                account_count: cbv_flow.fully_synced_payroll_accounts.count
         ))
     end
   end

--- a/app/spec/models/cbv_flow_spec.rb
+++ b/app/spec/models/cbv_flow_spec.rb
@@ -1,7 +1,9 @@
-
 require 'rails_helper'
 
 RSpec.describe CbvFlow, type: :model do
+  let(:cbv_flow) { create(:cbv_flow, client_agency_id: client_agency_id) }
+  let(:client_agency_id) { "sandbox" }
+
   describe ".create_from_invitation" do
     let(:cbv_flow_invitation) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "ABC1234" }) }
 
@@ -15,11 +17,7 @@ RSpec.describe CbvFlow, type: :model do
   end
 
   describe "#to_generic_url" do
-    let(:cbv_flow) { create(:cbv_flow, client_agency_id: client_agency_id) }
-
     context "with valid client agency ID" do
-      let(:client_agency_id) { "sandbox" }
-
       context "in production environment" do
         before do
           stub_client_agency_config_value("sandbox", "agency_domain", "sandbox.reportmyincome.org")
@@ -59,8 +57,6 @@ RSpec.describe CbvFlow, type: :model do
     end
 
     context "with missing host configuration" do
-      let(:client_agency_id) { "sandbox" }
-
       before do
         stub_client_agency_config_value("sandbox", "agency_domain", nil)
       end
@@ -74,6 +70,25 @@ RSpec.describe CbvFlow, type: :model do
         expected_url = "http://localhost/en/cbv/links/sandbox?origin=shared"
         expect(cbv_flow.to_generic_url(origin: "shared")).to eq(expected_url)
       end
+    end
+  end
+
+  describe "#fully_synced_payroll_accounts" do
+    let(:payroll_accounts) do
+      [
+        build(:payroll_account),
+        build(:payroll_account, :pinwheel_fully_synced),
+        build(:payroll_account, :argyle_sync_in_progress),
+        build(:payroll_account, :argyle_fully_synced)
+      ]
+    end
+    it "returns only those payroll accounts that have fully synced" do
+      allow(cbv_flow).to receive(:payroll_accounts).and_return(payroll_accounts)
+
+      result = cbv_flow.fully_synced_payroll_accounts
+
+      expect(result).to all(be_has_fully_synced)
+      expect(result).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-3356](https://jiraent.cms.gov/browse/FFS-3356).


## Changes
<!-- What was added, updated, or removed in this PR. -->

Creates a new `#fully_synced_payroll_accounts` method on the `CbvFlow` model which filters `#payroll_accounts` based on their `#has_fully_synced?` property.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

The case_worker_transmitter_job task triggers a ApplicantSharedIncomeSummary event, which includes an `account_count` property. This property had been set by the count of all payroll accounts associated with the current `CbvFlow`;however, that left an edge case where a user might start to add an account, but fail to finish (by not being able to authenticate completely or similar). These partial accounts were counted.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change is verified by two unit tests: 1) asserts that the new CbvFlow method correctly filters payroll accounts, 2) asserts that the account_count value is set from the new method
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
