### PR TITLE
FFS-3885: Use new tables in activity review, hours, and summaries

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -365,15 +365,144 @@ input#invitation_link {
   background-color: color("gray-cool-10");
 }
 
-.activity-review-hours-table.usa-table--stacked .subheader-row th,
-.activity-review-hours-table.usa-table--stacked tr.subheader-row:nth-child(odd) th {
-  background-color: color("gray-cool-10");
+.activity-review-hours-table {
+  // On narrow viewports (including stacked mobile), fill the container.
+  // At wider breakpoints (min-width: 30em), shrink to content width so
+  // narrow tables don't sprawl across the full page.
+  max-width: 100%;
+  border: units(1px) solid color("ink");
+
+  // Override the default border-top-05 utility on thead (0.25rem !important)
+  // so the outer table border provides the top edge instead
+  thead {
+    border-top: 0 !important;
+  }
 }
 
-// Make sure second col is aligned between both tables on desktop
-.activity-review-hours-table th:not([colspan]),
-.activity-review-hours-table td:first-child {
-  width: 60%;
+.usa-table--borderless.activity-review-hours-table thead th {
+  background-color: color("blue-cool-5");
+  border-bottom: units(1px) solid color("ink");
+}
+
+.activity-review-hours-table.usa-table--stacked .subheader-row th,
+.activity-review-hours-table.usa-table--stacked tr.subheader-row:nth-child(odd) th {
+  background-color: color("blue-cool-5");
+}
+
+// Keep edit column compact in multi-column hours tables
+.activity-review-hours-table td:last-child,
+.activity-review-hours-table th:last-child {
+  white-space: nowrap;
+}
+
+// Stacked layout for activity review tables.
+// USWDS usa-table--stacked activates at max-width: 29.99em (480px).
+// We extend stacking to max-width: 39.99em (640px / tablet) so both
+// table types break to mobile view at the same point.
+// The USWDS stacking rules are re-declared here so they cover 480px–639px;
+// at < 480px they are also applied redundantly (harmless override).
+@media all and (max-width: 39.99em) {
+  // --- USWDS usa-table--stacked rules, scoped to our tables ---
+  .activity-review-hours-table thead,
+  .activity-review-table thead {
+    display: none;
+  }
+
+  .activity-review-hours-table th,
+  .activity-review-table th {
+    background-color: white;
+  }
+
+  .activity-review-hours-table th,
+  .activity-review-hours-table td,
+  .activity-review-table th,
+  .activity-review-table td {
+    border-bottom-width: 0;
+    display: block;
+    width: 100%;
+  }
+
+  .activity-review-hours-table tr,
+  .activity-review-table tr {
+    border-bottom: 0.25rem solid color("ink");
+    border-top-width: 0;
+    width: 100%;
+  }
+
+  .activity-review-hours-table tr th:first-child,
+  .activity-review-hours-table tr td:first-child,
+  .activity-review-table tr th:first-child,
+  .activity-review-table tr td:first-child {
+    border-top-width: 0;
+  }
+
+  .activity-review-hours-table tr:nth-child(odd) td,
+  .activity-review-hours-table tr:nth-child(odd) th,
+  .activity-review-table tr:nth-child(odd) td,
+  .activity-review-table tr:nth-child(odd) th {
+    background-color: inherit;
+  }
+
+  .activity-review-hours-table tr:first-child th:first-child,
+  .activity-review-hours-table tr:first-child td:first-child,
+  .activity-review-table tr:first-child th:first-child,
+  .activity-review-table tr:first-child td:first-child {
+    border-top: 0.25rem solid color("ink");
+  }
+
+  .activity-review-hours-table th[data-label],
+  .activity-review-hours-table td[data-label],
+  .activity-review-table th[data-label],
+  .activity-review-table td[data-label] {
+    padding-bottom: 0.75rem;
+  }
+
+  .activity-review-hours-table th[data-label]::before,
+  .activity-review-hours-table td[data-label]::before,
+  .activity-review-table th[data-label]::before,
+  .activity-review-table td[data-label]::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 700;
+    margin: -0.5rem -1rem 0rem;
+    padding: 0.75rem 1rem 0.25rem;
+  }
+
+  // --- Custom additions for hours tables only ---
+
+  .activity-review-hours-table tbody tr {
+    position: relative;
+  }
+
+  .activity-review-hours-table tbody tr:last-child {
+    border-bottom: 0;
+  }
+
+  .activity-review-hours-table tbody th {
+    font-weight: normal;
+  }
+
+  // Edit column: anchor top-right of the row group
+  .activity-review-hours-table tbody td:last-child {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.75rem 1rem 0;
+    width: auto;
+  }
+}
+
+// On wider screens (≥ tablet / 640px), shrink the table to its content width
+// rather than expanding to fill the full container (which would space out
+// narrow 2- and 3-column tables).
+@media all and (min-width: 40em) {
+  .activity-review-hours-table {
+    max-width: 44rem;
+  }
+}
+
+.activity-review-edit-header {
+  max-width: 44rem;
 }
 
 .activity-review-table {
@@ -382,7 +511,7 @@ input#invitation_link {
 
   @include at-media("tablet") {
     th {
-      width: 50%;
+      width: 40%;
     }
   }
 
@@ -391,12 +520,6 @@ input#invitation_link {
 
     &:last-child {
       border-bottom: none;
-    }
-  }
-
-  @include at-media-max("mobile-lg") {
-    thead {
-      display: none;
     }
   }
 }

--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -395,6 +395,11 @@ input#invitation_link {
   white-space: nowrap;
 }
 
+// Mobile edit link lives inside the th; hidden on desktop where the td column is visible
+.mobile-edit-link {
+  display: none;
+}
+
 // Stacked layout for activity review tables.
 // USWDS usa-table--stacked activates at max-width: 29.99em (480px).
 // We extend stacking to max-width: 39.99em (640px / tablet) so both
@@ -470,10 +475,6 @@ input#invitation_link {
 
   // --- Custom additions for hours tables only ---
 
-  .activity-review-hours-table tbody tr {
-    position: relative;
-  }
-
   .activity-review-hours-table tbody tr:last-child {
     border-bottom: 0;
   }
@@ -482,13 +483,21 @@ input#invitation_link {
     font-weight: normal;
   }
 
