### PR TITLE
FFS-3409: make 10 character invite link tokens

### DIFF
--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -65,7 +65,7 @@ class CbvFlowInvitation < ApplicationRecord
     }
     url_params[:origin] = origin if origin.present?
 
-    Rails.application.routes.url_helpers.cbv_flow_entry_url(url_params.compact)
+    Rails.application.routes.url_helpers.start_flow_url(url_params.compact)
   end
 
   def normalize_language

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -16,7 +16,7 @@ class CbvFlowInvitation < ApplicationRecord
   belongs_to :cbv_applicant, optional: true
   has_many :cbv_flows
 
-  has_secure_token :auth_token, length: 36
+  has_secure_token :auth_token, length: 10
 
   accepts_nested_attributes_for :cbv_applicant
 

--- a/app/config/initializers/active_record/secure_token.rb
+++ b/app/config/initializers/active_record/secure_token.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module SecureToken
+    MINIMUM_TOKEN_LENGTH = 10
+  end
+end

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
     # RFI (mail) origin tracking route for LA
     get "/start", to: "pages#home", defaults: { origin: "mail" }
+    get "/start/:token", to: "cbv/entries#show", defaults: { origin: "mail" }
 
     scope "/cbv", as: :cbv_flow, module: :cbv do
       resource :entry, only: %i[show create]

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
     # RFI (mail) origin tracking route for LA
     get "/start", to: "pages#home", defaults: { origin: "mail" }
-    get "/start/:token", to: "cbv/entries#show", defaults: { origin: "mail" }
+    get "/start/:token", to: "cbv/entries#show", defaults: { origin: "mail" }, as: :start_flow
 
     scope "/cbv", as: :cbv_flow, module: :cbv do
       resource :entry, only: %i[show create]


### PR DESCRIPTION
## [FFS-3409](https://jiraent.cms.gov/browse/FFS-3409)


## Changes
Before, invitation link tokens were always 36 characters. Now, they are 10 characters, but old links should still work.


## Context for reviewers
We want to shorten these tokens so that printed invites (such as the ones LA is about to mail out) are less onerous to type in. Tom did some research and showed that 10 characters should still represent about 430 quadrillion token possibilities, so we are comforted that this is still secure enough.


## Testing instructions
### How to generate an invitation
1. Generate a local api token
```
cd app && bin/rails c
user = User.create!(email: 'service_account1@example.com', is_service_account: true, client_agency_id: 'sandbox')
token = user.api_access_tokens.create!
api_token = token.access_token
```
2. Use it to generate an invitation
```
curl --location 'http://localhost:3000/api/v1/invitations' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <api token here>' \
--header 'Cookie: __profilin=p%3Dt' \
--data-raw '{
    "client_agency_id" : "sandbox",
    "agency_partner_metadata": {
        "first_name" : "Jom",
        "last_name" : "Doe",
        "snap_application_date": "2025-03-05"
    },
    "email_address": "applicant+test@navapbc.com",
    "language": "en"
}'
```

### Test 10-character links
1. Generate an invitation
2. In rails console, retrieve the link: `CbvFlowInvitation.last().to_url()`
3. It should generate the new /en/start/<token> style link, and the token should be 10 characters
4. Follow the link
5. It should start a flow as you would expect
6. Open Mixpanel and observe the ApplicantClickedCBVInvitationLink event you just generated. Make sure that the origin is set to "mail"

### Test 36 character links are still valid
1. In /models/cbv_flow_invitation.rb, modify this line so that the tokens are now 36 characters again: `has_secure_token :auth_token, length: 10`
2. Restart your server
3. Generate a new invitation with the instructions above
4. The token should now be 36 characters, not 10
5. Follow the link. It should still work.

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->

  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
