### PR TITLE
FFS-3919: Implement layout and content changes on the activity hub page

### DIFF
--- a/app/app/assets/stylesheets/activity_hub.scss
+++ b/app/app/assets/stylesheets/activity_hub.scss
@@ -23,26 +23,8 @@
   }
 }
 
-.activity-hub-submit-button {
-  width: 100%;
-  margin-top: units(3);
-}
-
 .activity-hub-subheading {
   margin: units(1) 0 0;
-}
-
-.activity-hub-subheading--reporting-period {
-  margin-top: units(2);
-}
-
-.activity-hub-info-link {
-  @include u-font("sans", "sm");
-
-  color: color("primary");
-  margin: units(2) 0 0;
-  text-align: center;
-  text-decoration: underline;
 }
 
 .activity-hub-columns__activities {

--- a/app/app/assets/stylesheets/activity_hub.scss
+++ b/app/app/assets/stylesheets/activity_hub.scss
@@ -23,6 +23,28 @@
   }
 }
 
+.activity-hub-submit-button {
+  width: 100%;
+  margin-top: units(3);
+}
+
+.activity-hub-subheading {
+  margin: units(1) 0 0;
+}
+
+.activity-hub-subheading--reporting-period {
+  margin-top: units(2);
+}
+
+.activity-hub-info-link {
+  @include u-font("sans", "sm");
+
+  color: color("primary");
+  margin: units(2) 0 0;
+  text-align: center;
+  text-decoration: underline;
+}
+
 .activity-hub-columns__activities {
   @include at-media("tablet") {
     flex: 1;
@@ -30,16 +52,6 @@
     margin-left: units(8);
     border-left: 1px solid color("base-lighter");
     padding-left: units(8);
-  }
-}
-
-// Mobile-only horizontal divider between progress and cards
-.activity-hub-mobile-divider {
-  border: none;
-  border-top: 1px solid color("base-lighter");
-
-  @include at-media("tablet") {
-    display: none;
   }
 }
 

--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -54,6 +54,8 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
 
   def renewal? = @renewal
 
+  def renewal_requires_subset_months? = renewal? && required_month_count < total_month_count
+
   def reporting_window_start_month = ordered_monthly_calculation_results.first&.month
 
   def reporting_window_end_month = ordered_monthly_calculation_results.last&.month

--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -1,16 +1,22 @@
 class ActivityFlowProgressIndicator < ViewComponent::Base
-  def self.from_calculator(progress_calculator, agency_full_name, variant: :standard, required_month_count: nil)
+  def self.from_calculator(
+    progress_calculator,
+    variant: :application,
+    required_month_count: nil
+  )
     new(
       monthly_calculation_results: progress_calculator.monthly_results,
-      agency_full_name: agency_full_name,
       variant: variant,
       required_month_count: required_month_count
     )
   end
 
-  def initialize(monthly_calculation_results:, agency_full_name:, variant: :standard, required_month_count: nil)
+  def initialize(
+    monthly_calculation_results:,
+    variant: :application,
+    required_month_count: nil
+  )
     @monthly_calculation_results = monthly_calculation_results
-    @agency_full_name = agency_full_name
     @renewal = variant.to_s == "renewal"
     @required_month_count = normalize_required_month_count(required_month_count)
   end
@@ -53,7 +59,7 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
   def reporting_window_end_month = ordered_monthly_calculation_results.last&.month
 
   private
-  attr_reader :monthly_calculation_results, :agency_full_name, :required_month_count
+  attr_reader :monthly_calculation_results, :required_month_count
 
   def normalize_required_month_count(required_month_count)
     requested_count = required_month_count || monthly_calculation_results.length

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -22,7 +22,7 @@
         <% end %>
       </h2>
 