-  // Edit column: anchor top-right of the row group
-  .activity-review-hours-table tbody td:last-child {
+  // On mobile, show the edit link inside the th and hide the desktop td column.
+  // Absolutely positioned to sit alongside the ::before label at the top of the cell.
+  .activity-review-hours-table th[data-label] {
+    position: relative;
+  }
+
+  .activity-review-hours-table .mobile-edit-link {
+    display: inline;
     position: absolute;
-    top: 0;
-    right: 0;
-    padding: 0.75rem 1rem 0;
-    width: auto;
+    top: 0.75rem;
+    right: 1rem;
+  }
+
+  .activity-review-hours-table .desktop-edit-link {
+    display: none !important;
   }
 }
 
@@ -499,10 +508,33 @@ input#invitation_link {
   .activity-review-hours-table {
     max-width: 44rem;
   }
+
+  // Lock the Edit column to a consistent width so it aligns with the
+  // Edit link in the .activity-review-edit-header above.
+  .activity-review-hours-table .subheader-row th:last-child,
+  .activity-review-hours-table .desktop-edit-link {
+    width: 5rem;
+  }
 }
 
 .activity-review-edit-header {
   max-width: 44rem;
+  align-items: flex-start;
+}
+
+@media all and (max-width: 39.99em) {
+  .activity-review-edit-header > .usa-link {
+    margin-right: 1rem;
+  }
+}
+
+// On desktop, match the Edit column width from the hours table so the
+// header Edit link aligns with the table Edit column.
+@media all and (min-width: 40em) {
+  .activity-review-edit-header > .usa-link {
+    width: 5rem;
+    padding-left: 1rem;
+  }
 }
 
 .activity-review-table {

--- a/app/app/components/report/gig_monthly_summary_table_component.erb
+++ b/app/app/components/report/gig_monthly_summary_table_component.erb
@@ -7,7 +7,10 @@
         <%= I18n.t("components.report.monthly_summary_table.monthly_summary") %>
       </h2>
     <% end %>
-    <%= render(TableComponent.new(is_responsive: @is_responsive)) do |table| %>
+    <% table_options = @use_activity_style \
+        ? { is_responsive: @is_responsive, class_names: "activity-review-hours-table" } \
+        : { is_responsive: @is_responsive } %>
+    <%= render(TableComponent.new(**table_options)) do |table| %>
       <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
         <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
                .with_content(I18n.t("components.report.monthly_summary_table.month")) %>

--- a/app/app/components/report/gig_monthly_summary_table_component.rb
+++ b/app/app/components/report/gig_monthly_summary_table_component.rb
@@ -4,12 +4,13 @@ class Report::GigMonthlySummaryTableComponent < ViewComponent::Base
 
   attr_reader :employer_name
 
-  def initialize(report, payroll_account, is_responsive: true, is_caseworker: false, show_payments: true, show_footnote: true, show_header: true, is_pdf: false)
+  def initialize(report, payroll_account, is_responsive: true, is_caseworker: false, show_payments: true, show_footnote: true, show_header: true, is_pdf: false, use_activity_style: false)
     @report = report
     @show_payments = show_payments
     @show_footnote = show_footnote
     @show_header = show_header
     @is_pdf = is_pdf
+    @use_activity_style = use_activity_style
 
     # Note: payroll_account may either be the ID or the payroll_account object
     @account_id = payroll_account.class == String ? payroll_account : payroll_account.aggregator_account_id

--- a/app/app/components/report/w2_monthly_summary_table_component.erb
+++ b/app/app/components/report/w2_monthly_summary_table_component.erb
@@ -4,7 +4,10 @@
       <%= I18n.t("components.report.monthly_summary_table.monthly_summary") %>
     </h2>
   <% end %>
-  <%= render(TableComponent.new(is_responsive: @is_responsive)) do |table| %>
+  <% table_options = @use_activity_style \
+      ? { is_responsive: @is_responsive, class_names: "activity-review-hours-table" } \
+      : { is_responsive: @is_responsive } %>
+  <%= render(TableComponent.new(**table_options)) do |table| %>
     <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
       <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
              .with_content(I18n.t("components.report.monthly_summary_table.month")) %>

--- a/app/app/components/report/w2_monthly_summary_table_component.rb
+++ b/app/app/components/report/w2_monthly_summary_table_component.rb
@@ -4,11 +4,12 @@ class Report::W2MonthlySummaryTableComponent < ViewComponent::Base
 
   attr_reader :employer_name
 
-  def initialize(report, payroll_account, is_responsive: true, is_caseworker: false, show_footnote: true, show_header: true, is_pdf: false)
+  def initialize(report, payroll_account, is_responsive: true, is_caseworker: false, show_footnote: true, show_header: true, is_pdf: false, use_activity_style: false)
     @report = report
     @show_footnote = show_footnote
     @show_header = show_header
     @is_pdf = is_pdf
+    @use_activity_style = use_activity_style
 
     # Note: payroll_account may either be the ID or the payroll_account object
     @account_id = payroll_account.class == String ? payroll_account : payroll_account.aggregator_account_id

--- a/app/app/views/activities/education/_review_fully_self_attested.html.erb
+++ b/app/app/views/activities/education/_review_fully_self_attested.html.erb
@@ -1,4 +1,4 @@
-<div class="display-flex flex-justify flex-align-center">
+<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.education.review.school_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_education_path(id: @education_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -14,31 +14,28 @@
 
 <h2><%= t("activities.education.review.credit_hours_section") %></h2>
 <%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
+  <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.summary.education.month")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.education.review.credit_hours")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.education.review.community_engagement_hours")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.education.review.edit")) %>
+  <% end %>
   <% @education_activity.education_activity_months.order(:month).each_with_index do |activity_month, index| %>
-    <%= table.with_row(class_names: "subheader-row") do |row| %>
-      <%= row.with_data_cell(is_header: true, colspan: 2) do %>
-        <div class="display-flex flex-justify">
-          <span><%= I18n.l(activity_month.month, format: :month) %></span>
-          <%= link_to t("activities.education.review.edit"),
-                edit_activities_flow_education_month_path(education_id: @education_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-                class: "usa-link" %>
-        </div>
-      <% end %>
-    <% end %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.education.review.credit_hours") %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.education.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.credit_hours"))
+             .with_content(activity_month.hours) %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.community_engagement_hours"))
+             .with_content(@education_activity.community_engagement_hours(activity_month.hours)) %>
       <%= row.with_data_cell do %>
