### PR TITLE
FFS-3916: Update progress calculator to decide between hours or dollars for each month

### DIFF
--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -17,24 +17,46 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
     required_month_count: nil
   )
     @monthly_calculation_results = monthly_calculation_results
-    @renewal = variant.to_s == "renewal"
+    @renewal = variant == :renewal
     @required_month_count = normalize_required_month_count(required_month_count)
   end
 
   def percent_complete(monthly_result)
+    progress_value = progress_value_for(monthly_result)
+    threshold_value = completion_threshold_for(monthly_result)
+
     [
-      (100.0 * monthly_result.total_hours) / completion_threshold,
+      (100.0 * progress_value) / threshold_value,
       100
     ].min
   end
 
-  def completion_threshold = ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+  def hours_completion_threshold = ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+  def earnings_completion_threshold = ActivityFlowProgressCalculator::PER_MONTH_EARNINGS_THRESHOLD
 
   def format_hours(hours)
     return hours.to_i if hours.to_i == hours
 
     hours.round(1)
   end
+
+  def display_progress_amount(monthly_result)
+    if display_dollars?(monthly_result)
+      format_dollar_amount(monthly_result.total_earnings_cents)
+    else
+      format_hours(monthly_result.total_hours)
+    end
+  end
+
+  def display_completion_threshold(monthly_result)
+    if display_dollars?(monthly_result)
+      format_dollar_amount(earnings_completion_threshold)
+    else
+      hours_completion_threshold
+    end
+  end
+
+  def display_hours_unit?(monthly_result) = !display_dollars?(monthly_result)
 
   def multi_month? = monthly_calculation_results.length > 1
 
@@ -62,6 +84,30 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
 
   private
   attr_reader :monthly_calculation_results, :required_month_count
+
+  def display_dollars?(monthly_result)
+    monthly_result.default_unit == :dollars
+  end
+
+  def progress_value_for(monthly_result)
+    if display_dollars?(monthly_result)
+      monthly_result.total_earnings_cents.to_f
+    else
+      monthly_result.total_hours.to_f
+    end
+  end
+
+  def completion_threshold_for(monthly_result)
+    if display_dollars?(monthly_result)
+      earnings_completion_threshold
+    else
+      hours_completion_threshold
+    end
+  end
+
+  def format_dollar_amount(cents)
+    helpers.number_to_currency(cents.to_f / 100, precision: 0)
+  end
 
   def normalize_required_month_count(required_month_count)
     requested_count = required_month_count || monthly_calculation_results.length

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -69,10 +69,13 @@
                 </svg>
               <% end %>
 
-              <%= format_hours(monthly_result.total_hours) %>
+              <%= display_progress_amount(monthly_result) %>
             </span>
             /
-            <%= completion_threshold %> <%= t(".hours") %>
+            <%= display_completion_threshold(monthly_result) %>
+            <% if display_hours_unit?(monthly_result) %>
+              <%= t(".hours") %>
+            <% end %>
           </span>
         </div>
       <% end %>

--- a/app/app/services/activity_flow_progress_calculator.rb
+++ b/app/app/services/activity_flow_progress_calculator.rb
@@ -5,7 +5,7 @@ class ActivityFlowProgressCalculator
   PER_MONTH_EARNINGS_THRESHOLD = 580_00 # in cents
 
   OverallResult = Struct.new(:total_hours, :meets_requirements, :meets_routing_requirements, keyword_init: true)
-  MonthlyResult = Struct.new(:month, :total_hours, :meets_requirements, keyword_init: true)
+  MonthlyResult = Struct.new(:month, :total_hours, :total_earnings_cents, :default_unit, :meets_requirements, keyword_init: true)
 
   def initialize(activity_flow)
     @activity_flow = activity_flow
@@ -26,11 +26,14 @@ class ActivityFlowProgressCalculator
   def monthly_results
     reporting_months.map do |month|
       hours = hours_for_month(month)
+      earnings_cents = earnings_for_month(month)
 
       MonthlyResult.new(
         month: month,
         total_hours: hours,
-        meets_requirements: hours >= PER_MONTH_HOURS_THRESHOLD
+        total_earnings_cents: earnings_cents,
+        default_unit: default_unit_for_month(hours: hours, earnings_cents: earnings_cents),
+        meets_requirements: hours >= PER_MONTH_HOURS_THRESHOLD || earnings_cents >= PER_MONTH_EARNINGS_THRESHOLD
       )
     end
   end
@@ -60,6 +63,10 @@ class ActivityFlowProgressCalculator
       hours_for_month(month_start) >= PER_MONTH_HOURS_THRESHOLD ||
         earnings_for_month(month_start) >= PER_MONTH_EARNINGS_THRESHOLD
     end
