### PR TITLE
Split image publishing workflows by GitHub org

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,16 +33,21 @@ The CD workflow uses these reusable workflows:
 
 - [`deploy`](./deploy.yml): deploys an application
 - [`database-migrations`](./database-migrations.yml): runs database migrations for an application
-- [`build-and-publish`](./build-and-publish.yml): builds a container image for an application and publishes it to an image repository
+- [`dsacms-build-and-publish`](./dsacms-build-and-publish.yml): DSACMS-only reusable workflow that builds a container image for an application and publishes it to ECR
+- [`cmsgov-build-and-publish`](./cmsgov-build-and-publish.yml): CMSgov-only reusable workflow that builds a container image for an application and publishes it to Artifactory
+- [`cmsgov-cd-app`](./cmsgov-cd-app.yml): CMSgov-only top-level workflow that publishes the `app` image to `artifactory.cloud.cms.gov/emmy-docker/emmy-app` on `main` pushes and manual dispatch
 
 ```mermaid
 graph TD
   cd-app
   deploy
   database-migrations
-  build-and-publish
+  dsacms-build-and-publish
+  cmsgov-cd-app
+  cmsgov-build-and-publish
 
-  cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|build-and-publish
+  cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|dsacms-build-and-publish
+  cmsgov-cd-app-->|calls|cmsgov-build-and-publish
 ```
 
 ## ⛑️ Helper workflows

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "main"
+      # Temporary branch trigger for pre-merge workflow validation. Remove before merge.
+      - "codex/split-image-publishing-org"
     paths:
       - "app/**"
       - "bin/**"

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - "main"
-      # Temporary branch trigger for pre-merge workflow validation. Remove before merge.
-      - "codex/split-image-publishing-org"
     paths:
       - "app/**"
       - "bin/**"

--- a/.github/workflows/cmsgov-build-and-publish.yml
+++ b/.github/workflows/cmsgov-build-and-publish.yml
@@ -61,6 +61,13 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Login to Artifactory
+        uses: docker/login-action@v3
+        with:
+          registry: artifactory.cloud.cms.gov
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
       - name: Get image metadata
         id: image-metadata
         run: |
@@ -75,21 +82,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         run: |
-          is_image_published=$(./bin/is-artifactory-image-published "${IMAGE_REPOSITORY_URL}" "${{ steps.image-metadata.outputs.image_tag }}")
+          is_image_published=$(./bin/is-artifactory-image-published "${{ steps.image-metadata.outputs.image_tag }}")
           echo "Is image published: $is_image_published"
           echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
 
       - name: Build release
         if: steps.check-image-published.outputs.is_image_published == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-build
-
-      - name: Login to Artifactory
-        if: steps.check-image-published.outputs.is_image_published == 'false'
-        uses: docker/login-action@v3
-        with:
-          registry: artifactory.cloud.cms.gov
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'

--- a/.github/workflows/cmsgov-build-and-publish.yml
+++ b/.github/workflows/cmsgov-build-and-publish.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   get-commit-hash:
     name: Get commit hash
+    if: github.repository_owner == 'CMSgov'
     runs-on: ubuntu-latest
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
@@ -39,44 +40,40 @@ jobs:
           COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
           echo "Commit hash: $COMMIT_HASH"
           echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+
   build-and-publish:
     name: Build and publish
+    if: github.repository_owner == 'CMSgov'
     runs-on: ubuntu-latest
     needs: get-commit-hash
     concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
 
     permissions:
       contents: read
-      id-token: write
 
     env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      IMAGE_REPOSITORY_URL: artifactory.cloud.cms.gov/emmy-docker/emmy-app
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Login to Docker Hub
-        if: env.DOCKERHUB_TOKEN != ''
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-
-      - name: Set up Terraform
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure AWS credentials
-        uses: ./.github/actions/configure-aws-credentials
-        with:
-          app_name: ${{ inputs.app_name }}
-          environment: shared
+      - name: Get image metadata
+        id: image-metadata
+        run: |
+          image_name=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
+          image_tag=$(make release-image-tag)
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
 
       - name: Check if image is already published
         id: check-image-published
