### PR TITLE
FFS-3917: Implement frontend toggle to switch units on the progress indicator

### DIFF
--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -1,28 +1,32 @@
 class ActivityFlowProgressIndicator < ViewComponent::Base
   def self.from_calculator(
     progress_calculator,
-    variant: :application
+    variant: :application,
+    show_unit_toggle: false
   )
     new(
       monthly_calculation_results: progress_calculator.monthly_results,
       variant: variant,
-      required_month_count: progress_calculator.required_month_count
+      required_month_count: progress_calculator.required_month_count,
+      show_unit_toggle: show_unit_toggle
     )
   end
 
   def initialize(
     monthly_calculation_results:,
     variant: :application,
-    required_month_count: nil
+    required_month_count: nil,
+    show_unit_toggle: false
   )
     @monthly_calculation_results = monthly_calculation_results
     @renewal = variant == :renewal
     @required_month_count = normalize_required_month_count(required_month_count)
+    @show_unit_toggle = show_unit_toggle
   end
 
-  def percent_complete(monthly_result)
-    progress_value = progress_value_for(monthly_result)
-    threshold_value = completion_threshold_for(monthly_result)
+  def percent_complete(monthly_result, unit:)
+    progress_value = progress_value_for(monthly_result, unit:)
+    threshold_value = completion_threshold_for(unit:)
 
     [
       (100.0 * progress_value) / threshold_value,
@@ -39,23 +43,23 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
     hours.round(1)
   end
 
-  def display_progress_amount(monthly_result)
-    if display_dollars?(monthly_result)
+  def display_progress_amount(monthly_result, unit:)
+    if unit == :dollars
       format_dollar_amount(monthly_result.total_earnings_cents)
     else
       format_hours(monthly_result.total_hours)
     end
   end
 
-  def display_completion_threshold(monthly_result)
-    if display_dollars?(monthly_result)
+  def display_completion_threshold(monthly_result, unit:)
+    if unit == :dollars
       format_dollar_amount(earnings_completion_threshold)
     else
       hours_completion_threshold
     end
   end
 
-  def display_hours_unit?(monthly_result) = !display_dollars?(monthly_result)
+  def display_hours_unit?(unit:) = unit == :hours
 
   def multi_month? = monthly_calculation_results.length > 1
 
@@ -81,23 +85,31 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
 
   def reporting_window_end_month = ordered_monthly_calculation_results.last&.month
 
+  def show_unit_toggle? = @show_unit_toggle
+
+  def can_toggle_units? = show_unit_toggle? && ordered_monthly_calculation_results.any? { |result| !result.meets_requirements }
+
+  def toggle_label(unit)
+    if multi_month?
+      unit == :hours ? t("activity_flow_progress_indicator.see_progress_in_dollars") : t("activity_flow_progress_indicator.see_progress_in_hours")
+    else
+      unit == :hours ? t("activity_flow_progress_indicator.switch_to_dollars") : t("activity_flow_progress_indicator.switch_to_hours")
+    end
+  end
+
   private
   attr_reader :monthly_calculation_results, :required_month_count
 
-  def display_dollars?(monthly_result)
-    monthly_result.default_unit == :dollars
-  end
-
-  def progress_value_for(monthly_result)
-    if display_dollars?(monthly_result)
+  def progress_value_for(monthly_result, unit:)
+    if unit == :dollars
       monthly_result.total_earnings_cents.to_f
     else
       monthly_result.total_hours.to_f
     end
   end
 
-  def completion_threshold_for(monthly_result)
-    if display_dollars?(monthly_result)
+  def completion_threshold_for(unit:)
+    if unit == :dollars
       earnings_completion_threshold
     else
       hours_completion_threshold

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -69,7 +69,7 @@
         </div>
 
         <div class="activity-flow-progress-indicator__progress-amount-container">
-          <span class="activity-flow-progress-indicator__progress-label">
+          <span>
             <% if multi_month? %>
               <% if monthly_result.meets_requirements %>
                 <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
@@ -81,7 +81,7 @@
               <% [ :hours, :dollars ].each do |unit| %>
                 <button
                   type="button"
-                  class="usa-button usa-button--unstyled activity-flow-progress-indicator__toggle"
+                  class="usa-button usa-button--unstyled"
                   data-action="progress-indicator-units#toggle"
                   data-progress-indicator-units-target="toggle"
                   data-unit="<%= unit %>"
@@ -137,7 +137,7 @@
           <% [ :hours, :dollars ].each do |unit| %>
             <button
               type="button"
-              class="usa-button usa-button--unstyled activity-flow-progress-indicator__toggle"
+              class="usa-button usa-button--unstyled"
               data-action="progress-indicator-units#toggle"
               data-progress-indicator-units-target="toggle"
               data-unit="<%= unit %>"

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -1,6 +1,12 @@
 <%= render(Uswds::Card.new(class: "activity-flow-progress-indicator__card")) do |card| %>
   <% card.with_body do %>
-    <div class="activity-flow-progress-indicator">
+    <div
+      class="activity-flow-progress-indicator"
+      <% if can_toggle_units? %>
+        data-controller="progress-indicator-units"
+        data-progress-indicator-units-unit-value="hours"
+      <% end %>
+    >
       <h2 class="activity-flow-progress-indicator__title">
         <% if renewal? %>
           <% if complete? %>
@@ -38,18 +44,32 @@
       <% end %>
 
       <% ordered_monthly_calculation_results.each do |monthly_result| %>
+        <% completed_unit = monthly_result.default_unit || :hours %>
         <div class="activity-flow-progress-indicator__progress-bar
           <% if monthly_result.meets_requirements %>activity-flow-progress-indicator__progress-bar--complete<% end %>"
         >
-          <div class="activity-flow-progress-indicator__progress-bar-fill
-            <% if monthly_result.meets_requirements %>activity-flow-progress-indicator__progress-bar-fill--complete<% end %>"
-            style="width: <%= percent_complete(monthly_result) %>%"
-          >
-          </div>
+          <% if monthly_result.meets_requirements %>
+            <div
+              class="activity-flow-progress-indicator__progress-bar-fill activity-flow-progress-indicator__progress-bar-fill--complete"
+              style="width: <%= percent_complete(monthly_result, unit: completed_unit) %>%"
+            >
+            </div>
+          <% else %>
+            <% [ :hours, :dollars ].each do |unit| %>
+              <div
+                class="activity-flow-progress-indicator__progress-bar-fill"
+                style="width: <%= percent_complete(monthly_result, unit: unit) %>%"
+                data-progress-indicator-units-target="unitContent"
+                data-unit="<%= unit %>"
+                <% if unit != :hours %>hidden<% end %>
+              >
+              </div>
+            <% end %>
+          <% end %>
         </div>
 
         <div class="activity-flow-progress-indicator__progress-amount-container">
-          <span>
+          <span class="activity-flow-progress-indicator__progress-label">
             <% if multi_month? %>
               <% if monthly_result.meets_requirements %>
                 <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
@@ -57,26 +77,76 @@
                 </svg>
               <% end %>
               <%= l(monthly_result.month, format: :month) %>
+            <% elsif can_toggle_units? %>
+              <% [ :hours, :dollars ].each do |unit| %>
+                <button
+                  type="button"
+                  class="usa-button usa-button--unstyled activity-flow-progress-indicator__toggle"
+                  data-action="progress-indicator-units#toggle"
+                  data-progress-indicator-units-target="toggle"
+                  data-unit="<%= unit %>"
+                  data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
+                  <% if unit != :hours %>hidden<% end %>
+                >
+                  <%= toggle_label(unit) %>
+                </button>
+              <% end %>
             <% end %>
           </span>
 
           <span>
-            <span class="activity-flow-progress-indicator__progress-amount
-                        <% if monthly_result.meets_requirements %>activity-flow-progress-indicator__progress-amount--complete<% end %>">
-              <% if monthly_result.meets_requirements && !multi_month? %>
-                <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-                  <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-                </svg>
-              <% end %>
+            <% if monthly_result.meets_requirements %>
+              <span class="activity-flow-progress-indicator__progress-amount activity-flow-progress-indicator__progress-amount--complete">
+                <% if !multi_month? %>
+                  <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+                    <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+                  </svg>
+                <% end %>
 
-              <%= display_progress_amount(monthly_result) %>
-            </span>
-            /
-            <%= display_completion_threshold(monthly_result) %>
-            <% if display_hours_unit?(monthly_result) %>
-              <%= t(".hours") %>
+                <%= display_progress_amount(monthly_result, unit: completed_unit) %>
+              </span>
+              /
+              <%= display_completion_threshold(monthly_result, unit: completed_unit) %>
+              <% if display_hours_unit?(unit: completed_unit) %>
+                <%= t(".hours") %>
+              <% end %>
+            <% else %>
+              <% [ :hours, :dollars ].each do |unit| %>
+                <span
+                  data-progress-indicator-units-target="unitContent"
+                  data-unit="<%= unit %>"
+                  <% if unit != :hours %>hidden<% end %>
+                >
+                  <span class="activity-flow-progress-indicator__progress-amount">
+                    <%= display_progress_amount(monthly_result, unit: unit) %>
+                  </span>
+                  /
+                  <%= display_completion_threshold(monthly_result, unit: unit) %>
+                  <% if display_hours_unit?(unit: unit) %>
+                    <%= t(".hours") %>
+                  <% end %>
+                </span>
+              <% end %>
             <% end %>
           </span>
+        </div>
+      <% end %>
+
+      <% if can_toggle_units? && multi_month? %>
+        <div class="display-flex flex-justify-center margin-top-1">
+          <% [ :hours, :dollars ].each do |unit| %>
+            <button
+              type="button"
+              class="usa-button usa-button--unstyled activity-flow-progress-indicator__toggle"
+              data-action="progress-indicator-units#toggle"
+              data-progress-indicator-units-target="toggle"
+              data-unit="<%= unit %>"
+              data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
+              <% if unit != :hours %>hidden<% end %>
+            >
+              <%= toggle_label(unit) %>
+            </button>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
@@ -34,13 +34,6 @@
   margin: units(1) 0 units(2);
 }
 
