### PR TITLE
Fix bin/run-command not actually running in intended environment

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -15,7 +15,7 @@
 #   app_name (required) - the name of subdirectory of /infra that holds the
 #     application's infrastructure code.
 #   environment (required) - the name of the application environment (e.g. dev,
-#     staging, prod)
+#     demo, prod)
 #   command (required) - a JSON list representing the command to run
 #     e.g. To run the command `db-migrate-up` with no arguments, set
 #     command='["db-migrate-up"]'
@@ -37,6 +37,14 @@ while :; do
       task_role_arn="$2"
       shift 2
       ;;
+    --help)
+      echo "Usage: $0 [app_name] [environment] [command]"
+      echo "  --environment_variables   - JSON list of environment variables"
+      echo "  --task_role_arn           - IAM role ARN that teh task should assume"
+      echo
+      echo "Example: $0 app prod '[\"echo\", \"Hello, world\"]'"
+      exit 0
+      ;;
     *)
       break
       ;;
@@ -57,6 +65,9 @@ echo "  command=${command}"
 echo "  environment_variables=${environment_variables:-}"
 echo "  task_role_arn=${task_role_arn:-}"
 echo
+
+# Initialize terraform and select workspace if specified
+./bin/terraform-init "infra/${app_name}/service" "${environment}"
 
 # Use the same cluster, task definition, and network configuration that the application service uses
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## Ticket

N/A


## Changes
<!-- What was added, updated, or removed in this PR. -->

The `bin/run-command` script didn't previously actually use the
"environment" argument, it just ran in whatever environment was last
initialized(!!) This was fixed upstream in [this commit][1]. This commit
backports it and adds a help menu to the options parsing as well, just
for fun.

[1]: https://github.com/navapbc/template-infra/commit/5cc1f4d326de530a72b8a967d6d3ab9649ca1c2b


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->


## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