-      <% if renewal? %>
+      <% if renewal_requires_subset_months? %>
         <p class="activity-flow-progress-indicator__description">
           <% if reporting_window_start_month && reporting_window_end_month %>
             <%= t(

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -9,18 +9,21 @@
             </svg>
           <% end %>
           <%= t(".renewal_months_completed", complete: complete_month_count, required: required_month_count) %>
-        <% elsif complete? %>
-          <%= t(".title_complete") %>
         <% elsif multi_month? %>
-          <%= t(".title_multi_month") %>
+          <% if complete? %>
+            <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+              <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+            </svg>
+          <% end %>
+          <%= t(".application_months_completed", complete: complete_month_count, total: total_month_count) %>
         <% else %>
           <% first_month = ordered_monthly_calculation_results.first.month %>
           <%= t(".title", month: l(first_month, format: :month)) %>
         <% end %>
       </h2>
 
-      <p class="activity-flow-progress-indicator__description">
-        <% if renewal? %>
+      <% if renewal? %>
+        <p class="activity-flow-progress-indicator__description">
           <% if reporting_window_start_month && reporting_window_end_month %>
             <%= t(
               ".renewal_subtitle",
@@ -31,21 +34,6 @@
           <% else %>
             <%= t(".renewal_subtitle_no_range", required: required_month_count) %>
           <% end %>
-        <% elsif complete? %>
-          <%= t(".description_complete", agency_full_name: agency_full_name) %>
-        <% else %>
-          <%= t(".description") %>
-        <% end %>
-      </p>
-
-      <% if multi_month? && !renewal? %>
-        <p class="activity-flow-progress-indicator__months-completed">
-          <% if complete? %>
-            <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-            </svg>
-          <% end %>
-          <%= t(".months_completed_html", complete: complete_month_count, total: total_month_count) %>
         </p>
       <% end %>
 

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
@@ -1,7 +1,7 @@
 @forward "uswds";
 @use "uswds" as *;
 
-.activity-flow-progress-indicator__card {
+.usa-card.activity-flow-progress-indicator__card {
   margin: units(2) 0 0;
   padding-left: 0;
   padding-right: 0;
@@ -49,6 +49,10 @@
   height: units(2);
   width: 100%;
 
+  &:first-of-type {
+    margin-top: units(3);
+  }
+
   &--complete {
     border-color: color("success-dark");
     background-color: color("success-dark");
@@ -72,6 +76,10 @@
   justify-content: space-between;
   line-height: 1.5;
   margin: units(1) 0 units(2);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 .activity-flow-progress-indicator__progress-amount {

--- a/app/app/helpers/activities_helper.rb
+++ b/app/app/helpers/activities_helper.rb
@@ -1,6 +1,28 @@
 module ActivitiesHelper
-  def display_progress_indicator?(progress_calculator)
-    progress_calculator.overall_result.total_hours > 0
+  def activity_hub_state(any_activities_added:, monthly_results:)
+    return :empty unless any_activities_added
+
+    monthly_results.all?(&:meets_requirements) ? :completed : :in_progress
+  end
+
+  def activity_hub_title_key(state)
+    case state
+    when :empty
+      "activities.hub.empty_state_title"
+    when :completed
+      "activities.hub.completed_state_title"
+    else
+      "activities.hub.in_progress_state_title"
+    end
+  end
+
+  def activity_hub_description_key(state)
+    case state
+    when :completed
+      "activities.hub.completed_state_description"
+    else
+      "activities.hub.in_progress_state_description"
+    end
   end
 
   def employment_cards(payroll_accounts, aggregator_report, reporting_range)

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -96,6 +96,10 @@ class ActivityFlow < Flow
     true
   end
 
+  def renewal_reporting_window?
+    reporting_window_type == "renewal"
+  end
+
   private
 
   def set_default_reporting_window
@@ -103,7 +107,7 @@ class ActivityFlow < Flow
   end
 
   def calculate_reporting_window_months
-    return 6 if reporting_window_type == "renewal"
+    return 6 if renewal_reporting_window?
 
     client_agency = Rails.application.config.client_agencies[cbv_applicant&.client_agency_id]
     client_agency&.application_reporting_months || 1

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -9,6 +9,8 @@
 <%# i18n-tasks-use t("activities.hub.in_progress_state_title") %>
 <%# i18n-tasks-use t("activities.hub.completed_state_description", agency_name: "Test Agency") %>
 <%# i18n-tasks-use t("activities.hub.in_progress_state_description", agency_name: "Test Agency") %>
+<%# i18n-tasks-use t("activities.hub.empty_state_months_required_any", required_month_count: 3) %>
+<%# i18n-tasks-use t("activities.hub.empty_state_months_required_all", required_month_count: 6) %>
 
 <% content_for :title, t(title_key) %>
 
@@ -19,15 +21,16 @@
     </h1>
 
     <% if state == :empty %>
-      <p class="activity-hub-subheading activity-hub-subheading--reporting-period">
+      <p class="activity-hub-subheading margin-top-2">
         <strong><%= t("activities.hub.empty_state_reporting_period_label") %></strong>
         <%= @flow.reporting_window_display %>
       </p>
 
       <% if variant == :renewal %>
+        <% months_required_key = monthly_results.length < @flow.reporting_window_months ? "activities.hub.empty_state_months_required_any" : "activities.hub.empty_state_months_required_all" %>
         <p class="activity-hub-subheading">
           <strong><%= t("activities.hub.empty_state_months_required_label") %></strong>
-          <%= t("activities.hub.empty_state_months_required", required_month_count: monthly_results.length) %>
+          <%= t(months_required_key, required_month_count: monthly_results.length) %>
         </p>
       <% end %>
 
@@ -48,10 +51,10 @@
         )
       ) %>
 
-      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button activity-hub-submit-button", method: :get %>
+      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button width-full margin-top-3", method: :get %>
 
       <% if state == :in_progress %>
-        <p class="activity-hub-info-link">
+        <p class="margin-top-2 text-center text-primary font-sans-sm text-underline">
           <%= t("activities.hub.verification_info_link") %>
         </p>
       <% end %>

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -1,21 +1,62 @@
-<% content_for :title, t("activities.hub.title") %>
+<% any_activities_added = @flow.any_activities_added? %>
+<% monthly_results = progress_calculator.monthly_results %>
+<% state = activity_hub_state(any_activities_added:, monthly_results:) %>
+<% variant = @flow.renewal_reporting_window? ? :renewal : :application %>
+<% title_key = activity_hub_title_key(state) %>
+<% description_key = activity_hub_description_key(state) %>
+<%# i18n-tasks-use t("activities.hub.empty_state_title") %>
+<%# i18n-tasks-use t("activities.hub.completed_state_title") %>
+<%# i18n-tasks-use t("activities.hub.in_progress_state_title") %>
+<%# i18n-tasks-use t("activities.hub.completed_state_description", agency_name: "Test Agency") %>
+<%# i18n-tasks-use t("activities.hub.in_progress_state_description", agency_name: "Test Agency") %>
 
-<h1>
-  <%= t("activities.hub.title") %>
-</h1>
-<p>
-  <%= t("activities.hub.description_html", reporting_window: @flow.reporting_window_display) %>
-</p>
+<% content_for :title, t(title_key) %>
 
 <div class="activity-hub-columns">
   <div class="activity-hub-columns__progress">
-    <%= render(ActivityFlowProgressIndicator.from_calculator(progress_calculator, agency_translation("shared.agency_full_name"))) %>
+    <h1>
+      <%= t(title_key) %>
+    </h1>
 
-    <% if @flow.any_activities_added? %>
-      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button margin-top-3", method: :get %>
+    <% if state == :empty %>
+      <p class="activity-hub-subheading activity-hub-subheading--reporting-period">
+        <strong><%= t("activities.hub.empty_state_reporting_period_label") %></strong>
+        <%= @flow.reporting_window_display %>
+      </p>
+
+      <% if variant == :renewal %>
+        <p class="activity-hub-subheading">
+          <strong><%= t("activities.hub.empty_state_months_required_label") %></strong>
+          <%= t("activities.hub.empty_state_months_required", required_month_count: monthly_results.length) %>
+        </p>
+      <% end %>
+
+      <p class="activity-hub-subheading">
+        <%= t("activities.hub.empty_state_description", reporting_window: @flow.reporting_window_display) %>
+      </p>
+    <% else %>
+      <p class="activity-hub-subheading">
+        <%= t(description_key, agency_name: agency_translation("shared.agency_full_name")) %>
+      </p>
     <% end %>
 
-    <hr class="margin-y-4 activity-hub-mobile-divider">
+    <% if any_activities_added %>
+      <%= render(
+        ActivityFlowProgressIndicator.from_calculator(
+          progress_calculator,
+          variant: variant
+        )
+      ) %>
+
+      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button activity-hub-submit-button", method: :get %>
+
+      <% if state == :in_progress %>
+        <p class="activity-hub-info-link">
+          <%= t("activities.hub.verification_info_link") %>
+        </p>
+      <% end %>
+    <% end %>
+
   </div>
   <div class="activity-hub-columns__activities">
     <% if activity_type_enabled?(:employment) %>

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -38,20 +38,22 @@
         <%= t("activities.hub.empty_state_description", reporting_window: @flow.reporting_window_display) %>
       </p>
     <% else %>
-      <p class="activity-hub-subheading">
+      <p class="activity-hub-subheading margin-top-2">
         <%= t(description_key, agency_name: agency_translation("shared.agency_full_name")) %>
       </p>
     <% end %>
 
     <% if any_activities_added %>
-      <%= render(
-        ActivityFlowProgressIndicator.from_calculator(
-          progress_calculator,
-          variant: variant
-        )
-      ) %>
+      <div class="margin-top-4">
+        <%= render(
+          ActivityFlowProgressIndicator.from_calculator(
+            progress_calculator,
+            variant: variant
+          )
+        ) %>
+      </div>
 
-      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button width-full margin-top-3", method: :get %>
+      <%= button_to t("activities.hub.review_and_submit"), next_path, class: "btn btn-primary usa-button width-full margin-top-4", method: :get %>
 
       <% if state == :in_progress %>
         <p class="margin-top-2 text-center text-primary font-sans-sm text-underline">

--- a/app/app/views/activities/summary/show.html.erb
+++ b/app/app/views/activities/summary/show.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 </p>
 
-<%= render(ActivityFlowProgressIndicator.from_calculator(progress_calculator, agency_translation("shared.agency_full_name"))) %>
+<%= render(ActivityFlowProgressIndicator.from_calculator(progress_calculator)) %>
 
 <hr class="border-gray-30 border-top-0 margin-bottom-4">
 

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -326,7 +326,8 @@ en:
         employment: No employment added
         work_programs: No work programs added
       empty_state_description: Add employment, education, community service, or work program activities you've done between %{reporting_window}.
-      empty_state_months_required: any %{required_month_count} months in the reporting period
+      empty_state_months_required_all: all %{required_month_count} months in the reporting period
+      empty_state_months_required_any: any %{required_month_count} months in the reporting period
       empty_state_months_required_label: 'Months required:'
       empty_state_reporting_period_label: 'Reporting period:'
       empty_state_title: Build your community engagement report

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -317,17 +317,25 @@ en:
         hours: 'Community engagement hours: %{count}'
         no_employment_data: No payments found from this employer.
         not_enrolled: Not enrolled
-      description_html: "<strong>Reporting period:</strong> %{reporting_window}"
+      completed_state_description: "%{agency_name} will determine your eligibility based on the activities you've added to your report."
+      completed_state_title: You're ready to review and submit your report
       edit: Edit
       empty:
         community_service: No community service added
         education: No education added
         employment: No employment added
         work_programs: No work programs added
+      empty_state_description: Add employment, education, community service, or work program activities you've done between %{reporting_window}.
+      empty_state_months_required: any %{required_month_count} months in the reporting period
+      empty_state_months_required_label: 'Months required:'
+      empty_state_reporting_period_label: 'Reporting period:'
+      empty_state_title: Build your community engagement report
+      in_progress_state_description: "%{agency_name} will determine your eligibility based on the activities you add to your report."
+      in_progress_state_title: Add more activities or continue to review and submit your report
       reporting_window: 'Reporting window: %{range}'
       review_and_submit: Review and Submit
       save: Save changes
-      title: Add activities to your community engagement report
+      verification_info_link: What if I can't meet the requirements?
     income:
       employer_searches:
         employer:
@@ -520,16 +528,12 @@ en:
       title: Work programs
       title_singular: Work Program
   activity_flow_progress_indicator:
-    description: We calculate your community engagement from the activities you add to your report.
-    description_complete: "%{agency_full_name} will determine your final eligibility based on the activities you’ve added to your report."
+    application_months_completed: "%{complete}/%{total} months completed"
     hours: hours
-    months_completed_html: "<strong>%{complete}</strong> / <strong>%{total}</strong> months completed"
     renewal_months_completed: "%{complete}/%{required} months completed"
     renewal_subtitle: Complete any %{required} months between %{start_month}-%{end_month} to meet requirements.
     renewal_subtitle_no_range: Complete any %{required} months to meet requirements.
     title: Your %{month} progress
-    title_complete: You're ready to review and submit your report
-    title_multi_month: Your progress
   aggregator_strings:
     deductions:
       401k: 401k

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   subject(:component) do
     described_class.new(
       monthly_calculation_results: monthly_calculation_results,
-      agency_full_name: "Test Agency",
       variant: variant,
       required_month_count: required_month_count
     )
@@ -22,7 +21,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   end
   let(:monthly_calculation_results) { [ monthly_result ] }
   let(:hours) { 40 }
-  let(:variant) { :standard }
+  let(:variant) { :application }
   let(:required_month_count) { nil }
   let(:expected_title) do
     I18n.t(
@@ -31,11 +30,11 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     )
   end
 
-  it "renders the title and description" do
+  it "renders the title without description for application variants" do
     render_inline(component)
 
     expect(page).to have_css("h2", text: expected_title)
-    expect(page).to have_content(I18n.t("activity_flow_progress_indicator.description"))
+    expect(page).not_to have_css(".activity-flow-progress-indicator__description")
   end
 
   it "renders inside a card component" do
@@ -81,13 +80,6 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
 
       expect(page).to have_css(".activity-flow-progress-indicator__success-icon")
     end
-
-    it "renders the 'completed' copy variants for header and description" do
-      render_inline(component)
-
-      expect(page).to have_text(I18n.t("activity_flow_progress_indicator.title_complete"))
-      expect(page).to have_text(I18n.t("activity_flow_progress_indicator.description_complete", agency_full_name: "Test Agency"))
-    end
   end
 
   it "renders whole hours without decimals" do
@@ -115,11 +107,11 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   context "when variant is unsupported" do
     let(:variant) { :future_variant }
 
-    it "falls back to standard rendering" do
+    it "falls back to application rendering" do
       render_inline(component)
 
       expect(page).to have_css("h2", text: expected_title)
-      expect(page).to have_content(I18n.t("activity_flow_progress_indicator.description"))
+      expect(page).not_to have_css(".activity-flow-progress-indicator__description")
     end
   end
 
@@ -163,7 +155,8 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "includes a 'months completed' message" do
       render_inline(component)
 
-      expect(page).to have_css(".activity-flow-progress-indicator", text: "1 / 3 months completed")
+      expect(page).to have_css("h2", text: "1/3 months completed")
+      expect(page).not_to have_css(".activity-flow-progress-indicator__months-completed")
     end
   end
 
@@ -214,6 +207,12 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       )
     end
 
+    it "shows a success icon in the header when renewal requirements are complete" do
+      render_inline(component)
+
+      expect(page).to have_css("h2 .activity-flow-progress-indicator__success-icon")
+    end
+
     it "renders renewal months oldest to newest" do
       render_inline(component)
 
@@ -222,19 +221,6 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         .map { |row| row.find("span", match: :first).text.strip }
 
       expect(month_labels).to eq([ "August", "September", "October", "November", "December", "January" ])
-    end
-
-    it "does not render the default completed copy variants" do
-      render_inline(component)
-
-      expect(page).not_to have_text(I18n.t("activity_flow_progress_indicator.title_complete"))
-      expect(page).not_to have_text(I18n.t("activity_flow_progress_indicator.description_complete", agency_full_name: "Test Agency"))
-    end
-
-    it "does not render the multi-month completion banner copy" do
-      render_inline(component)
-
-      expect(page).not_to have_text("1 / 3 months completed")
     end
 
     context "when completed months are below the required count" do
@@ -277,6 +263,19 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         render_inline(component)
 
         expect(page).to have_css("h2", text: "2/3 months completed")
+      end
+    end
+
+    context "when required_month_count is omitted" do
+      let(:required_month_count) { nil }
+
+      it "defaults required_month_count to the reporting window length" do
+        render_inline(component)
+
+        expect(page).to have_css("h2", text: "4/6 months completed")
+        expect(page).to have_text(
+          "Complete any 6 months between August-January to meet requirements."
+        )
       end
     end
   end

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -273,9 +273,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         render_inline(component)
 
         expect(page).to have_css("h2", text: "4/6 months completed")
-        expect(page).to have_text(
-          "Complete any 6 months between August-January to meet requirements."
-        )
+        expect(page).not_to have_css(".activity-flow-progress-indicator__description")
       end
     end
   end

--- a/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
+++ b/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
@@ -6,7 +6,6 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     result = make_result(Date.new(2026, 1, 1), hours.to_f)
 
     render ActivityFlowProgressIndicator.new(
-      agency_full_name: "Test Agency",
       monthly_calculation_results: [ result ]
     )
   end
@@ -24,7 +23,6 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results << make_result(Date.new(2025, 10, 1), month_4_hours) if num_months.to_i > 3
 
     render ActivityFlowProgressIndicator.new(
-      agency_full_name: "Test Agency",
       monthly_calculation_results: results
     )
   end
@@ -35,7 +33,6 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results << make_result(Date.new(2025, 12, 1), 91)
 
     render ActivityFlowProgressIndicator.new(
-      agency_full_name: "Test Agency",
       monthly_calculation_results: results
     )
   end
@@ -51,7 +48,6 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results << make_result(Date.new(2025, 8, 1), 0)
 
     render ActivityFlowProgressIndicator.new(
-      agency_full_name: "Test Agency",
       monthly_calculation_results: results,
       variant: :renewal,
       required_month_count: required_months.to_i
@@ -69,7 +65,6 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results << make_result(Date.new(2025, 8, 1), 93)
 
     render ActivityFlowProgressIndicator.new(
-      agency_full_name: "Test Agency",
       monthly_calculation_results: results,
       variant: :renewal,
       required_month_count: required_months.to_i
@@ -82,7 +77,7 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     ActivityFlowProgressCalculator::MonthlyResult.new(
       month: month,
       total_hours: hours.to_f,
-      meets_requirements: hours.to_f > ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+      meets_requirements: hours.to_f >= ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
     )
   end
 end

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
     it "renders the progress indicator when hours exist" do
       expect(response.body).to include("activity-flow-progress-indicator")
     end
+
+    it "shows in progress hub heading and description" do
+      expect(response.body).to include(I18n.t("activities.hub.in_progress_state_title"))
+      expect(response.body).to include(
+        I18n.t(
+          "activities.hub.in_progress_state_description",
+          agency_name: "Test Agency"
+        )
+      )
+    end
+
+    it "does not render progress indicator description copy for application variant" do
+      expect(response.body).not_to include("activity-flow-progress-indicator__description")
+    end
+
+    it "uses months completed in the indicator title for multi-month application progress" do
+      rendered = Capybara.string(response.body)
+      indicator_title = rendered.find(".activity-flow-progress-indicator__title").text.squish
+
+      expect(indicator_title).to eq("0/2 months completed")
+      expect(rendered).not_to have_css(".activity-flow-progress-indicator__months-completed")
+    end
   end
 
   context "when no activities are added" do
@@ -66,16 +88,26 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(response.body).not_to include(I18n.t("activities.hub.review_and_submit"))
     end
 
-    it "renders the progress indicator even with no hours" do
-      expect(response.body).to include("activity-flow-progress-indicator")
+    it "does not render the progress indicator" do
+      expect(response.body).not_to include("activity-flow-progress-indicator")
+    end
+
+    it "shows empty-state hub heading and description" do
+      page_text = Capybara.string(response.body).text
+
+      expect(page_text).to include(I18n.t("activities.hub.empty_state_title"))
+      expect(page_text).to include(I18n.t("activities.hub.empty_state_reporting_period_label"))
+      expect(page_text).to include(current_flow.reporting_window_display)
+      expect(page_text).to include(
+        I18n.t(
+          "activities.hub.empty_state_description",
+          reporting_window: current_flow.reporting_window_display
+        )
+      )
     end
 
     it "renders the two-column container" do
       expect(response.body).to include("activity-hub-columns")
-    end
-
-    it "does not render the horizontal divider" do
-      expect(response.body).not_to include("activity-hub-divider")
     end
   end
 
@@ -92,6 +124,154 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
     it "does not show empty state for community service and shows review and submit" do
       expect(response.body).not_to include(I18n.t("activities.hub.empty.community_service"))
       expect(response.body).to include(I18n.t("activities.hub.review_and_submit"))
+    end
+
+    it "shows the verification info link in the in-progress state" do
+      page_text = Capybara.string(response.body).text
+      expect(page_text).to include(I18n.t("activities.hub.verification_info_link"))
+    end
+  end
+
+  context "when activity requirements are completed" do
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        reporting_window_months: 1,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      activity = create(:volunteering_activity, activity_flow: current_flow)
+      create(
+        :volunteering_activity_month,
+        volunteering_activity: activity,
+        month: current_flow.reporting_window_range.begin,
+        hours: 90
+      )
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "shows completed hub heading and description and hides the verification info link" do
+      page_text = Capybara.string(response.body).text
+
+      expect(page_text).to include(I18n.t("activities.hub.completed_state_title"))
+      expect(page_text).to include(
+        I18n.t(
+          "activities.hub.completed_state_description",
+          agency_name: "Test Agency"
+        )
+      )
+      expect(page_text).not_to include(I18n.t("activities.hub.verification_info_link"))
+    end
+
+    it "keeps single-month application indicator title in month-progress format" do
+      rendered = Capybara.string(response.body)
+      indicator_title = rendered.find(".activity-flow-progress-indicator__title").text.squish
+
+      expected_month = I18n.l(current_flow.reporting_window_range.begin, format: :month)
+      expect(indicator_title).to eq(I18n.t("activity_flow_progress_indicator.title", month: expected_month))
+    end
+  end
+
+  context "when earnings meet threshold but hours do not" do
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        reporting_window_months: 1,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      employment_activity = create(:employment_activity, activity_flow: current_flow)
+      create(
+        :employment_activity_month,
+        employment_activity: employment_activity,
+        month: current_flow.reporting_window_range.begin,
+        hours: 0,
+        gross_income: 600
+      )
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "keeps the hub in in-progress state to match the progress indicator completion rule" do
+      expect(response.body).to include(I18n.t("activities.hub.in_progress_state_title"))
+      expect(response.body).not_to include(I18n.t("activities.hub.completed_state_title"))
+    end
+  end
+
+  context "when activities are added for a renewal flow" do
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        reporting_window_type: "renewal",
+        reporting_window_months: 6,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      activity = create(:volunteering_activity, activity_flow: current_flow)
+      create(
+        :volunteering_activity_month,
+        volunteering_activity: activity,
+        month: current_flow.reporting_window_range.begin,
+        hours: 20
+      )
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "renders the renewal progress indicator subtitle" do
+      expected_subtitle = I18n.t(
+        "activity_flow_progress_indicator.renewal_subtitle",
+        required: 6,
+        start_month: I18n.l(current_flow.reporting_window_range.begin, format: :month),
+        end_month: I18n.l(current_flow.reporting_window_range.end, format: :month)
+      )
+
+      expect(response.body).to include(expected_subtitle)
+      expect(response.body).to include("activity-flow-progress-indicator__description")
+    end
+  end
+
+  context "when no activities are added for a renewal flow" do
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        reporting_window_type: "renewal",
+        reporting_window_months: 6,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "shows renewal months-required copy in the empty state" do
+      page_text = Capybara.string(response.body).text
+
+      expect(page_text).to include(I18n.t("activities.hub.empty_state_months_required_label"))
+      expect(page_text).to include(
+        I18n.t("activities.hub.empty_state_months_required", required_month_count: 6)
+      )
     end
   end
 

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -234,16 +234,8 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "renders the renewal progress indicator subtitle" do
-      expected_subtitle = I18n.t(
-        "activity_flow_progress_indicator.renewal_subtitle",
-        required: 6,
-        start_month: I18n.l(current_flow.reporting_window_range.begin, format: :month),
-        end_month: I18n.l(current_flow.reporting_window_range.end, format: :month)
-      )
-
-      expect(response.body).to include(expected_subtitle)
-      expect(response.body).to include("activity-flow-progress-indicator__description")
+    it "does not render renewal subtitle when required months equals reporting window" do
+      expect(response.body).not_to include("activity-flow-progress-indicator__description")
     end
   end
 
@@ -270,7 +262,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
 
       expect(page_text).to include(I18n.t("activities.hub.empty_state_months_required_label"))
       expect(page_text).to include(
-        I18n.t("activities.hub.empty_state_months_required", required_month_count: 6)
+        I18n.t("activities.hub.empty_state_months_required_all", required_month_count: 6)
       )
     end
   end

--- a/app/spec/e2e/activity_hub_education_partially_self_attested_review_spec.rb
+++ b/app/spec/e2e/activity_hub_education_partially_self_attested_review_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "e2e Education mixed enrollment review flow", :js, type: :feature
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     # Seed a partially self-attested education activity with mixed enrollments
     flow = ActivityFlow.last
@@ -79,7 +79,7 @@ RSpec.describe "e2e Education mixed enrollment review flow", :js, type: :feature
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     current_flow = ActivityFlow.order(created_at: :desc).first
     education_activity = create(
@@ -110,7 +110,7 @@ RSpec.describe "e2e Education mixed enrollment review flow", :js, type: :feature
     )
 
     visit activities_flow_root_path
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     click_button I18n.t("activities.hub.review_and_submit")
     verify_page(page, title: I18n.t("activities.summary.title", benefit: I18n.t("shared.benefit.sandbox")))
 
@@ -125,7 +125,7 @@ RSpec.describe "e2e Education mixed enrollment review flow", :js, type: :feature
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     flow = ActivityFlow.last
     education_activity = create(
@@ -155,7 +155,7 @@ RSpec.describe "e2e Education mixed enrollment review flow", :js, type: :feature
     )
 
     click_button I18n.t("activities.education.review.save")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_button(I18n.t("activities.hub.review_and_submit"))
   end
 end

--- a/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "e2e Education self-attestation review flow", :js, type: :feature
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     flow = ActivityFlow.last
     month1 = flow.reporting_months.first
@@ -64,7 +64,7 @@ RSpec.describe "e2e Education self-attestation review flow", :js, type: :feature
 
     # --- Step 2: Save and return to the hub ---
     click_button I18n.t("activities.education.review.save")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
 
     # --- Step 3: Edit from the hub card → review (no back button) → edit school info → review ---
     within("[data-activity-type='education']") do
@@ -99,7 +99,7 @@ RSpec.describe "e2e Education self-attestation review flow", :js, type: :feature
     # --- Step 4: Save and return to the hub ---
     click_button I18n.t("activities.hub.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content("Updated University of Illinois")
   end
 end

--- a/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     flow = ActivityFlow.last
     month1 = flow.reporting_months.first
@@ -166,6 +166,6 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
     verify_page(page, title: I18n.t("activities.employment.review.title", employer_name: "Updated Employer"))
     click_button I18n.t("activities.employment.review.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
   end
 end

--- a/app/spec/e2e/activity_hub_spec.rb
+++ b/app/spec/e2e/activity_hub_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
     flow = ActivityFlow.last
 
     # Add a Community Service activity
@@ -57,7 +57,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     expect(page).to have_content "jane@example.com"
     click_button I18n.t("activities.community_service.review.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Helping Hands"
 
     # Add a Work Program activity
@@ -96,7 +96,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     click_button I18n.t("activities.document_uploads.new.continue")
     verify_page(page, title: I18n.t("activities.work_programs.review.title", program_name: "Resume Workshop"))
     click_button I18n.t("activities.work_programs.review.save")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Resume Workshop"
 
     add_self_attested_employment_activity
@@ -107,7 +107,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     expect(page).to have_content I18n.t("activities.hub.cards.hours", count: 40)
 
     # Verify that the hub has the Community Service activity
-    expect(page).to have_content I18n.t("activities.hub.title")
+    expect(page).to have_content I18n.t("activities.hub.in_progress_state_title")
     expect(page).to have_content "Helping Hands"
     expect(page).to have_content I18n.t("activities.hub.cards.hours", count: 20)
     expect(page).to have_content I18n.t("activities.hub.cards.hours", count: 10)
@@ -184,7 +184,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.employment.review.title", employer_name: employer_name))
     click_button I18n.t("activities.employment.review.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
   end
 
 
@@ -195,7 +195,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     # Add an Employment activity
     within("[data-activity-type='employment']") do
@@ -249,7 +249,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     # Add an Education activity
     within("[data-activity-type='education']") do
@@ -264,7 +264,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     expect(page).to have_content I18n.t("activities.education.error.retry_button")
 
     visit activities_flow_root_path
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
     expect(page).to have_content I18n.t("activities.hub.empty.education")
   end
 
@@ -275,14 +275,14 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     current_flow = ActivityFlow.order(created_at: :desc).first
     education_activity = create(:education_activity, activity_flow: current_flow)
     create(:nsc_enrollment_term, education_activity:)
 
     visit activities_flow_root_path
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Test University"
 
     click_button I18n.t("activities.hub.review_and_submit")
@@ -304,7 +304,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     current_flow = ActivityFlow.order(created_at: :desc).first
     education_activity = create(
@@ -322,7 +322,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     )
 
     visit activities_flow_root_path
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Test University"
     expect(page).to have_content(
       I18n.t(
@@ -340,7 +340,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     click_link I18n.t("activities.entries.show.continue")
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
 
     flow = ActivityFlow.last
     month1 = flow.reporting_months.first
@@ -388,7 +388,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.community_service.review.title", organization_name: "Helping Hands"))
     click_button I18n.t("activities.community_service.review.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Helping Hands"
 
     # --- Step 2: Edit the activity from the hub ---
@@ -457,7 +457,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.community_service.review.title", organization_name: "Updated Org"))
     click_button I18n.t("activities.hub.save")
 
-    verify_page(page, title: I18n.t("activities.hub.title"))
+    verify_page(page, title: I18n.t("activities.hub.in_progress_state_title"))
     expect(page).to have_content "Updated Org"
   end
 

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -1,6 +1,68 @@
 require "rails_helper"
 
 RSpec.describe ActivitiesHelper do
+  describe "activity hub display helpers" do
+    describe "#activity_hub_state" do
+      let(:meeting_result) { instance_double(ActivityFlowProgressCalculator::MonthlyResult, meets_requirements: true) }
+      let(:not_meeting_result) { instance_double(ActivityFlowProgressCalculator::MonthlyResult, meets_requirements: false) }
+
+      it "returns empty when no activities are added" do
+        state = helper.activity_hub_state(
+          any_activities_added: false,
+          monthly_results: [ meeting_result ]
+        )
+
+        expect(state).to eq(:empty)
+      end
+
+      it "returns completed when all months meet requirements" do
+        state = helper.activity_hub_state(
+          any_activities_added: true,
+          monthly_results: [ meeting_result, meeting_result ]
+        )
+
+        expect(state).to eq(:completed)
+      end
+
+      it "returns in_progress when any month does not meet requirements" do
+        state = helper.activity_hub_state(
+          any_activities_added: true,
+          monthly_results: [ meeting_result, not_meeting_result ]
+        )
+
+        expect(state).to eq(:in_progress)
+      end
+    end
+
+    describe "#activity_hub_title_key" do
+      it "maps empty state to empty-state title key" do
+        expect(helper.activity_hub_title_key(:empty)).to eq("activities.hub.empty_state_title")
+      end
+
+      it "maps completed state to completed-state title key" do
+        expect(helper.activity_hub_title_key(:completed)).to eq("activities.hub.completed_state_title")
+      end
+
+      it "maps in-progress state to in-progress title key" do
+        expect(helper.activity_hub_title_key(:in_progress)).to eq("activities.hub.in_progress_state_title")
+      end
+    end
+
+    describe "#activity_hub_description_key" do
+      it "maps completed state to completed-state description key" do
+        expect(helper.activity_hub_description_key(:completed)).to eq("activities.hub.completed_state_description")
+      end
+
+      it "maps in-progress state to in-progress description key" do
+        expect(helper.activity_hub_description_key(:in_progress)).to eq("activities.hub.in_progress_state_description")
+      end
+
+      it "maps empty state to in-progress description key" do
+        expect(helper.activity_hub_description_key(:empty)).to eq("activities.hub.in_progress_state_description")
+      end
+    end
+  end
+
   describe "#community_service_cards" do
     let(:flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
     let(:first_month) { flow.reporting_window_range.begin.beginning_of_month }

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe ActivityFlow, type: :model do
     end
   end
 
+  describe "reporting window helpers" do
+    it "returns true for renewal_reporting_window? on renewal flows" do
+      flow = create(:activity_flow, reporting_window_type: "renewal")
+
+      expect(flow.renewal_reporting_window?).to be true
+    end
+
+    it "returns false for renewal_reporting_window? on application flows" do
+      flow = create(:activity_flow, reporting_window_type: "application")
+
+      expect(flow.renewal_reporting_window?).to be false
+    end
+  end
+
   describe "#after_payroll_sync_succeeded" do
     let(:flow) { create(:activity_flow, reporting_window_months: 1) }
     let(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, flow: flow, aggregator_account_id: "acct-1") }


### PR DESCRIPTION
## [FFS-3919](https://jiraent.cms.gov/browse/FFS-3919)

## Changes
- Activity Hub now uses different heading/subheading content for different states: empty, in progress, and completed
- Progress indicator is hidden when no activities exist and shows when activities are present
- Progress indicator variant adjusts according to flow type: application or renewal
- Informational link under the CTA is shown only in the appropriate state
- Hub layout/styling updated to align with the current designs, including full-width submit CTA
- Mobile HR divider was removed since it is (not present in design)
- E2E expectation mismatch in enrollment submission flow was corrected (completed -> in_progress).
- Some test cleanup

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<details>
<summary>Screenshots</summary>

**Empty**
<img width="979" height="662" alt="Screenshot 2026-04-07 at 4 39 58 PM" src="https://github.com/user-attachments/assets/ae1a0a9d-ce86-4d52-8bf0-aef7afba6ada" />
<img width="925" height="645" alt="Screenshot 2026-04-07 at 4 42 01 PM" src="https://github.com/user-attachments/assets/e42ee35d-b934-4183-80b4-5e80d4c30629" />

**In progress**
<img width="917" height="584" alt="Screenshot 2026-04-07 at 4 45 46 PM" src="https://github.com/user-attachments/assets/a58531d0-d53b-4968-bafd-54694a29ff59" />
<img width="903" height="867" alt="Screenshot 2026-04-07 at 4 47 44 PM" src="https://github.com/user-attachments/assets/92247d09-8a5d-4482-b572-7e803a823c54" />

**Complete**
<img width="947" height="517" alt="Screenshot 2026-04-07 at 4 51 22 PM" src="https://github.com/user-attachments/assets/96dd55f6-560b-4eee-83fd-0ae86b26e6aa" />
<img width="932" height="811" alt="Screenshot 2026-04-07 at 4 52 28 PM" src="https://github.com/user-attachments/assets/47b02f8a-835c-4cb1-8af1-aed36afa50ac" />

**Single month**
<img width="341" height="271" alt="Screenshot 2026-04-07 at 5 00 49 PM" src="https://github.com/user-attachments/assets/9103226e-e96d-4c00-b27e-e6482ead9603" />
</details>

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->