-.activity-flow-progress-indicator__months-completed {
-  @include u-font("sans", "md");
-
-  font-weight: font-weight("bold");
-  margin: 0 0 units(2);
-}
-
 .activity-flow-progress-indicator__progress-bar {
   background-color: color("primary-lighter");
   border-radius: 4px;
@@ -82,6 +75,10 @@
   }
 }
 
+.activity-flow-progress-indicator__progress-label {
+  min-height: 24px;
+}
+
 .activity-flow-progress-indicator__progress-amount {
   color: color("primary-vivid");
 
@@ -95,4 +92,22 @@
   height: 18px;
   vertical-align: text-bottom;
   width: 18px;
+}
+
+.activity-flow-progress-indicator__toggle {
+  @include u-font("sans", "sm");
+
+  color: color("primary");
+  font-weight: font-weight("normal");
+  line-height: 1;
+  text-decoration: underline;
+
+  &:hover {
+    color: color("primary-dark");
+  }
+}
+
+.activity-flow-progress-indicator__toggle[hidden],
+[data-progress-indicator-units-target="unitContent"][hidden] {
+  display: none !important;
 }

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
@@ -75,10 +75,6 @@
   }
 }
 
-.activity-flow-progress-indicator__progress-label {
-  min-height: 24px;
-}
-
 .activity-flow-progress-indicator__progress-amount {
   color: color("primary-vivid");
 
@@ -94,20 +90,7 @@
   width: 18px;
 }
 
