### PR TITLE
FFS-3380: Add signature verification to JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To run database migrations on the test environment that is used by rpec tests, r
 
 ### JSON API Receiver (for testing)
 
-To test the JSON Push API integration, you can run a simple receiver:
+To test the JSON Push API integration, you can run the receiver:
 
 ```bash
 cd app
@@ -105,6 +105,8 @@ bin/api-test
 ```
 
 This starts a test server on port 4567 that logs incoming JSON data.
+
+**For e2e testing:** Run `rails db:seed` to create the matching API key in your database for the transmitter.
 
 ## Branching model
 When beginning work on a feature, create a new branch based off of `main` and make the commits for that feature there.

--- a/app/app/services/json_api_signature.rb
+++ b/app/app/services/json_api_signature.rb
@@ -1,0 +1,17 @@
+require "openssl"
+
+class JsonApiSignature
+  def self.generate(body, timestamp, api_key)
+    payload = "#{timestamp}:#{body}"
+    OpenSSL::HMAC.hexdigest(
+      OpenSSL::Digest.new("sha512"),
+      api_key.encode("utf-8"),
+      payload
+    )
+  end
+
+  def self.verify(body, timestamp, signature, api_key)
+    expected_signature = generate(body, timestamp, api_key)
+    ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
+  end
+end

--- a/app/app/services/json_api_signature.rb
+++ b/app/app/services/json_api_signature.rb
@@ -1,4 +1,5 @@
 require "openssl"
+require "active_support/security_utils"
 
 class JsonApiSignature
   def self.generate(body, timestamp, api_key)

--- a/app/app/services/transmitters/json_transmitter.rb
+++ b/app/app/services/transmitters/json_transmitter.rb
@@ -13,6 +13,10 @@ class Transmitters::JsonTransmitter
       agency_partner_metadata: agency_partner_metadata
     }.to_json
 
+    timestamp = Time.now.to_i.to_s
+    req["X-IVAAS-Timestamp"] = timestamp
+    req["X-IVAAS-Signature"] = JsonApiSignature.generate(req.body, timestamp, get_api_key_for_agency)
+
     res = Net::HTTP.start(api_url.hostname, api_url.port, use_ssl: api_url.scheme == "https") do |http|
       http.request(req)
     end
@@ -25,5 +29,27 @@ class Transmitters::JsonTransmitter
     else
       raise "Unexpected response from agency: #{res.code} #{res.message}"
     end
+  end
+
+  private
+
+  def get_api_key_for_agency
+    user = User.find_by(client_agency_id: @current_agency.id, is_service_account: true)
+    unless user
+      Rails.logger.error "No service account found for agency #{@current_agency.id}"
+      raise "No service account found for agency #{@current_agency.id}"
+    end
+
+    oldest_token = user.api_access_tokens
+      .where(deleted_at: nil)
+      .order(:created_at)
+      .first
+
+    unless oldest_token
+      Rails.logger.error "No active API key found for agency #{@current_agency.id}"
+      raise "No active API key found for agency #{@current_agency.id}"
+    end
+
+    oldest_token.access_token
   end
 end

--- a/app/app/services/transmitters/json_transmitter.rb
+++ b/app/app/services/transmitters/json_transmitter.rb
@@ -15,7 +15,7 @@ class Transmitters::JsonTransmitter
 
     timestamp = Time.now.to_i.to_s
     req["X-IVAAS-Timestamp"] = timestamp
-    req["X-IVAAS-Signature"] = JsonApiSignature.generate(req.body, timestamp, get_api_key_for_agency)
+    req["X-IVAAS-Signature"] = JsonApiSignature.generate(req.body, timestamp, api_key_for_agency)
 
     res = Net::HTTP.start(api_url.hostname, api_url.port, use_ssl: api_url.scheme == "https") do |http|
       http.request(req)
@@ -33,7 +33,7 @@ class Transmitters::JsonTransmitter
 
   private
 
