### PR TITLE
Allow run-command on PR envs

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -10,6 +10,8 @@
 #     e.g. '[{ "name" : "DB_USER", "value" : "migrator" }]'
 #   --task_role_arn - the IAM role ARN that the task should assume. Overrides the
 #     task role specified in the task definition.
+#   --workspace - the Terraform workspace to use when resolving service outputs.
+#     This is useful for PR environments, which use workspaces like "p-1606".
 #
 # Positional parameters:
 #   app_name (required) - the name of subdirectory of /infra that holds the
@@ -27,6 +29,7 @@ set -euo pipefail
 # Parse optional parameters
 environment_variables=""
 task_role_arn=""
+workspace=""
 while :; do
   case "$1" in
     --environment-variables)
@@ -37,12 +40,18 @@ while :; do
       task_role_arn="$2"
       shift 2
       ;;
+    --workspace)
+      workspace="$2"
+      shift 2
+      ;;
     --help)
       echo "Usage: $0 [app_name] [environment] [command]"
-      echo "  --environment_variables   - JSON list of environment variables"
-      echo "  --task_role_arn           - IAM role ARN that teh task should assume"
+      echo "  --environment-variables   - JSON list of environment variables"
+      echo "  --task-role-arn           - IAM role ARN that the task should assume"
+      echo "  --workspace               - Terraform workspace to select before reading outputs"
       echo
       echo "Example: $0 app prod '[\"echo\", \"Hello, world\"]'"
+      echo "Example: $0 --workspace p-1606 app dev '[\"bin/rails\", \"--version\"]'"
       exit 0
       ;;
     *)
@@ -64,10 +73,14 @@ echo "  environment=${environment}"
 echo "  command=${command}"
 echo "  environment_variables=${environment_variables:-}"
 echo "  task_role_arn=${task_role_arn:-}"
+echo "  workspace=${workspace:-}"
 echo
 
 # Initialize terraform and select workspace if specified
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
+if [ -n "${workspace}" ]; then
+  terraform -chdir="infra/${app_name}/service" workspace select "${workspace}"
+fi
 
 # Use the same cluster, task definition, and network configuration that the application service uses
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)

--- a/bin/run-command
+++ b/bin/run-command
@@ -77,6 +77,11 @@ echo "  workspace=${workspace:-}"
 echo
 
 # Initialize terraform and select workspace if specified
+# If a workspace is specified, reset to default first so that a stale
+# .terraform/environment from a previous run doesn't cause terraform-init to fail.
+if [ -n "${workspace}" ]; then
+  echo "default" > "infra/${app_name}/service/.terraform/environment"
+fi
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
 if [ -n "${workspace}" ]; then
   terraform -chdir="infra/${app_name}/service" workspace select "${workspace}"

--- a/bin/run-command
+++ b/bin/run-command
@@ -79,7 +79,7 @@ echo
 # Initialize terraform and select workspace if specified
 # If a workspace is specified, reset to default first so that a stale
 # .terraform/environment from a previous run doesn't cause terraform-init to fail.
-if [ -n "${workspace}" ]; then
+if [ -n "${workspace}" ] && [ -d "infra/${app_name}/service/.terraform" ]; then
   echo "default" > "infra/${app_name}/service/.terraform/environment"
 fi
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"


### PR DESCRIPTION
## Changes
**Allow run-command on PR envs**
I wanted to [accept this story](https://github.com/DSACMS/iv-cbv-payroll/pull/1606#issuecomment-4254451020) by running commands on a PR environment but wasn't able to. Now you can. 🌟 

- Add `--workspace` flag to `bin/run-command` for selecting Terraform workspace, enables targeting PR environments like `p-1606`)
- Fix help text: correct flag format from underscores to hyphens, fix typo ("teh" → "the")

## Context for reviewers
PR environments use Terraform workspaces (e.g. `p-1606`) separate from the default workspace. Without this flag, `run-command` could only target the default workspace for each environment. Now we can run one-off commands (rails console, migrations, etc.) against PR environments.

## Acceptance testing
- [x] Acceptance testing prior to merge
  * Try running this against the PR environment: 
    * `bin/run-command --workspace p-1613 app dev '["bin/rails","runner", "puts ENV[\"IMAGE_TAG\"]"]'`
    * You should see the current sha `2c2037b37b87a85742be1d6e5675bfd4a9d8796b` put out in the logs, confirming it works.

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->