-.activity-flow-progress-indicator__toggle {
-  @include u-font("sans", "sm");
-
-  color: color("primary");
-  font-weight: font-weight("normal");
-  line-height: 1;
-  text-decoration: underline;
-
-  &:hover {
-    color: color("primary-dark");
-  }
-}
-
-.activity-flow-progress-indicator__toggle[hidden],
+[data-progress-indicator-units-target="toggle"][hidden],
 [data-progress-indicator-units-target="unitContent"][hidden] {
   display: none !important;
 }

--- a/app/app/javascript/controllers/index.js
+++ b/app/app/javascript/controllers/index.js
@@ -13,6 +13,7 @@ import DemoLauncherController from "./demo_launcher_controller.js"
 import HoursInputController from "./hours_input_controller.js"
 import SelfEmployedController from "./self_employed_controller.js"
 import ActivityFlowHeaderController from "./activity_flow_header_controller.js"
+import ProgressIndicatorUnitsController from "./progress_indicator_units_controller.js"
 
 application.register("cbv-employer-search", CbvEmployerSearch)
 application.register("polling", PollingController)
@@ -27,6 +28,7 @@ application.register("demo-launcher", DemoLauncherController)
 application.register("hours-input", HoursInputController)
 application.register("self-employed", SelfEmployedController)
 application.register("activity-flow-header", ActivityFlowHeaderController)