-  def get_api_key_for_agency
+  def api_key_for_agency
     user = User.find_by(client_agency_id: @current_agency.id, is_service_account: true)
     unless user
       Rails.logger.error "No service account found for agency #{@current_agency.id}"

--- a/app/db/seeds.rb
+++ b/app/db/seeds.rb
@@ -1,7 +1,16 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+
+# Create test API key for JSON API receiver
+user = User.find_or_create_by(
+  client_agency_id: "sandbox",
+  is_service_account: true,
+  email: "ffs-eng+sandbox@navapbc.com"
+)
+
+unless user.api_access_tokens.exists?(access_token: "test-api-key")
+  token = user.api_access_tokens.build
+  token.access_token = "test-api-key"
+  token.save!
+  puts "Created test API key: test-api-key"
+end

--- a/app/lib/json_api_receiver.rb
+++ b/app/lib/json_api_receiver.rb
@@ -1,14 +1,30 @@
 require "sinatra"
 require "json"
+require_relative "../config/environment"
+require_relative "../app/services/json_api_signature"
 
 class JsonApiReceiver < Sinatra::Base
+  # For the reference implementation, we'll use a simple test key
+  API_KEY = "test-api-key"
+
   post "/" do
     content_type :json
 
     request.body.rewind
     body = request.body.read
+    signature = request.env["HTTP_X_IVAAS_SIGNATURE"]
+    timestamp = request.env["HTTP_X_IVAAS_TIMESTAMP"]
 
     puts "Received JSON: #{body}"
+
+    if signature && timestamp
+      unless JsonApiSignature.verify(body, timestamp, signature, API_KEY)
+        puts "❌ Invalid signature"
+        status 401
+        return { error: "Unauthorized" }.to_json
+      end
+      puts "✅ Verified signature"
+    end
 
     begin
       JSON.parse(body)
@@ -18,4 +34,6 @@ class JsonApiReceiver < Sinatra::Base
       { error: "Invalid JSON" }.to_json
     end
   end
+
+  run! if __FILE__ == $0
 end

--- a/app/spec/services/json_api_signature_spec.rb
+++ b/app/spec/services/json_api_signature_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe JsonApiSignature do
+  let(:body) { '{"test":"data"}' }
+  let(:timestamp) { "1640995200" }
+  let(:api_key) { "test-api-key" }
+
+  describe '.generate' do
+    it 'generates a valid HMAC sha512 signature' do
+      signature = described_class.generate(body, timestamp, api_key)
+
+      # sha512 hex is always 128 characters...
+      expect(signature.length).to eq(128)
+    end
+
+    it 'generates the same signature from the same inputs' do
+      signature1 = described_class.generate(body, timestamp, api_key)
+      signature2 = described_class.generate(body, timestamp, api_key)
+
+      expect(signature1).to eq(signature2)
+    end
+
+    it 'generates different signatures for different inputs' do
+      signature1 = described_class.generate(body, timestamp, api_key)
+      signature2 = described_class.generate(body, "different_timestamp", api_key)
+
+      expect(signature1).not_to eq(signature2)
+    end
+  end
+
+  describe '.verify' do
+    it 'returns true for valid signatures' do
+      signature = described_class.generate(body, timestamp, api_key)
+
+      expect(described_class.verify(body, timestamp, signature, api_key)).to be true
+    end
+
+    it 'returns false for invalid signatures' do
+      expect(described_class.verify(body, timestamp, "invalid-signature", api_key)).to be false
+    end
+
+    it 'returns false when body is different' do
+      signature = described_class.generate(body, timestamp, api_key)
+
+      expect(described_class.verify("different body", timestamp, signature, api_key)).to be false
+    end
+  end
+end

--- a/app/spec/services/json_api_signature_spec.rb
+++ b/app/spec/services/json_api_signature_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe JsonApiSignature do
 
       # sha512 hex is always 128 characters...
       expect(signature.length).to eq(128)
