### PR TITLE
FFS-3980: Limit NH DHHS transmission concurrency to 1

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -3,6 +3,17 @@ class CaseWorkerTransmitterJob < ApplicationJob
 
   queue_as :default
 
+  limits_concurrency to: 1,
+    key: ->(flow_id) {
+      flow = CbvFlow.find(flow_id)
+      if flow.cbv_applicant.client_agency_id == "nh_dhhs"
+        flow.cbv_applicant.client_agency_id
+      else
+        flow_id
+      end
+    },
+    duration: 2.minutes
+
   def perform(cbv_flow_id)
     @cbv_flow = CbvFlow.find(cbv_flow_id)
     @current_agency = current_agency(@cbv_flow)

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
     end
   end
 
+  describe "concurrency key" do
+    let(:transmission_method) { "shared_email" }
+
+    context "for NH DHHS cbv_flows" do
+      let(:nh_dhhs_applicant) { create(:cbv_applicant, client_agency_id: "nh_dhhs", case_number: "NH123456") }
+      let(:nh_dhhs_flow) { create(:cbv_flow, cbv_applicant: nh_dhhs_applicant) }
+      let(:another_nh_dhhs_flow) { create(:cbv_flow, cbv_applicant: create(:cbv_applicant, client_agency_id: "nh_dhhs", case_number: "NH654321")) }
+
+      it "returns the same fixed key to serialize transmissions" do
+        job = described_class.new.tap { |j| j.arguments = [ nh_dhhs_flow.id ] }
+        another_job = described_class.new.tap { |j| j.arguments = [ another_nh_dhhs_flow.id ] }
+        expect(job.concurrency_key).to eq(another_job.concurrency_key)
+        expect(job.concurrency_key).to include("nh_dhhs")
+      end
+    end
+
+    context "for non-NH cbv_flows" do
+      let(:sandbox_flow) { create(:cbv_flow, cbv_applicant: create(:cbv_applicant, client_agency_id: "sandbox")) }
+      let(:another_sandbox_flow) { create(:cbv_flow, cbv_applicant: create(:cbv_applicant, client_agency_id: "sandbox")) }
+
+      it "returns distinct keys so they are not subject to the concurrency limit" do
+        job = described_class.new.tap { |j| j.arguments = [ sandbox_flow.id ] }
+        another_job = described_class.new.tap { |j| j.arguments = [ another_sandbox_flow.id ] }
+        expect(job.concurrency_key).not_to eq(another_job.concurrency_key)
+      end
+    end
+  end
+
   describe "#perform" do
     let(:argyle_report) { build(:argyle_report, :with_argyle_account) }
 


### PR DESCRIPTION
## [FFS-3980](https://jiraent.cms.gov/browse/FFS-3980)

## Changes
Send 1 NH application at a time

## Context for reviewers
- The `duration` setting is for If a job crashes due to worker process failure (like during a deploy) SolidQueue forcibly expires a job after 2 minutes/

## Acceptance testing
- [x] Acceptance testing locally

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->