+application.register("progress-indicator-units", ProgressIndicatorUnitsController)
 
 Turbo.StreamActions.redirect = function () {
   Turbo.visit(this.target)

--- a/app/app/javascript/controllers/progress_indicator_units_controller.js
+++ b/app/app/javascript/controllers/progress_indicator_units_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["toggle", "unitContent"]
+  static values = { unit: String }
+
+  connect() {
+    this.render()
+  }
+
+  toggle(event) {
+    const wasFocused = this.toggleTargets.includes(document.activeElement)
+    this.unitValue = event.currentTarget.dataset.nextUnit
+    this.render()
+    if (wasFocused) {
+      this.toggleTargets.find((toggle) => !toggle.hidden)?.focus()
+    }
+  }
+
+  render() {
+    this.toggleTargets.forEach((toggle) => {
+      toggle.hidden = toggle.dataset.unit !== this.unitValue
+    })
+
+    this.unitContentTargets.forEach((content) => {
+      content.hidden = content.dataset.unit !== this.unitValue
+    })
+  }
+}

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -45,11 +45,13 @@
     <% end %>
 
     <% if any_activities_added %>
+      <% show_progress_unit_toggle = @employment_activities.any? || @employment_payroll_accounts.any? %>
       <div class="margin-top-4">
         <%= render(
           ActivityFlowProgressIndicator.from_calculator(
             progress_calculator,
-            variant: variant
+            variant: variant,
+            show_unit_toggle: show_progress_unit_toggle
           )
         ) %>
       </div>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -535,6 +535,10 @@ en:
     renewal_months_completed: "%{complete}/%{required} months completed"
     renewal_subtitle: Complete any %{required} months between %{start_month}-%{end_month} to meet requirements.
     renewal_subtitle_no_range: Complete any %{required} months to meet requirements.
+    see_progress_in_dollars: See progress in $
+    see_progress_in_hours: See progress in hours
+    switch_to_dollars: Switch to $
+    switch_to_hours: Switch to hours
     title: Your %{month} progress
   aggregator_strings:
     deductions:

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     described_class.new(
       monthly_calculation_results: monthly_calculation_results,
       variant: variant,
-      required_month_count: required_month_count
+      required_month_count: required_month_count,
+      show_unit_toggle: show_unit_toggle
     )
   end
 
@@ -23,6 +24,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   let(:hours) { 40 }
   let(:variant) { :application }
   let(:required_month_count) { nil }
