### PR TITLE
Fix flaky test in submits controller spec

### DIFF
--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Cbv::SubmitsController do
       context "for Tim (a gig worker with two gigs)" do
         let(:cbv_applicant) { create(:cbv_applicant, created_at: current_time, case_number: "ABC1234") }
         let(:account_id) { "019571bc-2f60-3955-d972-dbadfe0913a8" }
-        let(:account_id_2) { "2" }
+        let(:account_id_2) { "22222222-2222-2222-2222-222222222222" }
         let(:supported_jobs) { %w[accounts identity paystubs employment] }
         let(:errored_jobs) { [] }
         let(:cbv_flow) do
@@ -403,7 +403,7 @@ RSpec.describe Cbv::SubmitsController do
       context "for Kim (a w2 worker with two w2s)" do
         let(:cbv_applicant) { create(:cbv_applicant, created_at: current_time, case_number: "ABC1234") }
         let(:account_id) { "01956d5f-cb8d-af2f-9232-38bce8531f58" }
-        let(:account_id_2) { "2" }
+        let(:account_id_2) { "22222222-2222-2222-2222-222222222222" }
         let(:supported_jobs) { %w[accounts identity paystubs employment income] }
         let(:errored_jobs) { [] }
         let(:cbv_flow) do

--- a/app/spec/support/fixtures/argyle/kim/request_identity.json
+++ b/app/spec/support/fixtures/argyle/kim/request_identity.json
@@ -47,7 +47,7 @@
         },
         {
             "id": "fabbdb07-7e6b-3cfd-b952-571ba55f083a",
-            "account": "2",
+            "account": "22222222-2222-2222-2222-222222222222",
             "address": {
                 "city": "New York",
                 "line1": "250 Vesey Street",

--- a/app/spec/support/fixtures/argyle/tim/request_gigs.json
+++ b/app/spec/support/fixtures/argyle/tim/request_gigs.json
@@ -3122,7 +3122,7 @@
     },
     {
       "id": "0f017ed4-1cd1-33f0-a87d-dda5f46afb99",
-      "account": "2",
+      "account": "22222222-2222-2222-2222-222222222222",
       "employer": "Uber Driver",
       "created_at": "2025-03-07T17:52:09.361Z",
       "updated_at": "2025-03-07T17:52:09.361Z",

--- a/app/spec/support/fixtures/argyle/tim/request_identity.json
+++ b/app/spec/support/fixtures/argyle/tim/request_identity.json
@@ -47,7 +47,7 @@
         },
         {
             "id": "408c332f-cc7b-327e-b3a4-0a46de8429ab",
-            "account": "2",
+            "account": "22222222-2222-2222-2222-222222222222",
             "address": {
                 "city": "New York",
                 "line1": "759 Victoria Plaza",


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A


## Changes
<!-- What was added, updated, or removed in this PR. -->


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This test was flaky because the account ID being unusually short
resulted in the request stub (`argyle_stub_request_account_response`)
not successfully stubbing the `/account/<id>` API request. This caused VCR
to raise an exception, which caused the report fetching to fail when the
shorter account_id was fetched.

This worked most of the time, because the longer account_id was usually
fetched first. But since we freeze time, sometimes,
nondeterministically, the shorter account_id was fetched first, causing
the report fetching to crash and leave the data fetched empty.

Anyway, the fix is simple: use UUIDs of the proper format so that
regardless of which account is fetched first, it returns the same data.


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
