### PR TITLE
Fix ArgumentError by disabling NewRelic SemanticLogger integration

### DIFF
--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -58,6 +58,12 @@ common: &default_settings
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  instrumentation:
+    # Disable SemanticLogger integration as we use SemanticLogger's NewRelic
+    # forwarder, which works better (doesn't give a 500 error when reporting an
+    # exception).
+    semantic_logger: disabled
+
   # Instrument CBV custom rake tasks:
   rake:
     tasks: [ "data_deletion:.+", "weekly_reports:.+" ]


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## N/A - Oncall bugfix

## Changes
<!-- What was added, updated, or removed in this PR. -->

* **Disable NewRelic SemanticLogger integration**

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

On a page that raises an exception (for example a 404 page), these were
turning into a 500 error due to a complex monkeypatching battle between
NewRelic and SemanticLogger, both vying for control over the logger.

This is due to NewRelic 10.3.0 adding first-party support for
SemanticLogger (see https://github.com/newrelic/newrelic-ruby-agent/pull/3467).

Their docs recommend enabling only one or the other. Disabling NewRelic
seems to fix the ArgumentError triggered on a 404 page.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