-        <%= activity_month.hours %>
-      <% end %>
-    <% end %>
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.education.review.community_engagement_hours") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= @education_activity.community_engagement_hours(activity_month.hours) %>
+        <%= link_to t("activities.education.review.edit"),
+              edit_activities_flow_education_month_path(education_id: @education_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
+              class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/education/_review_fully_self_attested.html.erb
+++ b/app/app/views/activities/education/_review_fully_self_attested.html.erb
@@ -1,4 +1,4 @@
-<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
+<div class="display-flex flex-justify activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.education.review.school_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_education_path(id: @education_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -25,17 +25,18 @@
            .with_content(t("activities.education.review.edit")) %>
   <% end %>
   <% @education_activity.education_activity_months.order(:month).each_with_index do |activity_month, index| %>
+    <% edit_path = edit_activities_flow_education_month_path(education_id: @education_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence) %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(data_label: t("activities.summary.education.month"), is_header: true)
-             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.education.month"), is_header: true) do %>
+        <%= I18n.l(activity_month.month, format: :month) %>
+        <%= link_to t("activities.education.review.edit"), edit_path, class: "usa-link mobile-edit-link" %>
+      <% end %>
       <%= row.with_data_cell(data_label: t("activities.education.review.credit_hours"))
              .with_content(activity_month.hours) %>
       <%= row.with_data_cell(data_label: t("activities.education.review.community_engagement_hours"))
              .with_content(@education_activity.community_engagement_hours(activity_month.hours)) %>
-      <%= row.with_data_cell do %>
-        <%= link_to t("activities.education.review.edit"),
-              edit_activities_flow_education_month_path(education_id: @education_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-              class: "usa-link" %>
+      <%= row.with_data_cell(class_names: "desktop-edit-link") do %>
+        <%= link_to t("activities.education.review.edit"), edit_path, class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/education/_review_partially_self_attested.html.erb
+++ b/app/app/views/activities/education/_review_partially_self_attested.html.erb
@@ -30,11 +30,18 @@
              .with_content(t("activities.education.review.edit")) %>
     <% end %>
     <% term_index = less_than_half_time_terms.index { |term| term.id == enrollment_term.id } || 0 %>
+    <% edit_path = edit_activities_flow_education_term_credit_hour_path(
+          education_id: @education_activity,
+          id: term_index,
+          from_review: 1,
+          from_edit: params[:from_edit].presence
+        ) %>
     <%= table.with_row do |row| %>
       <%= row.with_data_cell(data_label: t("activities.education.review.term"), is_header: true) do %>
         <%= format_date(enrollment_term.term_begin) %>
         &dash;
         <%= format_date(enrollment_term.term_end) %>
+        <%= link_to t("activities.education.review.edit"), edit_path, class: "usa-link mobile-edit-link" %>
       <% end %>
       <%= row.with_data_cell(data_label: t("components.enrollment_term_table_component.enrollment_status")) do %>
         <% enrollment_status_key = "components.enrollment_term_table_component.status.#{enrollment_term.enrollment_status}" %>
@@ -44,15 +51,8 @@
              .with_content(@education_activity.review_term_credit_hours(enrollment_term)) %>
       <%= row.with_data_cell(data_label: t("activities.education.review.community_engagement_hours"))
              .with_content(@education_activity.community_engagement_hours(@education_activity.review_term_credit_hours(enrollment_term))) %>
-      <%= row.with_data_cell do %>
-        <%= link_to t("activities.education.review.edit"),
-              edit_activities_flow_education_term_credit_hour_path(
-                education_id: @education_activity,
-                id: term_index,
-                from_review: 1,
-                from_edit: params[:from_edit].presence
-              ),
-              class: "usa-link" %>
+      <%= row.with_data_cell(class_names: "desktop-edit-link") do %>
+        <%= link_to t("activities.education.review.edit"), edit_path, class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/education/_review_partially_self_attested.html.erb
+++ b/app/app/views/activities/education/_review_partially_self_attested.html.erb
@@ -17,40 +17,42 @@
 
   <h3><%= t("activities.education.review.credit_hours_section") %></h3>
   <%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
-    <%= table.with_row(class_names: "subheader-row") do |row| %>
-      <%= row.with_data_cell(is_header: true, colspan: 2) do %>
-        <div class="display-flex flex-justify">
-          <span>
-            <%= format_date(enrollment_term.term_begin) %>
-            &dash;
-            <%= format_date(enrollment_term.term_end) %>
-          </span>
-          <% term_index = less_than_half_time_terms.index { |term| term.id == enrollment_term.id } || 0 %>
-          <%= link_to t("activities.education.review.edit"),
-                edit_activities_flow_education_term_credit_hour_path(
-                  education_id: @education_activity,
-                  id: term_index,
-                  from_review: 1,
-                  from_edit: params[:from_edit].presence
-                ),
-                class: "usa-link" %>
-        </div>
-      <% end %>
+    <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+      <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+             .with_content(t("activities.education.review.term")) %>
+      <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+             .with_content(t("components.enrollment_term_table_component.enrollment_status")) %>
+      <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+             .with_content(t("activities.education.review.credit_hours")) %>
+      <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+             .with_content(t("activities.education.review.community_engagement_hours")) %>
+      <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+             .with_content(t("activities.education.review.edit")) %>
     <% end %>
+    <% term_index = less_than_half_time_terms.index { |term| term.id == enrollment_term.id } || 0 %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.education.review.credit_hours") %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.term"), is_header: true) do %>
+        <%= format_date(enrollment_term.term_begin) %>
+        &dash;
+        <%= format_date(enrollment_term.term_end) %>
       <% end %>
+      <%= row.with_data_cell(data_label: t("components.enrollment_term_table_component.enrollment_status")) do %>
+        <% enrollment_status_key = "components.enrollment_term_table_component.status.#{enrollment_term.enrollment_status}" %>
+        <%= I18n.exists?(enrollment_status_key) ? t(enrollment_status_key) : t("shared.not_applicable") %>
+      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.credit_hours"))
+             .with_content(@education_activity.review_term_credit_hours(enrollment_term)) %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.community_engagement_hours"))
+             .with_content(@education_activity.community_engagement_hours(@education_activity.review_term_credit_hours(enrollment_term))) %>
       <%= row.with_data_cell do %>