+  let(:show_unit_toggle) { false }
   let(:expected_title) do
     I18n.t(
       "activity_flow_progress_indicator.title",
@@ -53,6 +55,27 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       render_inline(described_class.from_calculator(calculator, variant: :renewal))
 
       expect(page).to have_css("h2", text: "1/1 months completed")
+    end
+
+    it "passes show_unit_toggle through to the component" do
+      monthly_results = [
+        ActivityFlowProgressCalculator::MonthlyResult.new(
+          month: Date.new(2026, 1, 1),
+          total_hours: 40,
+          total_earnings_cents: 500_00,
+          default_unit: :hours,
+          meets_requirements: false
+        )
+      ]
+      calculator = instance_double(
+        ActivityFlowProgressCalculator,
+        monthly_results: monthly_results,
+        required_month_count: 1
+      )
+
+      render_inline(described_class.from_calculator(calculator, show_unit_toggle: true))
+
+      expect(page).to have_button(I18n.t("activity_flow_progress_indicator.switch_to_dollars"))
     end
   end
 
@@ -116,6 +139,37 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     end
   end
 
+  context "when unit toggle is enabled for a single incomplete month" do
+    let(:show_unit_toggle) { true }
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: 40,
+        total_earnings_cents: 500_00,
+        default_unit: :hours,
+        meets_requirements: false
+      )
+    end
+
+    it "renders the single-month toggle in place of the label area" do
+      render_inline(component)
+
+      expect(page).to have_button(I18n.t("activity_flow_progress_indicator.switch_to_dollars"))
+      hours_unit_content_text = page
+        .all("[data-progress-indicator-units-target='unitContent'][data-unit='hours']", visible: :all)
+        .map { |node| node.text.squish }
+      dollars_unit_content_text = page
+        .all("[data-progress-indicator-units-target='unitContent'][data-unit='dollars'][hidden]", visible: :all)
+        .map { |node| node.text.squish }
+
+      expect(hours_unit_content_text).to include(
+        "40 / #{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+        "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      )
+      expect(dollars_unit_content_text).to include("$500 / $580")
+    end
+  end
+
   context "when hours and earnings both meet threshold" do
     let(:monthly_result) do
       ActivityFlowProgressCalculator::MonthlyResult.new(
@@ -131,8 +185,33 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       render_inline(component)
 
       row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
-      expect(row_text).to include("82 / 80 #{I18n.t("activity_flow_progress_indicator.hours")}")
+      expect(row_text).to include(
+        "82 / #{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+        "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      )
       expect(row_text).not_to include("$620 / $580")
+    end
+  end
+
+  context "when a completed month omits default_unit" do
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: 84,
+        total_earnings_cents: 620_00,
+        default_unit: nil,
+        meets_requirements: true
+      )
+    end
+
+    it "falls back to hours for the completed-month unit label" do
+      render_inline(component)
+
+      row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
+      expect(row_text).to include(
+        "84 / #{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+        "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      )
     end
   end
 
@@ -235,6 +314,66 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       expect(page).to have_css("h2", text: "1/3 months completed")
       expect(page).not_to have_css(".activity-flow-progress-indicator__months-completed")
     end
+
+    context "when unit toggle is enabled" do
+      let(:show_unit_toggle) { true }
+      let(:monthly_calculation_results) do
+        [
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 12, 1),
+            total_hours: 40,
+            total_earnings_cents: 500_00,
+            default_unit: :hours,
+            meets_requirements: false
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 11, 1),
+            total_hours: 77,
+            total_earnings_cents: 597_00,
+            default_unit: :dollars,
+            meets_requirements: true
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 10, 1),
+            total_hours: 10,
+            total_earnings_cents: 200_00,
+            default_unit: :hours,
+            meets_requirements: false
+          )
+        ]
+      end
+
+      it "renders the multi-month toggle link" do
+        render_inline(component)
+
+        expect(page).to have_button(I18n.t("activity_flow_progress_indicator.see_progress_in_dollars"))
+      end
+
+      it "shows incomplete months in hours by default and keeps completed months frozen" do
+        render_inline(component)
+        rows = page.all(".activity-flow-progress-indicator__progress-amount-container")
+        expect(rows.length).to eq(3)
+
+        expect(rows[0].text).to include("October")
+        october_hours_content_text = rows[0]
+          .all("[data-progress-indicator-units-target='unitContent'][data-unit='hours']", visible: :all)
+          .map { |node| node.text.squish }
+        expect(october_hours_content_text).to include(
+          "10 / #{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+          "#{I18n.t("activity_flow_progress_indicator.hours")}"
+        )
+        expect(rows[1].text.squish).to include("November")
+        expect(rows[1].text.squish).to include("$597 / $580")
+        expect(rows[2].text).to include("December")
+        december_hours_content_text = rows[2]
+          .all("[data-progress-indicator-units-target='unitContent'][data-unit='hours']", visible: :all)
+          .map { |node| node.text.squish }
+        expect(december_hours_content_text).to include(
+          "40 / #{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+          "#{I18n.t("activity_flow_progress_indicator.hours")}"
+        )
+      end
+    end
   end
 
   context "when variant is renewal" do