+        env:
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         run: |
-          is_image_published=$(./bin/is-image-published "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          is_image_published=$(./bin/is-artifactory-image-published "${IMAGE_REPOSITORY_URL}" "${{ steps.image-metadata.outputs.image_tag }}")
           echo "Is image published: $is_image_published"
           echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
 
@@ -84,6 +81,16 @@ jobs:
         if: steps.check-image-published.outputs.is_image_published == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-build
 
+      - name: Login to Artifactory
+        if: steps.check-image-published.outputs.is_image_published == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: artifactory.cloud.cms.gov
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'
-        run: make APP_NAME=${{ inputs.app_name }} release-publish
+        run: |
+          docker tag "${{ steps.image-metadata.outputs.image_name }}:${{ steps.image-metadata.outputs.image_tag }}" "${IMAGE_REPOSITORY_URL}:${{ steps.image-metadata.outputs.image_tag }}"
+          docker push "${IMAGE_REPOSITORY_URL}:${{ steps.image-metadata.outputs.image_tag }}"

--- a/.github/workflows/cmsgov-build-and-publish.yml
+++ b/.github/workflows/cmsgov-build-and-publish.yml
@@ -28,6 +28,8 @@ jobs:
     name: Get commit hash
     if: github.repository_owner == 'CMSgov'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
     steps:

--- a/.github/workflows/cmsgov-cd-app.yml
+++ b/.github/workflows/cmsgov-cd-app.yml
@@ -1,0 +1,26 @@
+name: Publish App Image
+run-name: Publish ${{ inputs.commit_sha || github.sha }} to Artifactory
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "app/**"
+      - "bin/**"
+      - "infra/**"
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        required: false
+        type: string
+        description: "SHA to publish (defaults to the workflow trigger SHA)"
+
+jobs:
+  build-and-publish:
+    name: Publish
+    uses: ./.github/workflows/cmsgov-build-and-publish.yml
+    with:
+      app_name: "app"
+      ref: ${{ inputs.commit_sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/cmsgov-cd-app.yml
+++ b/.github/workflows/cmsgov-cd-app.yml
@@ -18,6 +18,10 @@ on:
         type: string
         description: "SHA to publish (defaults to the workflow trigger SHA)"
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-and-publish:
     name: Publish

--- a/.github/workflows/cmsgov-cd-app.yml
+++ b/.github/workflows/cmsgov-cd-app.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - "main"
+      # Temporary branch trigger for pre-merge workflow validation. Remove before merge.
+      - "codex/split-image-publishing-org"
     paths:
       - "app/**"
       - "bin/**"

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -20,7 +20,7 @@ concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }
 jobs:
   build-and-publish:
     name: Build
-    uses: ./.github/workflows/build-and-publish.yml
+    uses: ./.github/workflows/dsacms-build-and-publish.yml
     with:
       app_name: ${{ inputs.app_name }}
       ref: ${{ inputs.commit_sha || github.ref }}

--- a/.github/workflows/dsacms-build-and-publish.yml
+++ b/.github/workflows/dsacms-build-and-publish.yml
@@ -1,0 +1,91 @@
+name: Build and publish
+run-name: Build and publish ${{ inputs.app_name }}:${{ inputs.ref }}
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        required: true
+        type: string
+
+jobs:
+  get-commit-hash:
+    name: Get commit hash
+    if: github.repository_owner == 'DSACMS'
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get commit hash
+        id: get-commit-hash
+        run: |
+          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          echo "Commit hash: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+  build-and-publish:
+    name: Build and publish
+    if: github.repository_owner == 'DSACMS'
+    runs-on: ubuntu-latest
+    needs: get-commit-hash
+    concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Login to Docker Hub
+        if: env.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ inputs.app_name }}
+          environment: shared
+
+      - name: Check if image is already published
+        id: check-image-published
+        run: |
+          is_image_published=$(./bin/is-image-published "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          echo "Is image published: $is_image_published"
+          echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
+
+      - name: Build release
+        if: steps.check-image-published.outputs.is_image_published == 'false'
+        run: make APP_NAME=${{ inputs.app_name }} release-build
+
+      - name: Publish release
+        if: steps.check-image-published.outputs.is_image_published == 'false'
+        run: make APP_NAME=${{ inputs.app_name }} release-publish

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-and-publish:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
-    uses: ./.github/workflows/build-and-publish.yml
+    uses: ./.github/workflows/dsacms-build-and-publish.yml
     with:
       app_name: ${{ inputs.app_name }}
       ref: ${{ inputs.commit_hash }}

--- a/bin/is-artifactory-image-published
+++ b/bin/is-artifactory-image-published
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Checks if an image tag has already been published to Artifactory.
+# Prints "true" if so, "false" otherwise.
+
+set -euo pipefail
+
+image_repository_url="$1"
+image_tag="$2"
+
+registry="${image_repository_url%%/*}"
+repository="${image_repository_url#*/}"
+manifest_url="https://${registry}/v2/${repository}/manifests/${image_tag}"
+
+status_code="$(
+  curl \
+    --silent \
+    --show-error \
+    --output /dev/null \
+    --write-out "%{http_code}" \
+    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" \
+    --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    "${manifest_url}"
+)"
+
+if [ "${status_code}" = "200" ]; then
+  echo "true"
+elif [ "${status_code}" = "404" ]; then
+  echo "false"
+else
+  echo "Unexpected response from Artifactory: ${status_code}" >&2
+  exit 1
+fi

--- a/bin/is-artifactory-image-published
+++ b/bin/is-artifactory-image-published
@@ -1,32 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Checks if an image tag has already been published to Artifactory.
 # Prints "true" if so, "false" otherwise.
 
 set -euo pipefail
 
-image_repository_url="$1"
-image_tag="$2"
+image_tag="$1"
 
-registry="${image_repository_url%%/*}"
-repository="${image_repository_url#*/}"
-manifest_url="https://${registry}/v2/${repository}/manifests/${image_tag}"
-
-status_code="$(
-  curl \
-    --silent \
-    --show-error \
-    --output /dev/null \
-    --write-out "%{http_code}" \
-    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" \
-    --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-    "${manifest_url}"
-)"
-
-if [ "${status_code}" = "200" ]; then
-  echo "true"
-elif [ "${status_code}" = "404" ]; then
-  echo "false"
+if docker manifest inspect \
+          "artifactory.cloud.cms.gov/emmy-docker/emmy-app:${image_tag}" &>/dev/null ; then
+    echo "true"
 else
-  echo "Unexpected response from Artifactory: ${status_code}" >&2
-  exit 1
+    echo "false"
 fi


### PR DESCRIPTION
## Summary
- split Docker image publishing by GitHub organization
- keep the DSACMS reusable workflow publishing to ECR
- add matching CMSgov reusable and top-level workflows to publish to Artifactory

## Testing
- make infra-lint-workflows
- make infra-lint-scripts

## Notes
- includes a temporary branch-trigger commit for `codex/split-image-publishing-org` so the workflows can be validated before merge
- that temporary trigger should be removed before merging