-        <%= @education_activity.review_term_credit_hours(enrollment_term) %>
-      <% end %>
-    <% end %>
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.education.review.community_engagement_hours") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= @education_activity.community_engagement_hours(@education_activity.review_term_credit_hours(enrollment_term)) %>
+        <%= link_to t("activities.education.review.edit"),
+              edit_activities_flow_education_term_credit_hour_path(
+                education_id: @education_activity,
+                id: term_index,
+                from_review: 1,
+                from_edit: params[:from_edit].presence
+              ),
+              class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/employment/review.html.erb
+++ b/app/app/views/activities/employment/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.employment.review.description", employer_name: @employment_activity.employer_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
+<div class="display-flex flex-justify activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.employment.review.employer_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_income_employment_path(id: @employment_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -42,17 +42,18 @@
            .with_content(t("activities.hub.edit")) %>
   <% end %>
   <% @employment_activity.employment_activity_months.order(:month).each_with_index do |activity_month, index| %>
+    <% edit_path = edit_activities_flow_income_employment_month_path(employment_id: @employment_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence) %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(data_label: t("activities.summary.employment.month"), is_header: true)
-             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.employment.month"), is_header: true) do %>
+        <%= I18n.l(activity_month.month, format: :month) %>
+        <%= link_to t("activities.hub.edit"), edit_path, class: "usa-link mobile-edit-link" %>
+      <% end %>
       <%= row.with_data_cell(data_label: t("activities.employment.review.gross_income"))
              .with_content(number_to_currency(activity_month.gross_income)) %>
       <%= row.with_data_cell(data_label: t("activities.employment.review.hours_worked"))
              .with_content(activity_month.hours) %>
-      <%= row.with_data_cell do %>
-        <%= link_to t("activities.hub.edit"),
-              edit_activities_flow_income_employment_month_path(employment_id: @employment_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-              class: "usa-link" %>
+      <%= row.with_data_cell(class_names: "desktop-edit-link") do %>
+        <%= link_to t("activities.hub.edit"), edit_path, class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/employment/review.html.erb
+++ b/app/app/views/activities/employment/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.employment.review.description", employer_name: @employment_activity.employer_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center">
+<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.employment.review.employer_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_income_employment_path(id: @employment_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -31,31 +31,28 @@
 
 <h2><%= t("activities.employment.review.hours_and_income") %></h2>
 <%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
+  <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.summary.employment.month")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.employment.review.gross_income")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.employment.review.hours_worked")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.hub.edit")) %>
+  <% end %>
   <% @employment_activity.employment_activity_months.order(:month).each_with_index do |activity_month, index| %>
-    <%= table.with_row(class_names: "subheader-row") do |row| %>
-      <%= row.with_data_cell(is_header: true, colspan: 2) do %>
-        <div class="display-flex flex-justify">
-          <span><%= I18n.l(activity_month.month, format: :month) %></span>
-          <%= link_to t("activities.community_service.review.edit"),
-                edit_activities_flow_income_employment_month_path(employment_id: @employment_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-                class: "usa-link" %>
-        </div>
-      <% end %>
-    <% end %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.employment.review.gross_income") %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.employment.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.employment.review.gross_income"))
+             .with_content(number_to_currency(activity_month.gross_income)) %>
+      <%= row.with_data_cell(data_label: t("activities.employment.review.hours_worked"))
+             .with_content(activity_month.hours) %>
       <%= row.with_data_cell do %>
