### PR TITLE
Fix 0 community service hours in CE PDF report

### DIFF
--- a/app/app/views/activities/submit/show.pdf.erb
+++ b/app/app/views/activities/submit/show.pdf.erb
@@ -91,7 +91,7 @@
       <% date_value = activity.date ? l(activity.date) : not_provided %>
       <%= table.with_row do |row| %>
         <% row.with_data_cell.with_content(activity.organization_name.presence || not_provided) %>
-        <% row.with_data_cell.with_content(activity.hours || 0) %>
+        <% row.with_data_cell.with_content(activity.volunteering_activity_months.sum(:hours)) %>
         <% row.with_data_cell.with_content(date_value) %>
       <% end %>
     <% end %>

--- a/app/spec/controllers/activities/submit_controller_spec.rb
+++ b/app/spec/controllers/activities/submit_controller_spec.rb
@@ -41,5 +41,17 @@ RSpec.describe Activities::SubmitController, type: :controller do
       expect(pdf_text).to include(test_confirmation_code)
       expect(pdf_text).to include(I18n.l(frozen_time, format: :long))
     end
+
+    it "renders community service hours from monthly records in the PDF" do
+      activity_flow.update!(completed_at: frozen_time, confirmation_code: test_confirmation_code)
+      volunteering = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Food Pantry", hours: nil)
+      create(:volunteering_activity_month, volunteering_activity: volunteering, month: activity_flow.reporting_window_range.begin, hours: 17)
+      create(:volunteering_activity_month, volunteering_activity: volunteering, month: activity_flow.reporting_window_range.begin + 1.month, hours: 19)
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to match(/Food Pantry\s+36/)
+    end
   end
 end


### PR DESCRIPTION
## Changes
The community service section of the CE PDF report (`/activities/submit.pdf`) was displaying 0 hours for volunteering activities. The template read `activity.hours` instead of summing the actual monthly hour records from `volunteering_activity_months`. `activity.hours` is never written to by the current volunteering flow AFAICT; hours are tracked per-month in `volunteering_activity_months`.

This is consistent with how the work programs section already computes hours via `job_training_activity_months.sum(:hours)`.

## Context for reviewers

The `volunteering_activities.hours` column appears to be a legacy field (?) that isn't populated by the current monthly hours entry flow. The real data lives in `volunteering_activity_months`. The total hours summary row at the top of the PDF was already correct (it uses the progress calculator), but the per-activity row in the community service table was wrong.

I added a test that creates monthly hour records without setting the top-level `hours` attribute, then asserts the PDF renders the correct sum. This test fails without my changes, and passes with them.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## Before

<img width="400"  src="https://github.com/user-attachments/assets/6bc23b3a-c571-4074-8fd7-11b1adeaa88c" />
<img width="400" src="https://github.com/user-attachments/assets/a1855166-297d-4879-ae25-cbd14968f16c" />

## After

<img width="400" src="https://github.com/user-attachments/assets/0a48f8af-c894-41a7-88e2-0dbc4ce4d43e" />
<img width="400" src="https://github.com/user-attachments/assets/bf0132de-7257-4468-9062-3871d94fd6b2" />
<img width="400" src="https://github.com/user-attachments/assets/8758c23d-8adf-48b9-9afd-1c055abeabfd" />