### PR TITLE
FFS-3419: Allow all Tokenized Links to be reused, including in LA

### DIFF
--- a/app/app/controllers/cbv/base_controller.rb
+++ b/app/app/controllers/cbv/base_controller.rb
@@ -19,15 +19,6 @@ class Cbv::BaseController < ApplicationController
         return redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
       end
 
-      # using invitation.client_agency_id directly instead of current_agency
-      # because cbv_flow isn't created yet at this point
-      client_agency = agency_config[invitation.client_agency_id]
-      unless client_agency.allow_invitation_reuse
-        if invitation.complete?
-          return redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
-        end
-      end
-
       @cbv_flow = CbvFlow.create_from_invitation(invitation)
       session[:cbv_flow_id] = @cbv_flow.id
       cookies.permanent.encrypted[:cbv_applicant_id] = @cbv_flow.cbv_applicant_id

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -28,7 +28,6 @@
     w2: 90
     gig: 182
   invitation_valid_days: 10
-  allow_invitation_reuse: true
   logo_path: des_logo.png
   weekly_report:
     recipient: <%= ENV['AZ_DES_WEEKLY_REPORT_RECIPIENTS'] %>
@@ -93,7 +92,6 @@
     w2: 90
     gig: 90
   invitation_valid_days: 14
-  allow_invitation_reuse: true
   weekly_report:
     recipient: ffs-eng@navapbc.com
   applicant_attributes:

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -55,7 +55,6 @@ class ClientAgencyConfig
       transmission_method_configuration
       weekly_report
       applicant_attributes
-      allow_invitation_reuse
       generic_links_disabled
     ])
 
@@ -80,7 +79,6 @@ class ClientAgencyConfig
       @sso = yaml["sso"]
       @weekly_report = yaml["weekly_report"]
       @applicant_attributes = yaml["applicant_attributes"] || {}
-      @allow_invitation_reuse = yaml["allow_invitation_reuse"] || false
       @generic_links_disabled = yaml["generic_links_disabled"]
 
       raise ArgumentError.new("Client Agency missing id") if @id.blank?

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -162,38 +162,15 @@ RSpec.describe Cbv::EntriesController do
             )
           end
 
-          context "when an agency doesn't allow invitation reuse" do
-            before do
-              allow_any_instance_of(ClientAgencyConfig::ClientAgency)
-                .to receive(:allow_invitation_reuse)
-                .and_return(false)
-            end
+          it "creates a new CbvFlow object" do
+            expect { get :show, params: { token: invitation.auth_token } }
+              .to change { session[:cbv_flow_id] }
+                .from(nil)
+                .to(be_an(Integer))
+              .and change(CbvFlow, :count).by(1)
 
-            it "redirects to the expired invitation URL" do
-              expect { get :show, params: { token: invitation.auth_token } }
-                .not_to change { session[:cbv_flow_id] }
-
-              expect(response).to redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
-            end
-          end
-
-          context "when an agency allows invitation reuse" do
-            before do
-              allow_any_instance_of(ClientAgencyConfig::ClientAgency)
-                .to receive(:allow_invitation_reuse)
-                .and_return(true)
-            end
-
-            it "creates a new CbvFlow object" do
-              expect { get :show, params: { token: invitation.auth_token } }
-                .to change { session[:cbv_flow_id] }
-                  .from(nil)
-                  .to(be_an(Integer))
-                .and change(CbvFlow, :count).by(1)
-
-              expect(assigns(:cbv_flow)).to be_present
-              expect(assigns(:cbv_flow).cbv_flow_invitation).to eq(invitation)
-            end
+            expect(assigns(:cbv_flow)).to be_present
+            expect(assigns(:cbv_flow).cbv_flow_invitation).to eq(invitation)
           end
         end
       end


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

Resolves [FFS-3419](https://jiraent.cms.gov/browse/FFS-3419).


## Changes
<!-- What was added, updated, or removed in this PR. -->
**Always allow invitation reuse**
> We had a setting, allow_invitation_reuse, which would enable a tokenized
> link to be reused. We recently forgot to set this value to true for LA,
> since we've updated our product thinking such that this behavior is the
> default.

> As such, let's simplify the logic here so that these links can always be
> reused.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
I am not quite sure we want to do this from a product perspective. I will verify that as part of acceptance testing.


## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)