+      expect(signature).to eq(<<~VALID.strip)
+        de6af505fb38013fa776708265d21b988e4df27a99f10534ec78301e8e280eb460cbdd2309a55c30c062493e13be8d037b065c9294fd3ab5a18d8c0d9cacd765
+      VALID
     end
 
     it 'generates the same signature from the same inputs' do

--- a/app/spec/services/transmitters/json_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_transmitter_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Transmitters::JsonTransmitter do
   completed_at = Time.find_zone("UTC").local(2025, 5, 1, 1)
-
   let(:cbv_applicant) { create(:cbv_applicant, case_number: "ABC1234") }
   let(:cbv_flow) do
     create(:cbv_flow,
@@ -24,6 +23,9 @@ RSpec.describe Transmitters::JsonTransmitter do
     days_to_fetch_for_w2: 90,
     days_to_fetch_for_gig: 90
   ) }
+
+  let!(:service_user) { create(:user, client_agency_id: "sandbox", is_service_account: true) }
+  let!(:api_token) { create(:api_access_token, user: service_user) }
 
   before do
     allow(mock_client_agency).to receive(:transmission_method_configuration).and_return(transmission_method_configuration)
@@ -51,6 +53,29 @@ RSpec.describe Transmitters::JsonTransmitter do
     it 'raises an HTTP error' do
       VCR.use_cassette("json_transmitter_418") do
         expect { described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver }.to raise_error("Unexpected response from agency: 418 I'm a teapot")
+      end
+    end
+  end
+
+  context 'signature generation' do
+    it 'generates and sends signature headers' do
+      expect(JsonApiSignature).to receive(:generate).and_return("mock-signature")
+
+      VCR.use_cassette("json_transmitter_200") do
+        described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver
+      end
+    end
+
+    context 'with multiple API keys' do
+      let!(:older_token) { create(:api_access_token, user: service_user, created_at: 2.days.ago) }
+      let!(:newer_token) { create(:api_access_token, user: service_user, created_at: 1.day.ago) }
+
+      it 'uses the oldest active API key' do
+        expect(JsonApiSignature).to receive(:generate).with(anything, anything, older_token.access_token).and_return("mock-signature")
+
+        VCR.use_cassette("json_transmitter_200") do
+          described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver
+        end
       end
     end
   end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3380](https://jiraent.cms.gov/browse/FFS-3380).


## Changes
- Added HMAC sha512 request signature to JSON transmitter
- API key lookup (oldest active for an agency)
- Updated Sinatra receiver to optionally verify signatures
- `JsonApiSignature` util

## Context for reviewers
### How to test locally in your terminal

**Start the test receiver**
```bash
bin/api-test
```

**No signature**
```bash
curl -X POST http://localhost:4567/ \
  -H "Content-Type: application/json" \
  -d '{"test":"data"}'
```

**Invalid signature**
```bash
curl -X POST http://localhost:4567/ \
  -H "Content-Type: application/json" \
  -H "X-IVAAS-Timestamp: 1640995200" \
  -H "X-IVAAS-Signature: super-invalid-signature" \
  -d '{"test":"data"}'
```

**Valid signature**
```bash
ruby -r './app/services/json_api_signature' -e 'puts JsonApiSignature.generate("{\"test\":\"data\"}", "1640995200", "test-api-key")'

curl -X POST http://localhost:4567/ \
  -H "Content-Type: application/json" \
  -H "X-IVAAS-Timestamp: 1640995200" \
  -H "X-IVAAS-Signature: <insert signature here>" \
  -d '{"test":"data"}'
```

**Output**
<img width="703" height="381" alt="Screenshot 2025-09-29 at 2 49 38 PM" src="https://github.com/user-attachments/assets/29241b77-c89e-4655-af8b-459dc9c90d24" />

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)