### PR TITLE
FFS-4040: Configure custom SFTP PDF filenames

### DIFF
--- a/app/app/services/transmitters/pdf_filename_formatter.rb
+++ b/app/app/services/transmitters/pdf_filename_formatter.rb
@@ -1,0 +1,21 @@
+class Transmitters::PdfFilenameFormatter
+  def self.format(cbv_flow, format_string)
+    format_string % format_values(cbv_flow)
+  rescue KeyError => e
+    raise ArgumentError, "Invalid pdf filename format placeholder: #{e.key}"
+  end
+
+  def self.format_values(cbv_flow)
+    {
+      confirmation_code: cbv_flow.confirmation_code,
+      consent_date: cbv_flow.consented_to_authorized_use_at.strftime("%Y%m%d"),
+      consent_timestamp: cbv_flow.consented_to_authorized_use_at.strftime("%Y%m%d%H%M%S")
+    }.merge(applicant_attribute_values(cbv_flow))
+  end
+
+  def self.applicant_attribute_values(cbv_flow)
+    cbv_flow.cbv_applicant.applicant_attributes.each_with_object({}) do |attribute, values|
+      values[attribute] = cbv_flow.cbv_applicant.public_send(attribute)
+    end
+  end
+end

--- a/app/app/services/transmitters/sftp_transmitter.rb
+++ b/app/app/services/transmitters/sftp_transmitter.rb
@@ -1,5 +1,7 @@
 class Transmitters::SftpTransmitter < Transmitters::BasePdfTransmitter
   TRANSMISSION_METHOD = "sftp"
+  DEFAULT_PDF_FILENAME_FORMAT = "CBVPilot_%{consent_date}_Conf%{confirmation_code}"
+
   def deliver
     config = current_agency.transmission_method_configuration.with_indifferent_access
     sftp_gateway = SftpGateway.new(config)
@@ -10,10 +12,11 @@ class Transmitters::SftpTransmitter < Transmitters::BasePdfTransmitter
   private
 
   def pdf_filename(cbv_flow)
-    [
-      "CBVPilot",
-      cbv_flow.consented_to_authorized_use_at.strftime("%Y%m%d"),
-      "Conf#{cbv_flow.confirmation_code}"
-    ].join("_")
+    Transmitters::PdfFilenameFormatter.format(cbv_flow, pdf_filename_format)
+  end
+
+  def pdf_filename_format
+    current_agency.transmission_method_configuration.with_indifferent_access[:pdf_filename_format].presence ||
+      DEFAULT_PDF_FILENAME_FORMAT
   end
 end

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -53,6 +53,7 @@
     private_key: <%= ENV['NH_DHHS_SFTP_PRIVATE_KEY'].inspect %>
     url: <%= ENV['NH_DHHS_SFTP_URL'] %>
     sftp_directory: <%= ENV['NH_DHHS_SFTP_DIRECTORY'] %>
+    pdf_filename_format: CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}
   staff_portal_enabled: true
   pilot_ended: false
   sso:

--- a/app/spec/services/transmitters/pdf_filename_formatter_spec.rb
+++ b/app/spec/services/transmitters/pdf_filename_formatter_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Transmitters::PdfFilenameFormatter do
+  describe ".format" do
+    let(:cbv_applicant) do
+      instance_double(
+        CbvApplicant,
+        applicant_attributes: [ :case_number ],
+        case_number: "ABC1234"
+      )
+    end
+
+    let(:cbv_flow) do
+      instance_double(
+        CbvFlow,
+        confirmation_code: "SANDBOX001",
+        consented_to_authorized_use_at: Time.zone.parse("2025-01-01 08:00:30"),
+        cbv_applicant: cbv_applicant
+      )
+    end
+
+    it "injects the confirmation code" do
+      expect(described_class.format(cbv_flow, "Conf%{confirmation_code}"))
+        .to eq("ConfSANDBOX001")
+    end
+
+    it "injects the consent date" do
+      expect(described_class.format(cbv_flow, "CBVPilot_%{consent_date}"))
+        .to eq("CBVPilot_20250101")
+    end
+
+    it "injects applicant attributes referenced by name" do
+      expect(described_class.format(cbv_flow, "Case_%{case_number}"))
+        .to eq("Case_ABC1234")
+    end
+
+    it "formats the target sftp filename pattern" do
+      expect(described_class.format(cbv_flow, "CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}.pdf"))
+        .to eq("CBV_ABC1234_20250101080030_SANDBOX001.pdf")
+    end
+  end
+end