@@ -298,6 +437,16 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         .map { |row| row.find("span", match: :first).text.strip }
 
       expect(month_labels).to eq([ "August", "September", "October", "November", "December", "January" ])
+    end
+
+    context "when unit toggle is enabled" do
+      let(:show_unit_toggle) { true }
+
+      it "renders the toggle link for renewal" do
+        render_inline(component)
+
+        expect(page).to have_button(I18n.t("activity_flow_progress_indicator.see_progress_in_dollars"))
+      end
     end
 
     context "when completed months are below the required count" do

--- a/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
+++ b/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
@@ -14,7 +14,17 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     result = make_result(Date.new(2026, 1, 1), 77, earnings_cents: 597_00)
 
     render ActivityFlowProgressIndicator.new(
-      monthly_calculation_results: [ result ]
+      monthly_calculation_results: [ result ],
+      show_unit_toggle: true
+    )
+  end
+
+  def one_month_with_toggle
+    result = make_result(Date.new(2026, 1, 1), 40, earnings_cents: 500_00)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: [ result ],
+      show_unit_toggle: true
     )
   end
 
@@ -52,7 +62,8 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     results << make_result(Date.new(2025, 11, 1), 40, earnings_cents: 200_00) # hours
 
     render ActivityFlowProgressIndicator.new(
-      monthly_calculation_results: results
+      monthly_calculation_results: results,
+      show_unit_toggle: true
     )
   end
 
@@ -69,7 +80,8 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     render ActivityFlowProgressIndicator.new(
       monthly_calculation_results: results,
       variant: :renewal,
-      required_month_count: required_months.to_i
+      required_month_count: required_months.to_i,
+      show_unit_toggle: true
     )
   end
 

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(indicator_title).to eq("0/2 months completed")
       expect(rendered).not_to have_css(".activity-flow-progress-indicator__months-completed")
     end
+
+    it "does not show the unit toggle for non-employment activity-only flows" do
+      rendered = Capybara.string(response.body)
+
+      expect(rendered).not_to have_css("[data-controller='progress-indicator-units']")
+      expect(rendered).not_to have_css(".activity-flow-progress-indicator__toggle")
+    end
   end
 
   context "when no activities are added" do
@@ -743,6 +750,13 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(response.body).to include("Gainesville Wrecking")
       expect(response.body).to include(I18n.t("activities.hub.cards.gross_income", amount: "$500.00"))
       expect(response.body).to include(I18n.t("activities.hub.cards.hours", count: 40))
+    end
+
+    it "shows the unit toggle for employment flows" do
+      rendered = Capybara.string(response.body)
+
+      expect(rendered).to have_css("[data-controller='progress-indicator-units']")
+      expect(rendered).to have_css(".activity-flow-progress-indicator__toggle")
     end
   end
 end

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -756,7 +756,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       rendered = Capybara.string(response.body)
 
       expect(rendered).to have_css("[data-controller='progress-indicator-units']")
-      expect(rendered).to have_css(".activity-flow-progress-indicator__toggle")
+      expect(rendered).to have_css("[data-progress-indicator-units-target='toggle']")
     end
   end
 end

--- a/app/spec/e2e/activity_hub_spec.rb
+++ b/app/spec/e2e/activity_hub_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     expect(page).to have_content "Gainesville Wrecking"
     expect(page).to have_content I18n.t("activities.hub.cards.gross_income", amount: "$500.00")
     expect(page).to have_content I18n.t("activities.hub.cards.hours", count: 40)
+    expect(page).to have_button(I18n.t("activity_flow_progress_indicator.see_progress_in_dollars"))
+
+    click_button I18n.t("activity_flow_progress_indicator.see_progress_in_dollars")
+    expect(page).to have_button(I18n.t("activity_flow_progress_indicator.see_progress_in_hours"))
+    expect(page).to have_content "$500 / $580"
 
     # Verify that the hub has the Community Service activity
     expect(page).to have_content I18n.t("activities.hub.in_progress_state_title")

