### PR TITLE
FFS-4069: Prefix agency with device id for feedback

### DIFF
--- a/app/app/controllers/feedbacks_controller.rb
+++ b/app/app/controllers/feedbacks_controller.rb
@@ -24,13 +24,13 @@ class FeedbacksController < ApplicationController
 
   def redirect_path
     if params[:form] == "survey"
-      survey_form_url
+      append_prefill_params(survey_form_url, ApplicationHelper::SURVEY_FORM_SESSION_ID_ENTRY)
     else
-      append_prefill_params(feedback_form_url)
+      append_prefill_params(feedback_form_url, ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY)
     end
   end
 
-  def append_prefill_params(url)
+  def append_prefill_params(url, entry_key)
     device_id = cookies.permanent.signed[:device_id]
     return url if device_id.blank?
 
@@ -39,7 +39,7 @@ class FeedbacksController < ApplicationController
     uri = URI.parse(url)
     params = URI.decode_www_form(uri.query || "")
     params << [ "usp", "pp_url" ]
-    params << [ ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY, identifier ]
+    params << [ entry_key, identifier ]
     uri.query = URI.encode_www_form(params)
     uri.to_s
   end

--- a/app/app/controllers/feedbacks_controller.rb
+++ b/app/app/controllers/feedbacks_controller.rb
@@ -3,12 +3,13 @@ class FeedbacksController < ApplicationController
 
   def show
     cbv_flow = session[:flow_id] ? CbvFlow.find_by(id: session[:flow_id]) : nil
+    @client_agency_id = cbv_flow&.cbv_applicant&.client_agency_id
     event_name = params[:form] == "survey" ? "ApplicantClickedFeedbackSurveyLink" : "ApplicantClickedFeedbackLink"
     attributes = {
       referer: params[:referer],
       cbv_flow_id: cbv_flow&.id,
       cbv_applicant_id: cbv_flow&.cbv_applicant_id,
-      client_agency_id: cbv_flow&.cbv_applicant&.client_agency_id
+      client_agency_id: @client_agency_id
     }
 
     event_logger.track(event_name, request, {
@@ -33,10 +34,12 @@ class FeedbacksController < ApplicationController
     device_id = cookies.permanent.signed[:device_id]
     return url if device_id.blank?
 
+    identifier = [ @client_agency_id, device_id ].compact.join("/")
+
     uri = URI.parse(url)
     params = URI.decode_www_form(uri.query || "")
     params << [ "usp", "pp_url" ]
-    params << [ ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY, device_id ]
+    params << [ ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY, identifier ]
     uri.query = URI.encode_www_form(params)
     uri.to_s
   end

--- a/app/app/controllers/feedbacks_controller.rb
+++ b/app/app/controllers/feedbacks_controller.rb
@@ -2,13 +2,13 @@ class FeedbacksController < ApplicationController
   include ApplicationHelper
 
   def show
-    cbv_flow = session[:flow_id] ? CbvFlow.find_by(id: session[:flow_id]) : nil
-    @client_agency_id = cbv_flow&.cbv_applicant&.client_agency_id
+    flow = session[:flow_id] ? flow_class.find_by(id: session[:flow_id]) : nil
+    @client_agency_id = flow&.cbv_applicant&.client_agency_id
     event_name = params[:form] == "survey" ? "ApplicantClickedFeedbackSurveyLink" : "ApplicantClickedFeedbackLink"
     attributes = {
       referer: params[:referer],
-      cbv_flow_id: cbv_flow&.id,
-      cbv_applicant_id: cbv_flow&.cbv_applicant_id,
+      cbv_flow_id: flow&.id,
+      cbv_applicant_id: flow&.cbv_applicant_id,
       client_agency_id: @client_agency_id
     }
 

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -81,8 +81,9 @@ module ApplicationHelper
   end
 
   APPLICANT_FEEDBACK_FORM = "https://docs.google.com/forms/d/e/1FAIpQLSdTdLUdhZbn6JcHvR_SN6zbIKhhPfVvs6aeJHz6UrZ9j-83AA/viewform"
-  APPLICANT_SURVEY_FORM = "https://forms.gle/M9jVQNue96rjQTbD9"
+  APPLICANT_SURVEY_FORM = "https://docs.google.com/forms/d/e/1FAIpQLSeQsXvKS3KIKEedwcGxv-c2Qa11hvgr3vyZp1YdLsrQ1Td-qQ/viewform"
   FEEDBACK_FORM_DEVICE_ID_ENTRY = "entry.1176961978"
+  SURVEY_FORM_SESSION_ID_ENTRY = "entry.818699989"
 
   def feedback_form_url
     APPLICANT_FEEDBACK_FORM

--- a/app/spec/controllers/feedbacks_controller_spec.rb
+++ b/app/spec/controllers/feedbacks_controller_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe FeedbacksController, type: :controller do
           )
         )
         expect(response).to have_http_status(:redirect)