--- a/app/spec/services/transmitters/sftp_transmitter_spec.rb
+++ b/app/spec/services/transmitters/sftp_transmitter_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Transmitters::SftpTransmitter do
   let(:cbv_flow) { create(:cbv_flow) }
   let(:aggregator_report) { build(:argyle_report, :with_argyle_account) }
   let(:sftp_gateway) { instance_double(SftpGateway, upload_data: true) }
+  let(:formatted_filename) { "formatted_filename" }
 
   before do
     allow(client_agency).to receive_messages(
@@ -25,9 +26,28 @@ RSpec.describe Transmitters::SftpTransmitter do
       transmission_method: described_class::TRANSMISSION_METHOD
     )
     allow(SftpGateway).to receive(:new).and_return(sftp_gateway)
+    allow(Transmitters::PdfFilenameFormatter).to receive(:format).and_return(formatted_filename)
   end
 
   it_behaves_like "Transmitters::BasePdfTransmitter"
+
+  describe "#pdf_filename_format" do
+    subject(:pdf_filename_format) { transmitter.send(:pdf_filename_format) }
+
+    it "returns the default format when no custom format is configured" do
+      expect(pdf_filename_format).to eq(described_class::DEFAULT_PDF_FILENAME_FORMAT)
+    end
+
+    context "when a custom pdf filename format is configured" do
+      let(:transmission_method_configuration) do
+        super().merge("pdf_filename_format" => "CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}.pdf")
+      end
+
+      it "returns the configured format" do
+        expect(pdf_filename_format).to eq("CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}.pdf")
+      end
+    end
+  end
 
   describe "#deliver" do
     include_context "with #pdf_output" do
@@ -48,6 +68,26 @@ RSpec.describe Transmitters::SftpTransmitter do
       )
     end
 
+    context "when a custom pdf filename format is configured" do
+      let(:transmission_method_configuration) do
+        super().merge("pdf_filename_format" => "chosen_format")
+      end
+
+      it "passes the selected format to PdfFilenameFormatter" do
+        expect(Transmitters::PdfFilenameFormatter).to receive(:format).with(
+          cbv_flow,
+          "chosen_format"
+        ).and_return(formatted_filename)
+
+        expect(sftp_gateway).to receive(:upload_data).with(
+          an_instance_of(StringIO),
+          "test/formatted_filename.pdf"
+        )
+
+        transmitter.deliver
+      end
+    end
+
     context "when the agency uses username and password authentication" do
       it "passes the password-based config through to the gateway" do
         expect(SftpGateway).to receive(:new).with(
@@ -61,7 +101,7 @@ RSpec.describe Transmitters::SftpTransmitter do
 
         expect(sftp_gateway).to receive(:upload_data).with(
           an_instance_of(StringIO),
-          "test/CBVPilot_20250101_ConfSANDBOX001.pdf"
+          "test/formatted_filename.pdf"
         )
 
         transmitter.deliver
@@ -90,7 +130,7 @@ RSpec.describe Transmitters::SftpTransmitter do
 
         expect(sftp_gateway).to receive(:upload_data).with(
           an_instance_of(StringIO),
-          "test/CBVPilot_20250101_ConfSANDBOX001.pdf"
+          "test/formatted_filename.pdf"
         )
 
         transmitter.deliver


### PR DESCRIPTION
## [FFS-4040](https://jiraent.cms.gov/browse/FFS-4040)

## Changes
- add a PDF filename formatter for SFTP filename templates
- update the SFTP transmitter to choose either a configured filename format or the default format
- configure `nh_dhhs` to use `CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}` for transmitted PDFs
- add specs for the formatter and for the SFTP transmitter's interaction with it

## Context for reviewers
- the default SFTP filename format still produces the existing `CBVPilot_YYYYMMDD_ConfCONFIRMATIONCODE` filename
- applicant placeholders such as `%{case_number}` are resolved dynamically from the applicant attributes configured for the agency
- tests were not run in Codex for this PR; they were left for local verification in the developer shell

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->
  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in demo after merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

**Risk / Downtime:**
- Low risk. This changes the generated SFTP filename and only uses a custom format for `nh_dhhs`; other SFTP clients continue using the default format.