+  end
+
+  def default_unit_for_month(hours:, earnings_cents:)
+    earnings_cents >= PER_MONTH_EARNINGS_THRESHOLD && hours < PER_MONTH_HOURS_THRESHOLD ? :dollars : :hours
   end
 
   def each_month_meets_threshold_with_validated_data?

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -46,9 +46,10 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   it "renders the completion threshold and hours label" do
     render_inline(component)
 
-    expect(page).to have_content(
+    expect(page.find(".activity-flow-progress-indicator__progress-amount-container")).to have_text(
       "#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
-      "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      "#{I18n.t("activity_flow_progress_indicator.hours")}",
+      normalize_ws: true
     )
   end
 
@@ -57,6 +58,56 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
 
     progress = page.find(:css, ".activity-flow-progress-indicator__progress-bar-fill")
     expect(progress["style"]).to eq("width: 50.0%")
+  end
+
+  context "when monthly default unit is dollars" do
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: 77,
+        total_earnings_cents: 597_00,
+        default_unit: :dollars,
+        meets_requirements: true
+      )
+    end
+
+    it "renders dollars for amount and threshold" do
+      render_inline(component)
+
+      row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
+
+      expect(row_text).to include("$597 / $580")
+      expect(row_text).not_to include(I18n.t("activity_flow_progress_indicator.hours"))
+      expect(page).to have_css(".activity-flow-progress-indicator__progress-bar--complete")
+      expect(page).to have_css(".activity-flow-progress-indicator__success-icon")
+    end
+
+    it "calculates progress width using dollars threshold" do
+      render_inline(component)
+
+      progress = page.find(:css, ".activity-flow-progress-indicator__progress-bar-fill")
+      expect(progress["style"]).to eq("width: 100%")
+    end
+  end
+
+  context "when hours and earnings both meet threshold" do
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: 82,
+        total_earnings_cents: 620_00,
+        default_unit: :hours,
+        meets_requirements: true
+      )
+    end
+
+    it "keeps hours as the rendered unit" do
+      render_inline(component)
+
+      row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
+      expect(row_text).to include("82 / 80 #{I18n.t("activity_flow_progress_indicator.hours")}")
+      expect(row_text).not_to include("$620 / $580")
+    end
   end
 
   it "does not show the 'months completed' message" do

--- a/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
+++ b/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
@@ -10,6 +10,14 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     )
   end
 
+  def one_month_dollars_default
+    result = make_result(Date.new(2026, 1, 1), 77, earnings_cents: 597_00)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: [ result ]
+    )
+  end
+
   # @param num_months select { choices: [[2 months, 2], [3 months, 3], [4 months, 4]] }
   # @param month_1_hours range { min: 0, max: 100, step: 0.5 }
   # @param month_2_hours range { min: 0, max: 100, step: 0.5 }
@@ -31,6 +39,17 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results = []
     results << make_result(Date.new(2026, 1, 1), 82)
     results << make_result(Date.new(2025, 12, 1), 91)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: results