-        expected_url = "#{feedback_form_url}?usp=pp_url&#{ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY}=test-device-id-123"
+        agency_prefixed_device_id = "#{cbv_flow.cbv_applicant.client_agency_id}/test-device-id-123"
+        expected_url = "#{feedback_form_url}?usp=pp_url&#{ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY}=#{agency_prefixed_device_id}"
         expect(response.location).to eq(expected_url)
       end
 

--- a/app/spec/controllers/feedbacks_controller_spec.rb
+++ b/app/spec/controllers/feedbacks_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FeedbacksController, type: :controller do
           )
         )
         expect(response).to have_http_status(:redirect)
-        agency_prefixed_device_id = "#{cbv_flow.cbv_applicant.client_agency_id}/test-device-id-123"
+        agency_prefixed_device_id = CGI.escape("#{cbv_flow.cbv_applicant.client_agency_id}/test-device-id-123")
         expected_url = "#{feedback_form_url}?usp=pp_url&#{ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY}=#{agency_prefixed_device_id}"
         expect(response.location).to eq(expected_url)
       end

--- a/app/spec/controllers/feedbacks_controller_spec.rb
+++ b/app/spec/controllers/feedbacks_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FeedbacksController, type: :controller do
 
     before do
       session[:flow_id] = cbv_flow.id
+      session[:flow_type] = :cbv
       allow(controller).to receive(:event_logger).and_return(event_logger)
       allow(event_logger).to receive(:track)
       allow(ApplicationController.helpers).to receive(:feedback_form_url).and_return(feedback_form_url)
@@ -65,6 +66,37 @@ RSpec.describe FeedbacksController, type: :controller do
 
         expect(response).to have_http_status(:redirect)
         expect(response.location).to eq(feedback_form_url)
+      end
+    end
+
+    context "with an activity flow session" do
+      let(:activity_flow) { create(:activity_flow, id: 123, cbv_applicant: create(:cbv_applicant, client_agency_id: "nh_dhhs")) }
+
+      before do
+        create(:cbv_flow, id: 123, cbv_applicant: create(:cbv_applicant, :la_ldh))
+        session[:flow_id] = activity_flow.id
+        session[:flow_type] = :activity
+        cookies.permanent.signed[:device_id] = "test-device-id-123"
+      end
+
+      it "uses the activity flow agency for the prefilled identifier" do
+        referer_url = "http://www.example.com/activities?client_agency_id=nh_dhhs"
+
+        get :show, params: { referer: referer_url }
+
+        expect(event_logger).to have_received(:track).with(
+          "ApplicantClickedFeedbackLink",
+          kind_of(ActionDispatch::Request),
+          hash_including(
+            referer: referer_url,
+            client_agency_id: "nh_dhhs",
+            cbv_flow_id: activity_flow.id,
+            cbv_applicant_id: activity_flow.cbv_applicant_id
+          )
+        )
+        agency_prefixed_device_id = CGI.escape("nh_dhhs/test-device-id-123")
+        expected_url = "#{feedback_form_url}?usp=pp_url&#{ApplicationHelper::FEEDBACK_FORM_DEVICE_ID_ENTRY}=#{agency_prefixed_device_id}"
+        expect(response.location).to eq(expected_url)
       end
     end
   end

--- a/app/spec/controllers/feedbacks_controller_spec.rb
+++ b/app/spec/controllers/feedbacks_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FeedbacksController, type: :controller do
         expect(response.location).to eq(expected_url)
       end
 
-      it "redirects to the survey form without prefill params" do
+      it "redirects to the survey form with prefill params" do
         get :show, params: { form: "survey" }
 
         expect(event_logger).to have_received(:track).with(
@@ -49,7 +49,9 @@ RSpec.describe FeedbacksController, type: :controller do
           )
         )
         expect(response).to have_http_status(:redirect)
-        expect(response.location).to eq(ApplicationController.helpers.survey_form_url)
+        agency_prefixed_device_id = CGI.escape("#{cbv_flow.cbv_applicant.client_agency_id}/test-device-id-123")
+        expected_url = "#{ApplicationHelper::APPLICANT_SURVEY_FORM}?usp=pp_url&#{ApplicationHelper::SURVEY_FORM_SESSION_ID_ENTRY}=#{agency_prefixed_device_id}"
+        expect(response.location).to eq(expected_url)
       end
     end
 


### PR DESCRIPTION
## [FFS-4069](https://jiraent.cms.gov/browse/FFS-4069)

## Changes
- Prefix feedback form device ID param with `client_agency_id` so responses can be differentiated by agency (format: `agency_id/device_id`)

## Context for reviewers
<img width="1040" height="1268" alt="image" src="https://github.com/user-attachments/assets/4333595b-ac18-4a70-b21c-1021dd85c72f" />

- Recorded in [row 14 here.](https://docs.google.com/spreadsheets/d/1FG8TaQHTT9qui5gpbRCv0S8_fVMiAhi_q33hwJmIhnc/edit?resourcekey=&gid=521803766#gid=521803766)
## Acceptance testing
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## Infrastructure Changes
N/A

**Risk / Downtime:** None

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->