-        <%= number_to_currency(activity_month.gross_income) %>
-      <% end %>
-    <% end %>
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.employment.review.hours_worked") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= activity_month.hours %>
+        <%= link_to t("activities.hub.edit"),
+              edit_activities_flow_income_employment_month_path(employment_id: @employment_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
+              class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/income/payment_details/show.html.erb
+++ b/app/app/views/activities/income/payment_details/show.html.erb
@@ -23,7 +23,7 @@
 
 <% if @is_w2_worker %>
   <% if @payroll_account_report.paystubs.any? %>
-    <%= render(Report::W2MonthlySummaryTableComponent.new(@aggregator_report, @payroll_account)) %>
+    <%= render(Report::W2MonthlySummaryTableComponent.new(@aggregator_report, @payroll_account, use_activity_style: true)) %>
   <% else %>
     <%= render Uswds::Alert.new(type: :info, heading: t(".none_found"), class: "margin-top-5") do %>
       <%= t(".none_found_description",
@@ -34,7 +34,7 @@
   <% end %>
   <%= render(Report::PaymentsDeductionsMonthlySummaryComponent.new(@aggregator_report, @payroll_account, is_w2_worker: @is_w2_worker, pay_frequency_text: pay_frequency, use_activity_style: true)) %>
 <% else %>
-  <%= render(Report::GigMonthlySummaryTableComponent.new(@aggregator_report, @payroll_account)) %>
+  <%= render(Report::GigMonthlySummaryTableComponent.new(@aggregator_report, @payroll_account, use_activity_style: true)) %>
 <% end %>
 
 <div class="usa-form-group margin-top-5">

--- a/app/app/views/activities/job_training/review.html.erb
+++ b/app/app/views/activities/job_training/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.work_programs.review.description", program_name: @job_training_activity.program_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
+<div class="display-flex flex-justify activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.work_programs.review.organization_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_job_training_path(id: @job_training_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -90,15 +90,16 @@
            .with_content(t("activities.work_programs.review.edit")) %>
   <% end %>
   <% @job_training_activity.job_training_activity_months.order(:month).each_with_index do |activity_month, index| %>
+    <% edit_path = edit_activities_flow_job_training_month_path(job_training_id: @job_training_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence) %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(data_label: t("activities.summary.job_training.month"), is_header: true)
-             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.job_training.month"), is_header: true) do %>
+        <%= I18n.l(activity_month.month, format: :month) %>
+        <%= link_to t("activities.work_programs.review.edit"), edit_path, class: "usa-link mobile-edit-link" %>
+      <% end %>
       <%= row.with_data_cell(data_label: t("activities.work_programs.review.work_program_hours"))
              .with_content(activity_month.hours) %>
-      <%= row.with_data_cell do %>
-        <%= link_to t("activities.work_programs.review.edit"),
-              edit_activities_flow_job_training_month_path(job_training_id: @job_training_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-              class: "usa-link" %>
+      <%= row.with_data_cell(class_names: "desktop-edit-link") do %>
+        <%= link_to t("activities.work_programs.review.edit"), edit_path, class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/job_training/review.html.erb
+++ b/app/app/views/activities/job_training/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.work_programs.review.description", program_name: @job_training_activity.program_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center">
+<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.work_programs.review.organization_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_job_training_path(id: @job_training_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -80,24 +80,25 @@
 <% end %>
 
 <h2><%= t("activities.work_programs.review.hours_section") %></h2>
-<%= render(TableComponent.new(is_responsive: true, class_names: "cs-review-hours-table")) do |table| %>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
+  <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.summary.job_training.month")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.work_programs.review.work_program_hours")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.work_programs.review.edit")) %>
+  <% end %>
   <% @job_training_activity.job_training_activity_months.order(:month).each_with_index do |activity_month, index| %>
-    <%= table.with_row(class_names: "subheader-row") do |row| %>
-      <%= row.with_data_cell(is_header: true, colspan: 2) do %>
-        <div class="display-flex flex-justify">
-          <span><%= I18n.l(activity_month.month, format: :month) %></span>
-          <%= link_to t("activities.work_programs.review.edit"),
-                edit_activities_flow_job_training_month_path(job_training_id: @job_training_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-                class: "usa-link" %>
-        </div>
-      <% end %>
-    <% end %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.work_programs.review.work_program_hours") %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.job_training.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.work_programs.review.work_program_hours"))
+             .with_content(activity_month.hours) %>
       <%= row.with_data_cell do %>
-        <%= activity_month.hours %>
+        <%= link_to t("activities.work_programs.review.edit"),
+              edit_activities_flow_job_training_month_path(job_training_id: @job_training_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
+              class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/summary/_employment_table.html.erb
+++ b/app/app/views/activities/summary/_employment_table.html.erb
@@ -5,7 +5,7 @@
   <%= account_report&.employment&.employer_name || t("shared.not_applicable") %>
 </p>
 <% if is_w2_worker %>
-  <%= render(Report::W2MonthlySummaryTableComponent.new(persisted_report, payroll_account, show_footnote: false, show_header: false)) %>
+  <%= render(Report::W2MonthlySummaryTableComponent.new(persisted_report, payroll_account, show_footnote: false, show_header: false, use_activity_style: true)) %>
 <% else %>
-  <%= render(Report::GigMonthlySummaryTableComponent.new(persisted_report, payroll_account, show_footnote: false, show_header: false, show_payments: false)) %>
+  <%= render(Report::GigMonthlySummaryTableComponent.new(persisted_report, payroll_account, show_footnote: false, show_header: false, show_payments: false, use_activity_style: true)) %>
 <% end %>

--- a/app/app/views/activities/summary/_fully_self_attested_education_table.html.erb
+++ b/app/app/views/activities/summary/_fully_self_attested_education_table.html.erb
@@ -46,44 +46,18 @@
     <% end %>
   <% end %>
 
-  <% month_rows = activity.education_activity_months.order(:month) %>
-  <% if month_rows.empty? %>
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.education.month") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= t("shared.not_applicable") %>
-      <% end %>
-    <% end %>
+<% end %>
 
+<h3><%= t("activities.summary.monthly_details") %></h3>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-table", thead_class_names: "")) do |table| %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.education.month") } %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.education.credit_hours") } %>
+  <% activity.education_activity_months.order(:month).each do |activity_month| %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.education.credit_hours") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= t("shared.not_applicable") %>
-      <% end %>
-    <% end %>
-  <% else %>
-    <% month_rows.each do |activity_month| %>
-      <%= table.with_row do |row| %>
-        <%= row.with_data_cell(is_header: true) do %>
-          <%= t("activities.summary.education.month") %>
-        <% end %>
-        <%= row.with_data_cell do %>
-          <%= I18n.l(activity_month.month, format: :month) %>
-        <% end %>
-      <% end %>
-
-      <%= table.with_row do |row| %>
-        <%= row.with_data_cell(is_header: true) do %>
-          <%= t("activities.summary.education.credit_hours") %>
-        <% end %>
-        <%= row.with_data_cell do %>
-          <%= activity_month.hours %>
-        <% end %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.education.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.education.credit_hours"))
+             .with_content(activity_month.hours) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/app/views/activities/summary/_job_training_table.html.erb
+++ b/app/app/views/activities/summary/_job_training_table.html.erb
@@ -55,44 +55,18 @@
     <% end %>
   <% end %>
 
-  <% month_hours_rows = activity.job_training_activity_months.order(:month) %>
-  <% if month_hours_rows.empty? %>
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.job_training.month") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= t("shared.not_applicable") %>
-      <% end %>
-    <% end %>
+<% end %>
 
+<h3><%= t("activities.summary.monthly_details") %></h3>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-table", thead_class_names: "")) do |table| %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.job_training.month") } %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.job_training.work_program_hours") } %>
+  <% activity.job_training_activity_months.order(:month).each do |month_hours| %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.job_training.work_program_hours") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= t("shared.not_applicable") %>
-      <% end %>
-    <% end %>
-  <% else %>
-    <% month_hours_rows.each do |month_hours| %>
-      <%= table.with_row do |row| %>
-        <%= row.with_data_cell(is_header: true) do %>
-          <%= t("activities.summary.job_training.month") %>
-        <% end %>
-        <%= row.with_data_cell do %>
-          <%= I18n.l(month_hours.month, format: :month) %>
-        <% end %>
-      <% end %>
-
-      <%= table.with_row do |row| %>
-        <%= row.with_data_cell(is_header: true) do %>
-          <%= t("activities.summary.job_training.work_program_hours") %>
-        <% end %>
-        <%= row.with_data_cell do %>
-          <%= month_hours.hours %>
-        <% end %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.job_training.month"), is_header: true)
+             .with_content(I18n.l(month_hours.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.job_training.work_program_hours"))
+             .with_content(month_hours.hours) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/app/views/activities/summary/_partially_self_attested_education_table.html.erb
+++ b/app/app/views/activities/summary/_partially_self_attested_education_table.html.erb
@@ -46,14 +46,33 @@
         <% end %>
       <% end %>
 
-      <%= table.with_row do |row| %>
-        <%= row.with_data_cell(is_header: true) do %>
-          <%= t("activities.summary.education.term_credit_hours") %>
-        <% end %>
-        <%= row.with_data_cell do %>
-          <%= activity.review_term_credit_hours(enrollment_term) %>
-        <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h3><%= t("activities.summary.monthly_details") %></h3>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
+  <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.education.review.term")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("components.enrollment_term_table_component.enrollment_status")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.summary.education.term_credit_hours")) %>
+  <% end %>
+  <% enrollment_terms.each do |enrollment_term| %>
+    <%= table.with_row do |row| %>
+      <%= row.with_data_cell(data_label: t("activities.education.review.term"), is_header: true) do %>
+        <%= format_date(enrollment_term.term_begin) %>
+        &dash;
+        <%= format_date(enrollment_term.term_end) %>
       <% end %>