+    )
+  end
+
+  def many_months_mixed_units
+    results = []
+    results << make_result(Date.new(2026, 1, 1), 77, earnings_cents: 597_00) # dollars
+    results << make_result(Date.new(2025, 12, 1), 82, earnings_cents: 620_00) # hours
+    results << make_result(Date.new(2025, 11, 1), 40, earnings_cents: 200_00) # hours
 
     render ActivityFlowProgressIndicator.new(
       monthly_calculation_results: results
@@ -73,11 +92,23 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
 
   private
 
-  def make_result(month, hours)
+  def make_result(month, hours, earnings_cents: 0)
+    meets_threshold = hours.to_f >= ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD ||
+      earnings_cents >= ActivityFlowProgressCalculator::PER_MONTH_EARNINGS_THRESHOLD
+
+    default_unit = if earnings_cents >= ActivityFlowProgressCalculator::PER_MONTH_EARNINGS_THRESHOLD &&
+                      hours.to_f < ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+                     :dollars
+                   else
+                     :hours
+                   end
+
     ActivityFlowProgressCalculator::MonthlyResult.new(
       month: month,
       total_hours: hours.to_f,
-      meets_requirements: hours.to_f >= ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+      total_earnings_cents: earnings_cents,
+      default_unit: default_unit,
+      meets_requirements: meets_threshold
     )
   end
 end

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -203,9 +203,11 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "keeps the hub in in-progress state to match the progress indicator completion rule" do
-      expect(response.body).to include(I18n.t("activities.hub.in_progress_state_title"))
-      expect(response.body).not_to include(I18n.t("activities.hub.completed_state_title"))
+    it "shows the hub in completed state" do
+      page_text = Capybara.string(response.body).text
+
+      expect(page_text).to include(I18n.t("activities.hub.completed_state_title"))
+      expect(page_text).not_to include(I18n.t("activities.hub.in_progress_state_title"))
     end
   end
 

--- a/app/spec/services/activity_flow_progress_calculator_spec.rb
+++ b/app/spec/services/activity_flow_progress_calculator_spec.rb
@@ -403,10 +403,91 @@ RSpec.describe ActivityFlowProgressCalculator do
 
     it "returns empty results for all months when no activities exist" do
       expect(result).to contain_exactly(
-        have_attributes(month: reporting_range_months.first, total_hours: 0, meets_requirements: false),
-        have_attributes(month: reporting_range_months.second, total_hours: 0, meets_requirements: false),
-        have_attributes(month: reporting_range_months.third, total_hours: 0, meets_requirements: false),
+        have_attributes(month: reporting_range_months.first, total_hours: 0, total_earnings_cents: 0, default_unit: :hours, meets_requirements: false),
+        have_attributes(month: reporting_range_months.second, total_hours: 0, total_earnings_cents: 0, default_unit: :hours, meets_requirements: false),
+        have_attributes(month: reporting_range_months.third, total_hours: 0, total_earnings_cents: 0, default_unit: :hours, meets_requirements: false),
       )
+    end
+
+    context "when a month is complete by earnings only" do
+      let(:flow) { create(:activity_flow, reporting_window_months: 1) }
+      let(:month) { flow.reporting_window_range.begin }
+      let!(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, flow: flow, aggregator_account_id: "unit-test-account") }
+
+      before do
+        create(
+          :activity_flow_monthly_summary,
+          activity_flow: flow,
+          payroll_account: payroll_account,
+          month: month.beginning_of_month,
+          total_w2_hours: 77.0,
+          accrued_gross_earnings_cents: 597_00
+        )
+      end
+
+      it "uses dollars as the monthly default unit" do
+        monthly_result = result.first
+
+        expect(monthly_result).to have_attributes(
+          month: month,
+          total_hours: 77.0,
+          total_earnings_cents: 597_00,
+          default_unit: :dollars,
+          meets_requirements: true
+        )
+      end
+    end
+
+    context "when both hours and earnings meet thresholds" do
+      let(:flow) { create(:activity_flow, reporting_window_months: 1) }
+      let(:month) { flow.reporting_window_range.begin }
+      let!(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, flow: flow, aggregator_account_id: "unit-test-account-2") }
+
+      before do
+        create(
+          :activity_flow_monthly_summary,
+          activity_flow: flow,
+          payroll_account: payroll_account,
+          month: month.beginning_of_month,
+          total_w2_hours: 82.0,
+          accrued_gross_earnings_cents: 620_00
+        )
+      end
+
+      it "keeps hours as the monthly default unit" do
+        monthly_result = result.first
+
+        expect(monthly_result).to have_attributes(
+          default_unit: :hours,
+          meets_requirements: true
+        )
+      end
+    end
+
+    context "when a month is below both thresholds" do
+      let(:flow) { create(:activity_flow, reporting_window_months: 1) }
+      let(:month) { flow.reporting_window_range.begin }
+      let!(:payroll_account) { create(:payroll_account, :pinwheel_fully_synced, flow: flow, aggregator_account_id: "unit-test-account-3") }
+
+      before do
+        create(
+          :activity_flow_monthly_summary,
+          activity_flow: flow,
+          payroll_account: payroll_account,
+          month: month.beginning_of_month,
+          total_w2_hours: 77.0,
+          accrued_gross_earnings_cents: 570_00
+        )
+      end
+
+      it "uses hours as the default unit and remains incomplete" do
+        monthly_result = result.first
+
+        expect(monthly_result).to have_attributes(
+          default_unit: :hours,
+          meets_requirements: false
+        )
+      end
     end
 
     context "when there are job training activities within the reporting range" do


### PR DESCRIPTION
## [FFS-3916](https://jiraent.cms.gov/browse/FFS-3916)

## Changes
- Added default logic per month so the progress indicator shows dollars only when earnings meet threshold and hours don’t
- Calculator and indicator render mixed unit months
- Updated lookbook 

Note that it's easiest to test this change from /demo using self-attested employment or /lookbook.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)


<img width="303" height="197" alt="Screenshot 2026-04-09 at 12 55 12 PM" src="https://github.com/user-attachments/assets/0ba80c90-42f6-431c-bc7a-43d02495517a" />
<img width="316" height="204" alt="Screenshot 2026-04-09 at 12 54 52 PM" src="https://github.com/user-attachments/assets/fd711e8e-0d85-4c95-b703-5c4eb8e97954" />

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->