### PR TITLE
FFS-3413: Add safety guard to all generic link entry paths

### DIFF
--- a/app/app/controllers/cbv/generic_links_controller.rb
+++ b/app/app/controllers/cbv/generic_links_controller.rb
@@ -2,6 +2,7 @@ class Cbv::GenericLinksController < Cbv::BaseController
   skip_before_action :set_cbv_flow, :capture_page_view
   before_action :ensure_valid_client_agency_id
   before_action :check_if_pilot_ended_for_agency
+  before_action :redirect_if_generic_links_disabled
 
   def show
     @cbv_flow, is_new_session = find_or_create_cbv_flow
@@ -24,6 +25,13 @@ class Cbv::GenericLinksController < Cbv::BaseController
   def check_if_pilot_ended_for_agency
     agency = agency_config[params[:client_agency_id]]
     if agency&.pilot_ended
+      redirect_to root_url
+    end
+  end
+
+  def redirect_if_generic_links_disabled
+    agency = agency_config[params[:client_agency_id]]
+    if agency&.generic_links_disabled
       redirect_to root_url
     end
   end

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe Cbv::GenericLinksController do
   end
   describe '#show' do
     context 'when the hostname matches a client agency domain and the pilot is active' do
+      before do
+        stub_client_agency_config_value("sandbox", "generic_links_disabled", false)
+        stub_client_agency_config_value("sandbox", "pilot_ended", false)
+      end
+
+      context 'when generic links are disabled for the agency' do
+        before do
+          stub_client_agency_config_value("sandbox", "generic_links_disabled", true)
+        end
+
+        it 'redirects to the root path' do
+          get :show, params: { client_agency_id: "sandbox" }
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
       context 'when no existing CBV applicant cookie exists' do
         let(:headers) { {} }
         before do


### PR DESCRIPTION
## Ticket

Resolves [FFS-3413](https://jiraent.cms.gov/browse/FFS-3413).


## Changes
Implemented same guard that existed in pages controller for generic links controller + test.

## Context for reviewers
To test this locally, set `generic_links_disabled: true` for sandbox then visit the generic links url: http://localhost:3000/cbv/links/sandbox

## Acceptance testing
<!-- Check one: -->

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)