### PR TITLE
Re-implement bin/current-region

### DIFF
--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,15 @@
 #!/bin/bash
 # Print the current AWS region
 set -euo pipefail
-echo -n "$(aws configure list | grep region | awk '{print $2}')"
+
+result="$(aws configure get region)"
+
+if [ -z "${result}" ] ; then
+    result="${AWS_REGION}"
+fi
+
+if [ -z "${result}" ] ; then
+    result="${AWS_DEFAULT_REGION}"
+fi
+
+echo -n "${result}"


### PR DESCRIPTION
`aws configure` supports getting a specific value, so there's no need to do any scripting magic to parse the string output. For me, the awk command was grabbing the table delimiter ':' instead of the real value which caused some other scripts to break.

This change uses `aws configure get region` to get the specific region for the current profile, but then falls back on AWS_REGION and AWS_DEFAULT_REGION if there is nothing set for the current profile.

