### PR TITLE
FFS-4079: Fix expiring links early

### DIFF
--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -35,8 +35,7 @@ class CbvFlowInvitation < ApplicationRecord
 
   include Redactable
   has_redactable_fields(
-    email_address: :email,
-    auth_token: :string
+    email_address: :email
   )
 
   scope :unstarted, -> { left_outer_joins(:cbv_flows).where(cbv_flows: { id: nil }) }

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -1,7 +1,7 @@
 # This class is responsible for redacting data on all models in accordance with
 # our data retention policy.
 class DataRetentionService
-  # Redact unstarted and incomplete invitations 7 days after they expire
+  # Redact invitations 7 days after they expire
   REDACT_UNUSED_INVITATIONS_AFTER = 7.days
 
   # Redact transmitted CbvFlows 7 days after they are sent to caseworker
@@ -19,13 +19,13 @@ class DataRetentionService
 
   def redact_invitations
     CbvFlowInvitation
-      .unstarted
       .unredacted
+      .includes(:cbv_applicant, :cbv_flows)
       .find_each do |cbv_flow_invitation|
         next unless Time.current.after?(cbv_flow_invitation.expires_at + REDACT_UNUSED_INVITATIONS_AFTER)
 
         cbv_flow_invitation.redact!
-        cbv_flow_invitation.cbv_applicant&.redact!
+        cbv_flow_invitation.cbv_applicant&.redact! if cbv_flow_invitation.cbv_flows.none?
       end
   end
 
@@ -69,7 +69,6 @@ class DataRetentionService
       .includes(:cbv_flow_invitation, :payroll_accounts)
       .find_each do |cbv_flow|
         cbv_flow.redact!
-        cbv_flow.cbv_flow_invitation.redact! if cbv_flow.cbv_flow_invitation.present?
         cbv_flow.cbv_applicant&.redact!
         cbv_flow.payroll_accounts.each(&:redact!)
       end

--- a/app/spec/controllers/cbv/entries_controller_spec.rb
+++ b/app/spec/controllers/cbv/entries_controller_spec.rb
@@ -235,6 +235,19 @@ RSpec.describe Cbv::EntriesController do
           expect(response).to redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
         end
       end
+
+      context "when the invitation has been redacted" do
+        before do
+          invitation.redact!
+        end
+
+        it "redirects to the expired invitations page" do
+          expect { get :show, params: { token: invitation.auth_token } }
+            .not_to change { session[:flow_id] }
+
+          expect(response).to redirect_to(cbv_flow_expired_invitation_path(client_agency_id: invitation.client_agency_id))
+        end
+      end
     end
 
     context "when the session points to a deleted cbv flow" do

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DataRetentionService do
           service.redact_invitations
           expect(cbv_flow_invitation.reload).to have_attributes(
             email_address: "REDACTED@example.com",
-            auth_token: "REDACTED",
+            auth_token: cbv_flow_invitation.auth_token,
             redacted_at: within(1.second).of(Time.now)
           )
         end
@@ -48,6 +48,26 @@ RSpec.describe DataRetentionService do
           expect_any_instance_of(CbvFlowInvitation)
             .not_to receive(:redact!)
           service.redact_invitations
+        end
+      end
+    end
+
+    context "for a used invitation (with associated CbvFlows)" do
+      before do
+        CbvFlow.create_from_invitation(cbv_flow_invitation, "test_device_id")
+      end
+
+      context "after the deletion threshold" do
+        let(:now) { cbv_flow_invitation.expires_at + 7.days + 1.minute }
+
+        it "redacts the invitation without redacting the applicant" do
+          service.redact_invitations
+
+          expect(cbv_flow_invitation.reload).to have_attributes(
+            auth_token: cbv_flow_invitation.auth_token,
+            redacted_at: within(1.second).of(Time.now)
+          )
+          expect(cbv_flow_invitation.cbv_applicant.reload.redacted_at).to be_nil
         end
       end
     end
@@ -111,7 +131,7 @@ RSpec.describe DataRetentionService do
       it "redacts the associated invitation" do
         service.redact_incomplete_cbv_flows
         expect(cbv_flow_invitation.reload).to have_attributes(
-          auth_token: "REDACTED",
+          auth_token: cbv_flow_invitation.auth_token,
           redacted_at: within(1.second).of(now)
         )
       end
@@ -148,9 +168,14 @@ RSpec.describe DataRetentionService do
             .not_to change { cbv_flow.reload.attributes }
         end
 
-        it "does not redact the invitation" do
-          expect { service.redact_invitations }
-            .not_to change { cbv_flow_invitation.reload.attributes }
+        it "redacts the invitation without redacting the applicant" do
+          service.redact_invitations
+
+          expect(cbv_flow_invitation.reload).to have_attributes(
+            auth_token: cbv_flow_invitation.auth_token,
+            redacted_at: within(1.second).of(now)
+          )
+          expect(cbv_flow.cbv_applicant.reload.redacted_at).to be_nil
         end
       end
     end
@@ -248,12 +273,9 @@ RSpec.describe DataRetentionService do
         )
       end
 
-      it "redacts the associated invitation" do
+      it "does not redact the associated invitation before it expires" do
         service.redact_complete_cbv_flows
-        expect(cbv_flow_invitation.reload).to have_attributes(
-          auth_token: "REDACTED",
-          redacted_at: within(1.second).of(now)
-        )
+        expect(cbv_flow_invitation.reload.redacted_at).to be_nil
       end
 
       it "redacts the associated applicant" do


### PR DESCRIPTION
## [FFS-4079](https://jiraent.cms.gov/browse/FFS-4079)

## Changes
- Fix invitation retention so invitation records are redacted 7 days after `expires_at`, rather than being redacted early when a completed CBV flow hits its transmitted-flow retention window.
- Preserve `auth_token` when redacting `CbvFlowInvitation` so previously-issued links still resolve and show the expired invitation page instead of falling back to the generic flow.

## Acceptance testing
- [x] Acceptance testing in PR Environment (see comment)

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->