### PR TITLE
FFS-3400: Add ability to configure additional headers for JsonTransmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,24 @@ To run locally, use `bin/dev`
 
 To run database migrations on the test environment that is used by rpec tests, run `RAILS_ENV=test bin/rails db:schema:load`
 
-### JSON API Receiver (for testing)
+### JSON API Testing
 
-To test the JSON Push API integration, you can run the receiver:
+1. **Create an API key for the agency you want to test:**
+   ```bash
+   cd app
+   rails 'users:create_api_token[agency_name]'
+   ```
 
-```bash
-cd app
-bin/api-test
-```
+2. **Run the test receiver:**
+   ```bash
+   # For sandbox (default)
+   bin/api-test
 
-This starts a test server on port 4567 that logs incoming JSON data.
+   # For a different agency
+   JSON_API_AGENCY=agency_name bin/api-test
+   ```
 
-**For e2e testing:** Run `rails db:seed` to create the matching API key in your database for the transmitter.
+This starts a test server on port 4567 that logs incoming JSON data and verifies signatures.
 
 ## Branching model
 When beginning work on a feature, create a new branch based off of `main` and make the commits for that feature there.

--- a/app/app/models/user.rb
+++ b/app/app/models/user.rb
@@ -11,4 +11,16 @@ class User < ApplicationRecord
 
     token_user if token_user && token_user.is_service_account
   end
+
+  def self.api_key_for_agency(agency_id)
+    user = find_by(client_agency_id: agency_id, is_service_account: true)
+    return nil unless user
+
+    oldest_token = user.api_access_tokens
+      .where(deleted_at: nil)
+      .order(:created_at)
+      .first
+
+    oldest_token&.access_token
+  end
 end

--- a/app/db/seeds.rb
+++ b/app/db/seeds.rb
@@ -1,16 +1,7 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-
-# Create test API key for JSON API receiver
-user = User.find_or_create_by(
-  client_agency_id: "sandbox",
-  is_service_account: true,
-  email: "ffs-eng+sandbox@navapbc.com"
-)
-
-unless user.api_access_tokens.exists?(access_token: "test-api-key")
-  token = user.api_access_tokens.build
-  token.access_token = "test-api-key"
-  token.save!
-  puts "Created test API key: test-api-key"
-end
+#
+# Examples:
+#
+#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
+#   Character.create(name: "Luke", movie: movies.first)

--- a/app/spec/services/transmitters/json_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_transmitter_spec.rb
@@ -79,4 +79,23 @@ RSpec.describe Transmitters::JsonTransmitter do
       end
     end
   end
+
+  context 'custom headers' do
+    let(:transmission_method_configuration) { {
+      "url" => "http://fake-state.api.gov/api/v1/income-report",
+      "custom_headers" => {
+        "X-Client-ID" => "test-client-id",
+        "X-Request-ID" => "test-request-id"
+      }
+    } }
+
+    it 'sends configured custom headers' do
+      stub = stub_request(:post, "http://fake-state.api.gov/api/v1/income-report")
+        .with(headers: { 'X-Client-ID' => 'test-client-id', 'X-Request-ID' => 'test-request-id' })
+        .to_return(status: 200, body: '{"status": "success"}')
+
+      expect(described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver).to eq("ok")
+      expect(stub).to have_been_requested
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

Resolves [FFS-3400](https://jiraent.cms.gov/browse/FFS-3400).


## Changes
- Custom headers support via client-agency-config.yml
- Transmitter applies custom headers
- Update reference receiver to log all headers
- Fix end-to-end testing with API key, update documentation

## Context for reviewers
### End-to-end Testing
```yml
# In client-agency-config.yml for whatever agency
  transmission_method: json
  transmission_method_configuration:
    url: http://localhost:4567
    custom_headers:
      X-Client-ID: test-client-id
      X-Request-ID: test-request-id
      X-Pizza-Topping: peperony-and-chease
      X-Debug-Mode: totally-on
```
 
```bash
# For sandbox
rails 'users:create_api_token[sandbox]'
bin/api-test
# Complete CBV flow in browser, check receiver console for custom headers and ✅ signature
```

```bash
# For other agency
rails 'users:create_api_token[agency_name]'
JSON_API_AGENCY=agency_name bin/api-test
# Complete CBV flow via LA LDH domain, check for different custom headers
# Complete CBV flow in browser, check receiver console for custom headers and ✅ signature
```

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
<img width="1508" height="383" alt="Screenshot 2025-10-01 at 12 31 16 PM" src="https://github.com/user-attachments/assets/f6266c05-6ac4-4a50-b8f7-ce5f149b2f4e" />
<img width="1508" height="310" alt="Screenshot 2025-10-01 at 12 54 13 PM" src="https://github.com/user-attachments/assets/bb10cb7c-0f2b-4836-a9c8-f2d82b9e7b0a" />