--- a/app/spec/javascript/controllers/progress_indicator_units.spec.js
+++ b/app/spec/javascript/controllers/progress_indicator_units.spec.js
@@ -1,0 +1,52 @@
+import { describe, beforeEach, afterEach, it, expect } from "vitest"
+import ProgressIndicatorUnitsController from "@js/controllers/progress_indicator_units_controller"
+
+describe("ProgressIndicatorUnitsController", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div
+        data-controller="progress-indicator-units"
+        data-progress-indicator-units-unit-value="hours"
+      >
+        <button
+          type="button"
+          data-action="progress-indicator-units#toggle"
+          data-progress-indicator-units-target="toggle"
+          data-unit="hours"
+          data-next-unit="dollars"
+        >
+          Toggle to dollars
+        </button>
+        <button
+          type="button"
+          data-action="progress-indicator-units#toggle"
+          data-progress-indicator-units-target="toggle"
+          data-unit="dollars"
+          data-next-unit="hours"
+          hidden
+        >
+          Toggle to hours
+        </button>
+        <span data-progress-indicator-units-target="unitContent" data-unit="hours">hours content</span>
+        <span data-progress-indicator-units-target="unitContent" data-unit="dollars" hidden>dollars content</span>
+      </div>
+    `
+
+    window.Stimulus.register("progress-indicator-units", ProgressIndicatorUnitsController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("keeps keyboard focus on the visible toggle after switching", () => {
+    const dollarsToggle = document.querySelector("[data-next-unit='dollars']")
+    const hoursToggle = document.querySelector("[data-next-unit='hours']")
+
+    dollarsToggle.focus()
+    dollarsToggle.click()
+
+    expect(hoursToggle.hidden).toBe(false)
+    expect(document.activeElement).toBe(hoursToggle)
+  })
+})


### PR DESCRIPTION
## [FFS-3917](https://jiraent.cms.gov/browse/FFS-3917)

## Changes
<!-- What was added, updated, or removed in this PR. -->
 - Added hours/$ unit toggle to activity hub progress indicator for employment data (single month, multi month, renewal)
- Toggle only happens for incomplete months whereas completed months stay fixed to completed unit
- Stimulus controller for toggle behavior

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<details>
<summary>Screenshots Spam</summary>

**Single month $, hours & completed**
<img width="355" height="183" alt="Screenshot 2026-04-17 at 3 30 54 PM" src="https://github.com/user-attachments/assets/add6a50d-a51f-4fc4-9eda-e0475f7e0670" />
<img width="351" height="182" alt="Screenshot 2026-04-17 at 3 30 47 PM" src="https://github.com/user-attachments/assets/cb6d01c1-9c56-4252-b291-edb6b0d02a1d" />
<img width="352" height="178" alt="Screenshot 2026-04-17 at 3 32 16 PM" src="https://github.com/user-attachments/assets/abf5e1b1-8189-412d-aa04-37295a410391" />
<img width="357" height="186" alt="Screenshot 2026-04-17 at 3 31 54 PM" src="https://github.com/user-attachments/assets/4822f24b-a1e5-4bdc-8abd-b91cffe743af" />


**Multi-month $, hours, completed**
<img width="375" height="296" alt="Screenshot 2026-04-17 at 3 29 31 PM" src="https://github.com/user-attachments/assets/2045eaff-a69e-4297-bb76-d8ac0cdbc8f9" />
<img width="356" height="271" alt="Screenshot 2026-04-17 at 3 29 21 PM" src="https://github.com/user-attachments/assets/c5bf73a8-d276-413d-8b0c-4cd984fb94db" />
<img width="354" height="285" alt="Screenshot 2026-04-17 at 3 33 39 PM" src="https://github.com/user-attachments/assets/ac735a3e-a823-47e8-9311-782e73684ace" />
<img width="364" height="286" alt="Screenshot 2026-04-17 at 3 33 18 PM" src="https://github.com/user-attachments/assets/257e9440-d846-4684-9074-866facdb35b8" />


**Renewal**
<img width="367" height="625" alt="Screenshot 2026-04-17 at 3 45 51 PM" src="https://github.com/user-attachments/assets/8ad66458-1041-4b8f-a2bd-66d0439d60d6" />
<img width="364" height="633" alt="Screenshot 2026-04-17 at 3 47 40 PM" src="https://github.com/user-attachments/assets/c3528c03-6379-470c-83be-25ef1956b00e" />

</details>

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->