+      <%= row.with_data_cell(data_label: t("components.enrollment_term_table_component.enrollment_status")) do %>
+        <% enrollment_status_key = "components.enrollment_term_table_component.status.#{enrollment_term.enrollment_status}" %>
+        <%= I18n.exists?(enrollment_status_key) ? t(enrollment_status_key) : t("shared.not_applicable") %>
+      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.education.term_credit_hours"))
+             .with_content(activity.review_term_credit_hours(enrollment_term)) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/app/views/activities/summary/_self_attested_employment_table.html.erb
+++ b/app/app/views/activities/summary/_self_attested_employment_table.html.erb
@@ -48,7 +48,7 @@
 <% end %>
 
 <h3><%= t("activities.summary.monthly_details") %></h3>
-<%= render(TableComponent.new(is_responsive: true)) do |table| %>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
   <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
     <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
            .with_content(t("activities.summary.employment.month")) %>

--- a/app/app/views/activities/summary/_volunteering_table.html.erb
+++ b/app/app/views/activities/summary/_volunteering_table.html.erb
@@ -46,23 +46,18 @@
     <% end %>
   <% end %>
 
+<% end %>
+
+<h3><%= t("activities.summary.monthly_details") %></h3>
+<%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-table", thead_class_names: "")) do |table| %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.community_service.month") } %>
+  <%= table.with_header_cell(is_header: true, scope: "col") { t("activities.summary.community_service.hours_served") } %>
   <% activity.activity_months.order(month: :asc).each do |activity_month| %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.community_service.month") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= I18n.l(activity_month.month, format: :month) %>
-      <% end %>
-    <% end %>
-
-    <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.summary.community_service.hours_served") %>
-      <% end %>
-      <%= row.with_data_cell do %>
-        <%= activity_month.hours %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.community_service.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.community_service.hours_served"))
+             .with_content(activity_month.hours) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/app/views/activities/volunteering/review.html.erb
+++ b/app/app/views/activities/volunteering/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.community_service.review.description", organization_name: @volunteering_activity.organization_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center">
+<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.community_service.review.organization_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_community_service_path(id: @volunteering_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -31,23 +31,24 @@
 
 <h2><%= t("activities.community_service.review.hours_section") %></h2>
 <%= render(TableComponent.new(is_responsive: true, class_names: "activity-review-hours-table")) do |table| %>
+  <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.summary.community_service.month")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.community_service.review.community_service_hours")) %>
+    <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")
+           .with_content(t("activities.community_service.review.edit")) %>
+  <% end %>
   <% @volunteering_activity.volunteering_activity_months.order(:month).each_with_index do |activity_month, index| %>
-    <%= table.with_row(class_names: "subheader-row") do |row| %>
-      <%= row.with_data_cell(is_header: true, colspan: 2) do %>
-        <div class="display-flex flex-justify">
-          <span><%= I18n.l(activity_month.month, format: :month) %></span>
-          <%= link_to t("activities.community_service.review.edit"),
-                edit_activities_flow_community_service_month_path(community_service_id: @volunteering_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-                class: "usa-link" %>
-        </div>
-      <% end %>
-    <% end %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(is_header: true) do %>
-        <%= t("activities.community_service.review.community_service_hours") %>
-      <% end %>
+      <%= row.with_data_cell(data_label: t("activities.summary.community_service.month"), is_header: true)
+             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.community_service.review.community_service_hours"))
+             .with_content(activity_month.hours) %>
       <%= row.with_data_cell do %>
-        <%= activity_month.hours %>
+        <%= link_to t("activities.community_service.review.edit"),
+              edit_activities_flow_community_service_month_path(community_service_id: @volunteering_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
+              class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/volunteering/review.html.erb
+++ b/app/app/views/activities/volunteering/review.html.erb
@@ -15,7 +15,7 @@
   <%= t("activities.community_service.review.description", organization_name: @volunteering_activity.organization_name) %>
 </p>
 
-<div class="display-flex flex-justify flex-align-center activity-review-edit-header">
+<div class="display-flex flex-justify activity-review-edit-header">
   <h2 class="margin-y-0"><%= t("activities.community_service.review.organization_info") %></h2>
   <%= link_to t("activities.hub.edit"),
         edit_activities_flow_community_service_path(id: @volunteering_activity, from_review: 1, from_edit: params[:from_edit].presence),
@@ -40,15 +40,16 @@
            .with_content(t("activities.community_service.review.edit")) %>
   <% end %>
   <% @volunteering_activity.volunteering_activity_months.order(:month).each_with_index do |activity_month, index| %>
+    <% edit_path = edit_activities_flow_community_service_month_path(community_service_id: @volunteering_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence) %>
     <%= table.with_row do |row| %>
-      <%= row.with_data_cell(data_label: t("activities.summary.community_service.month"), is_header: true)
-             .with_content(I18n.l(activity_month.month, format: :month)) %>
+      <%= row.with_data_cell(data_label: t("activities.summary.community_service.month"), is_header: true) do %>
+        <%= I18n.l(activity_month.month, format: :month) %>
+        <%= link_to t("activities.community_service.review.edit"), edit_path, class: "usa-link mobile-edit-link" %>
+      <% end %>
       <%= row.with_data_cell(data_label: t("activities.community_service.review.community_service_hours"))
              .with_content(activity_month.hours) %>
-      <%= row.with_data_cell do %>
-        <%= link_to t("activities.community_service.review.edit"),
-              edit_activities_flow_community_service_month_path(community_service_id: @volunteering_activity, id: index, from_review: 1, from_edit: params[:from_edit].presence),
-              class: "usa-link" %>
+      <%= row.with_data_cell(class_names: "desktop-edit-link") do %>
+        <%= link_to t("activities.community_service.review.edit"), edit_path, class: "usa-link" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
         additional_comments_description: Share any comments or additional information that you'd like %{agency_name} to know.
         additional_comments_title: Additional comments (optional)
         address: Address
-        community_service_hours: Community service hours
+        community_service_hours: Community engagement hours
         coordinator_email: Coordinator's email
         coordinator_name: Coordinator's name
         coordinator_phone: Coordinator's phone number
@@ -215,6 +215,7 @@ en:
         save: Save and add to report
         school_info: School information
         school_name: School or program
+        term: Term
         title: Review your student information for %{school_name}
         title_no_school_name: Review your student information
       show:
@@ -452,7 +453,7 @@ en:
         coordinator_email: Coordinator's email
         coordinator_name: Coordinator's name
         coordinator_phone: Coordinator's phone
-        hours_served: Community service hours
+        hours_served: Community engagement hours
         month: Month
         organization: Organization name
       consent_label_html: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform %{agency_name} of any activities not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for community engagement verification by authorized %{agency_initials} personnel.'

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
         additional_comments_description: Share any comments or additional information that you'd like %{agency_name} to know.
         additional_comments_title: Additional comments (optional)
         address: Address
-        community_service_hours: Community engagement hours
+        community_service_hours: Community service hours
         coordinator_email: Coordinator's email
         coordinator_name: Coordinator's name
         coordinator_phone: Coordinator's phone number
@@ -453,7 +453,7 @@ en:
         coordinator_email: Coordinator's email
         coordinator_name: Coordinator's name
         coordinator_phone: Coordinator's phone
-        hours_served: Community engagement hours
+        hours_served: Community service hours
         month: Month
         organization: Organization name
       consent_label_html: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform %{agency_name} of any activities not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for community engagement verification by authorized %{agency_initials} personnel.'

--- a/app/spec/controllers/activities/education_controller_spec.rb
+++ b/app/spec/controllers/activities/education_controller_spec.rb
@@ -286,6 +286,16 @@ RSpec.describe Activities::EducationController, type: :controller do
         expect(response.body).to include("16")
       end
 
+      it "includes an edit link for each month" do
+        create(:education_activity_month, education_activity: education_activity, month: activity_flow.reporting_months.first, hours: 4)
+
+        get :review, params: { id: education_activity.id }
+
+        expect(response.body).to include(
+          edit_activities_flow_education_month_path(education_id: education_activity, id: 0, from_review: 1)
+        )
+      end
+
       it "renders an edit link to school info with from_review" do
         get :review, params: { id: education_activity.id }
 
@@ -403,7 +413,7 @@ RSpec.describe Activities::EducationController, type: :controller do
         )
         expect(doc).to have_selector("h3", text: I18n.t("activities.education.review.credit_hours_section"), count: 1)
         expect(response.body.scan(I18n.t("activities.education.review.ce_explainer_title")).count).to eq(1)
-        expect(response.body.scan(I18n.t("activities.education.review.community_engagement_hours")).count).to eq(1)
+        expect(response.body.scan(I18n.t("activities.education.review.community_engagement_hours")).count).to eq(2)
       end
 
       it "renders term-hours tables for each enrollment when all enrollments are less-than-half-time" do
@@ -439,7 +449,7 @@ RSpec.describe Activities::EducationController, type: :controller do
           )
         )
         expect(doc).to have_selector("h3", text: I18n.t("activities.education.review.credit_hours_section"), count: 2)
