### PR TITLE
FFS-3376: Add safe navigation operator to event logging code

### DIFF
--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -63,7 +63,7 @@ class Cbv::GenericLinksController < Cbv::BaseController
   def track_generic_link_clicked_event(cbv_flow, is_new_session)
     # Skip tracking this event for a specific user agent, since we tend
     # to get a ton of traffic from it during LA SMS sends
-    return if request.user_agent.match?(/go-http-client/i)
+    return if request.user_agent&.match?(/go-http-client/i)
 
     event_logger.track(TrackEvent::ApplicantClickedGenericLink, request, {
       time: Time.now.to_i,

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Cbv::GenericLinksController do
           )
         end
 
+        context "when the User Agent is nil" do
+          let(:headers) { { "User-Agent" => nil } }
+
+          it "tracks the ApplicantClickedGenericLink event" do
+            expect(EventTrackingJob).to have_received(:perform_later)
+              .with("ApplicantClickedGenericLink", anything, anything)
+          end
+        end
+
         context "when the User Agent is Go-Http-Client" do
           let(:headers) { { "User-Agent" => "Go-http-client/1.1" } }
 


### PR DESCRIPTION
## Ticket

Resolves [FFS-3376](https://jiraent.cms.gov/browse/FFS-3376).

## Changes
- Add safe navigator as requested + test that fails and duplicates error before passing

## Context for reviewers
<img width="1504" height="267" alt="Screenshot 2025-10-03 at 1 08 09 PM" src="https://github.com/user-attachments/assets/abaa9d63-010a-4bf3-a2ee-68ae7ac351fc" />

## Acceptance testing
<!-- Check one: -->

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)