-        expect(response.body.scan(I18n.t("activities.education.review.community_engagement_hours")).count).to eq(2)
+        expect(response.body.scan(I18n.t("activities.education.review.community_engagement_hours")).count).to eq(4)
         expect(response.body.scan(I18n.t("activities.education.review.ce_explainer_title")).count).to eq(1)
       end
     end

--- a/app/spec/controllers/activities/employment_controller_spec.rb
+++ b/app/spec/controllers/activities/employment_controller_spec.rb
@@ -197,6 +197,14 @@ RSpec.describe Activities::EmploymentController, type: :controller do
       expect(response.body).to include("25")
       expect(response.body).to include("500")
     end
+
+    it "includes an edit link for each month" do
+      get :review, params: { id: employment_activity.id }
+
+      expect(response.body).to include(
+        edit_activities_flow_income_employment_month_path(employment_id: employment_activity, id: 0, from_review: 1)
+      )
+    end
   end
 
   describe "PATCH #save_review" do

--- a/app/spec/controllers/activities/job_training_controller_spec.rb
+++ b/app/spec/controllers/activities/job_training_controller_spec.rb
@@ -127,11 +127,25 @@ RSpec.describe Activities::JobTrainingController, type: :controller do
   describe "GET #review" do
     let(:job_training_activity) { create(:job_training_activity, activity_flow: activity_flow) }
 
+    before do
+      activity_flow.reporting_months.each do |month|
+        create(:job_training_activity_month, job_training_activity: job_training_activity, month: month.beginning_of_month, hours: 10)
+      end
+    end
+
     it "renders the review page" do
       get :review, params: { id: job_training_activity.id }
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(job_training_activity.program_name)
+    end
+
+    it "includes an edit link for each month" do
+      get :review, params: { id: job_training_activity.id }
+
+      expect(response.body).to include(
+        edit_activities_flow_job_training_month_path(job_training_id: job_training_activity, id: 0, from_review: 1)
+      )
     end
   end
 

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -181,12 +181,12 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       doc = Capybara.string(response.body)
-      expect(doc).to have_selector("table", count: 1)
+      expect(doc).to have_selector("table", count: 2) # contact info table + monthly details table
       expect(response.body).to include("Ada B Lovelace")
       expect(response.body).to include("River College")
       expect(response.body).to include(I18n.t("components.enrollment_term_table_component.status.less_than_half_time"))
 
-      term_credit_rows = doc.all("tr").select { |row| row.text.include?(I18n.t("activities.summary.education.term_credit_hours")) }
+      term_credit_rows = doc.all("table").last.all("tbody tr")
       expect(term_credit_rows.size).to eq(1)
       expect(term_credit_rows.first.all("th, td").last.text.strip).to eq("9")
     end
@@ -220,13 +220,13 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       doc = Capybara.string(response.body)
-      expect(doc).to have_selector("table", count: 1)
+      expect(doc).to have_selector("table", count: 2) # contact info table + monthly details table
       expect(response.body.scan("River College").count).to eq(1)
       expect(response.body.scan(I18n.t("components.enrollment_term_table_component.enrollment_term")).count).to eq(2)
-      expect(response.body.scan(I18n.t("components.enrollment_term_table_component.enrollment_status")).count).to eq(2)
-      expect(response.body.scan(I18n.t("activities.summary.education.term_credit_hours")).count).to eq(2)
+      expect(response.body.scan(I18n.t("components.enrollment_term_table_component.enrollment_status")).count).to eq(5) # 2 contact info rows + 1 monthly header + 2 monthly data-labels
+      expect(response.body.scan(I18n.t("activities.summary.education.term_credit_hours")).count).to eq(3) # 1 monthly header + 2 monthly data-labels
 
-      term_credit_rows = doc.all("tr").select { |row| row.text.include?(I18n.t("activities.summary.education.term_credit_hours")) }
+      term_credit_rows = doc.all("table").last.all("tbody tr")
       expect(term_credit_rows.map { |row| row.all("th, td").last.text.strip }).to eq(%w[3 6])
     end
 
@@ -254,12 +254,12 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       doc = Capybara.string(response.body)
-      expect(doc).to have_selector("table", count: 1)
+      expect(doc).to have_selector("table", count: 2) # contact info table + monthly details table
       expect(response.body).to include("River College")
       expect(response.body).to include("Lake Tech")
       expect(response.body.scan(I18n.t("components.enrollment_term_table_component.school_or_program")).count).to eq(2)
 
-      term_credit_rows = doc.all("tr").select { |row| row.text.include?(I18n.t("activities.summary.education.term_credit_hours")) }
+      term_credit_rows = doc.all("table").last.all("tbody tr")
       expect(term_credit_rows.map { |row| row.all("th, td").last.text.strip }).to contain_exactly("3", "6")
     end
 

--- a/app/spec/controllers/activities/volunteering_controller_spec.rb
+++ b/app/spec/controllers/activities/volunteering_controller_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe Activities::VolunteeringController, type: :controller do
 
       expect(response.body).to include("25")
     end
+
+    it "includes an edit link for each month" do
+      create(:volunteering_activity_month, volunteering_activity: volunteering_activity, month: activity_flow.reporting_months.first, hours: 25)
+
+      get :review, params: { id: volunteering_activity.id }
+
+      expect(response.body).to include(
+        edit_activities_flow_community_service_month_path(community_service_id: volunteering_activity, id: 0, from_review: 1)
+      )
+    end
   end
 
   describe "PATCH #save_review" do

--- a/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "e2e Education self-attestation review flow", :js, type: :feature
     expect(page).to have_content "601 E John St, Champaign, IL"
 
     # Edit month 1 from review
-    month_edit_links = all(".subheader-row a", text: I18n.t("activities.education.review.edit"))
+    month_edit_links = all("td a", text: I18n.t("activities.education.review.edit"))
     month_edit_links.first.click
     verify_page(page, title: I18n.t("activities.education.hours_input.heading",
       month: month1_label, organization: "Updated University of Illinois"))

--- a/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
 
     # --- Step 3: Edit a single month from the review page ---
     # Month edit links are inside .subheader-row; the employer edit link is outside the table
-    month_edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    month_edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     month_edit_links.first.click
 
     verify_page(page, title: I18n.t("activities.employment.hours_input.heading",
@@ -132,7 +132,7 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
 
     # --- Step 4: Validation guard — cannot zero out all months from review ---
     # Set month 2 to 0 via edit from review
-    month_edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    month_edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     month_edit_links.last.click
 
     verify_page(page, title: I18n.t("activities.employment.hours_input.heading",
@@ -145,7 +145,7 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
     verify_page(page, title: I18n.t("activities.employment.review.title", employer_name: "Updated Employer"))
 
     # Now try to set month 1 to 0 — should fail validation
-    month_edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    month_edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     month_edit_links.first.click
 
     verify_page(page, title: I18n.t("activities.employment.hours_input.heading",

--- a/app/spec/e2e/activity_hub_spec.rb
+++ b/app/spec/e2e/activity_hub_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
 
     # --- Step 3: Edit a single month from the review page ---
     # Click Edit on month 1 — should go to hours input and return directly to review
-    edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     edit_links.first.click
 
     verify_page(page, title: I18n.t("activities.community_service.hours_input.heading",
@@ -426,7 +426,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
 
     # --- Step 4: Validation guard — cannot set all months to 0 from review ---
     # First, set month 2 to 0 via edit from review
-    edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     edit_links.last.click
 
     verify_page(page, title: I18n.t("activities.community_service.hours_input.heading",
@@ -438,7 +438,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     verify_page(page, title: I18n.t("activities.community_service.review.title", organization_name: "Updated Org"))
 
     # Now try to set month 1 to 0 — should fail validation
-    edit_links = all(".subheader-row a", text: I18n.t("activities.community_service.review.edit"))
+    edit_links = all("td a", text: I18n.t("activities.community_service.review.edit"))
     edit_links.first.click
 
     verify_page(page, title: I18n.t("activities.community_service.hours_input.heading",


### PR DESCRIPTION
## [FFS-3885](https://jiraent.cms.gov/browse/FFS-3885)
Update activity flow hours review tables with [new designs.](https://www.figma.com/design/Wo7VnF1C7x8tx22ikMY2fT/HR1-Prototype?node-id=6477-132428&m=dev) This means all the tables in activits flow should now use the new style. 

## Changes
- Converted activity review and summary tables from vertical 2-column per-month layouts to horizontal multi-column tables (Month | Gross income | Hours worked | Edit, etc.)
- Applied consistent table styling across all activity types: employment, volunteering, job training, and education (both fully and partially self-attested)
- Extended the USWDS `usa-table--stacked` breakpoint from 480px to 640px (tablet) for activity tables so 5-column tables don't overflow at intermediate widths
- Positioned the Edit link at the top-right of each stacked row group on mobile
- Applied new table styling to the summary page (`show.html.erb`), including payroll-connected employment tables and the `payment_details/show.html.erb` page
- Added `activity-review-edit-header` class to constrain the heading/Edit flex container to match the table max-width (44rem)
- Set 40/60 column width split on 2-column activity-review-table for better readability
- 2-column summary tables (volunteering, job training, fully self-attested education monthly details) use `activity-review-table` class instead of `activity-review-hours-table` to inherit the 40/60 column split and match the contact info tables above them.

## Acceptance testing
- [x] Acceptance testing prior to merge
  * Visual changes across all activity review pages and the summary page. Check desktop and mobile views at various widths (especially 480–640px range).

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->