### PR TITLE
FFS-3920: Implement progress indicator variants on the activity flow review page

### DIFF
--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -2,13 +2,15 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
   def self.from_calculator(
     progress_calculator,
     variant: :application,
-    show_unit_toggle: false
+    show_unit_toggle: false,
+    display_variant: :default
   )
     new(
       monthly_calculation_results: progress_calculator.monthly_results,
       variant: variant,
       required_month_count: progress_calculator.required_month_count,
-      show_unit_toggle: show_unit_toggle
+      show_unit_toggle: show_unit_toggle,
+      display_variant: display_variant
     )
   end
 
@@ -16,10 +18,12 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
     monthly_calculation_results:,
     variant: :application,
     required_month_count: nil,
-    show_unit_toggle: false
+    show_unit_toggle: false,
+    display_variant: :default
   )
     @monthly_calculation_results = monthly_calculation_results
     @renewal = variant == :renewal
+    @review = display_variant == :review
     @required_month_count = normalize_required_month_count(required_month_count)
     @show_unit_toggle = show_unit_toggle
   end
@@ -64,6 +68,18 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
   def multi_month? = monthly_calculation_results.length > 1
 
   def complete_month_count = monthly_calculation_results.count(&:meets_requirements)
+
+  def completed_months_label
+    if renewal?
+      t(".renewal_months_completed", complete: complete_month_count, required: required_month_count)
+    else
+      t(".application_months_completed", complete: complete_month_count, total: total_month_count)
+    end
+  end
+
+  def collapsed? = review? && complete?
+
+  def review? = @review
 
   def total_month_count = monthly_calculation_results.length
 

--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -71,9 +71,9 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
 
   def completed_months_label
     if renewal?
-      t(".renewal_months_completed", complete: complete_month_count, required: required_month_count)
+      t("activity_flow_progress_indicator.renewal_months_completed", complete: complete_month_count, required: required_month_count)
     else
-      t(".application_months_completed", complete: complete_month_count, total: total_month_count)
+      t("activity_flow_progress_indicator.application_months_completed", complete: complete_month_count, total: total_month_count)
     end
   end
 

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -2,12 +2,12 @@
 
 <% if collapsed? %>
   <div class="activity-flow-progress-indicator activity-flow-progress-indicator--review-collapsed <%= review_width_class %>">
-    <p class="activity-flow-progress-indicator__title">
+    <h3 class="activity-flow-progress-indicator__title">
       <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
         <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
       </svg>
       <%= completed_months_label %>
-    </p>
+    </h3>
   </div>
 <% else %>
   <% card_classes = [ "activity-flow-progress-indicator__card", review_width_class ] %>
@@ -21,7 +21,7 @@
           data-progress-indicator-units-unit-value="hours"
         <% end %>
       >
-        <h2 class="activity-flow-progress-indicator__title">
+        <h3 class="activity-flow-progress-indicator__title">
           <% if review? || renewal? || multi_month? %>
             <% if complete? %>
               <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
@@ -33,7 +33,7 @@
             <% first_month = ordered_monthly_calculation_results.first.month %>
             <%= t(".title", month: l(first_month, format: :month)) %>
           <% end %>
-        </h2>
+        </h3>
 
         <% if renewal_requires_subset_months? && !review? %>
           <p class="activity-flow-progress-indicator__description">

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -3,12 +3,12 @@
 <% if collapsed? %>
   <% success_icon_href = helpers.uswds_sprite_icon_href("check_circle") %>
   <div class="activity-flow-progress-indicator activity-flow-progress-indicator--review-collapsed <%= review_width_class %>">
-    <h3 class="activity-flow-progress-indicator__title">
+    <h2 class="activity-flow-progress-indicator__title">
       <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
         <use xlink:href="<%= success_icon_href %>"></use>
       </svg>
       <%= completed_months_label %>
-    </h3>
+    </h2>
   </div>
 <% else %>
   <% card_classes = [ "activity-flow-progress-indicator__card", review_width_class ] %>
@@ -23,7 +23,7 @@
           data-progress-indicator-units-unit-value="hours"
         <% end %>
       >
-        <h3 class="activity-flow-progress-indicator__title">
+        <h2 class="activity-flow-progress-indicator__title">
           <% if review? || renewal? || multi_month? %>
             <% if complete? %>
               <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
@@ -35,7 +35,7 @@
             <% first_month = ordered_monthly_calculation_results.first.month %>
             <%= t(".title", month: l(first_month, format: :month)) %>
           <% end %>
-        </h3>
+        </h2>
 
         <% if renewal_requires_subset_months? && !review? %>
           <p class="activity-flow-progress-indicator__description">

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -1,154 +1,162 @@
-<%= render(Uswds::Card.new(class: "activity-flow-progress-indicator__card")) do |card| %>
-  <% card.with_body do %>
-    <div
-      class="activity-flow-progress-indicator"
-      <% if can_toggle_units? %>
-        data-controller="progress-indicator-units"
-        data-progress-indicator-units-unit-value="hours"
-      <% end %>
-    >
-      <h2 class="activity-flow-progress-indicator__title">
-        <% if renewal? %>
-          <% if complete? %>
-            <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-            </svg>
-          <% end %>
-          <%= t(".renewal_months_completed", complete: complete_month_count, required: required_month_count) %>
-        <% elsif multi_month? %>
-          <% if complete? %>
-            <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-            </svg>
-          <% end %>
-          <%= t(".application_months_completed", complete: complete_month_count, total: total_month_count) %>
-        <% else %>
-          <% first_month = ordered_monthly_calculation_results.first.month %>
-          <%= t(".title", month: l(first_month, format: :month)) %>
+<% review_width_class = review? ? "maxw-table" : nil %>
+
+<% if collapsed? %>
+  <div class="activity-flow-progress-indicator activity-flow-progress-indicator--review-collapsed <%= review_width_class %>">
+    <p class="activity-flow-progress-indicator__title">
+      <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+      </svg>
+      <%= completed_months_label %>
+    </p>
+  </div>
+<% else %>
+  <% card_classes = [ "activity-flow-progress-indicator__card", review_width_class ] %>
+  <% card_classes << "activity-flow-progress-indicator__card--review" if review? %>
+  <%= render(Uswds::Card.new(class: card_classes.join(" "))) do |card| %>
+    <% card.with_body do %>
+      <div
+        class="activity-flow-progress-indicator"
+        <% if can_toggle_units? %>
+          data-controller="progress-indicator-units"
+          data-progress-indicator-units-unit-value="hours"
         <% end %>
-      </h2>
-
-      <% if renewal_requires_subset_months? %>
-        <p class="activity-flow-progress-indicator__description">
-          <% if reporting_window_start_month && reporting_window_end_month %>
-            <%= t(
-              ".renewal_subtitle",
-              required: required_month_count,
-              start_month: l(reporting_window_start_month, format: :month),
-              end_month: l(reporting_window_end_month, format: :month)
-            ) %>
+      >
+        <h2 class="activity-flow-progress-indicator__title">
+          <% if review? || renewal? || multi_month? %>
+            <% if complete? %>
+              <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+                <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+              </svg>
+            <% end %>
+            <%= completed_months_label %>
           <% else %>
-            <%= t(".renewal_subtitle_no_range", required: required_month_count) %>
+            <% first_month = ordered_monthly_calculation_results.first.month %>
+            <%= t(".title", month: l(first_month, format: :month)) %>
           <% end %>
-        </p>
-      <% end %>
+        </h2>
 
-      <% ordered_monthly_calculation_results.each do |monthly_result| %>
-        <% completed_unit = monthly_result.default_unit || :hours %>
-        <div class="activity-flow-progress-indicator__progress-bar
-          <% if monthly_result.meets_requirements %>activity-flow-progress-indicator__progress-bar--complete<% end %>"
-        >
-          <% if monthly_result.meets_requirements %>
-            <div
-              class="activity-flow-progress-indicator__progress-bar-fill activity-flow-progress-indicator__progress-bar-fill--complete"
-              style="width: <%= percent_complete(monthly_result, unit: completed_unit) %>%"
-            >
-            </div>
-          <% else %>
-            <% [ :hours, :dollars ].each do |unit| %>
+        <% if renewal_requires_subset_months? && !review? %>
+          <p class="activity-flow-progress-indicator__description">
+            <% if reporting_window_start_month && reporting_window_end_month %>
+              <%= t(
+                ".renewal_subtitle",
+                required: required_month_count,
+                start_month: l(reporting_window_start_month, format: :month),
+                end_month: l(reporting_window_end_month, format: :month)
+              ) %>
+            <% else %>
+              <%= t(".renewal_subtitle_no_range", required: required_month_count) %>
+            <% end %>
+          </p>
+        <% end %>
+
+        <% ordered_monthly_calculation_results.each do |monthly_result| %>
+          <% completed_unit = monthly_result.default_unit || :hours %>
+          <div class="activity-flow-progress-indicator__progress-bar
+            <% if monthly_result.meets_requirements %>activity-flow-progress-indicator__progress-bar--complete<% end %>"
+          >
+            <% if monthly_result.meets_requirements %>
               <div
-                class="activity-flow-progress-indicator__progress-bar-fill"
-                style="width: <%= percent_complete(monthly_result, unit: unit) %>%"
-                data-progress-indicator-units-target="unitContent"
-                data-unit="<%= unit %>"
-                <% if unit != :hours %>hidden<% end %>
+                class="activity-flow-progress-indicator__progress-bar-fill activity-flow-progress-indicator__progress-bar-fill--complete"
+                style="width: <%= percent_complete(monthly_result, unit: completed_unit) %>%"
               >
               </div>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="activity-flow-progress-indicator__progress-amount-container">
-          <span>
-            <% if multi_month? %>
-              <% if monthly_result.meets_requirements %>
-                <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-                  <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-                </svg>
-              <% end %>
-              <%= l(monthly_result.month, format: :month) %>
-            <% elsif can_toggle_units? %>
-              <% [ :hours, :dollars ].each do |unit| %>
-                <button
-                  type="button"
-                  class="usa-button usa-button--unstyled"
-                  data-action="progress-indicator-units#toggle"
-                  data-progress-indicator-units-target="toggle"
-                  data-unit="<%= unit %>"
-                  data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
-                  <% if unit != :hours %>hidden<% end %>
-                >
-                  <%= toggle_label(unit) %>
-                </button>
-              <% end %>
-            <% end %>
-          </span>
-
-          <span>
-            <% if monthly_result.meets_requirements %>
-              <span class="activity-flow-progress-indicator__progress-amount activity-flow-progress-indicator__progress-amount--complete">
-                <% if !multi_month? %>
-                  <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
-                    <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
-                  </svg>
-                <% end %>
-
-                <%= display_progress_amount(monthly_result, unit: completed_unit) %>
-              </span>
-              /
-              <%= display_completion_threshold(monthly_result, unit: completed_unit) %>
-              <% if display_hours_unit?(unit: completed_unit) %>
-                <%= t(".hours") %>
-              <% end %>
             <% else %>
               <% [ :hours, :dollars ].each do |unit| %>
-                <span
+                <div
+                  class="activity-flow-progress-indicator__progress-bar-fill"
+                  style="width: <%= percent_complete(monthly_result, unit: unit) %>%"
                   data-progress-indicator-units-target="unitContent"
                   data-unit="<%= unit %>"
                   <% if unit != :hours %>hidden<% end %>
                 >
-                  <span class="activity-flow-progress-indicator__progress-amount">
-                    <%= display_progress_amount(monthly_result, unit: unit) %>
-                  </span>
-                  /
-                  <%= display_completion_threshold(monthly_result, unit: unit) %>
-                  <% if display_hours_unit?(unit: unit) %>
-                    <%= t(".hours") %>
-                  <% end %>
-                </span>
+                </div>
               <% end %>
             <% end %>
-          </span>
-        </div>
-      <% end %>
+          </div>
 
-      <% if can_toggle_units? && multi_month? %>
-        <div class="display-flex flex-justify-center margin-top-1">
-          <% [ :hours, :dollars ].each do |unit| %>
-            <button
-              type="button"
-              class="usa-button usa-button--unstyled"
-              data-action="progress-indicator-units#toggle"
-              data-progress-indicator-units-target="toggle"
-              data-unit="<%= unit %>"
-              data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
-              <% if unit != :hours %>hidden<% end %>
-            >
-              <%= toggle_label(unit) %>
-            </button>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
+          <div class="activity-flow-progress-indicator__progress-amount-container">
+            <span>
+              <% if multi_month? %>
+                <% if monthly_result.meets_requirements %>
+                  <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+                    <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+                  </svg>
+                <% end %>
+                <%= l(monthly_result.month, format: :month) %>
+              <% elsif can_toggle_units? %>
+                <% [ :hours, :dollars ].each do |unit| %>
+                  <button
+                    type="button"
+                    class="usa-button usa-button--unstyled"
+                    data-action="progress-indicator-units#toggle"
+                    data-progress-indicator-units-target="toggle"
+                    data-unit="<%= unit %>"
+                    data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
+                    <% if unit != :hours %>hidden<% end %>
+                  >
+                    <%= toggle_label(unit) %>
+                  </button>
+                <% end %>
+              <% end %>
+            </span>
+
+            <span>
+              <% if monthly_result.meets_requirements %>
+                <span class="activity-flow-progress-indicator__progress-amount activity-flow-progress-indicator__progress-amount--complete">
+                  <% if !multi_month? %>
+                    <svg class="usa-icon activity-flow-progress-indicator__success-icon" aria-hidden="true" focusable="false" role="img">
+                      <use xlink:href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#check_circle") %>"></use>
+                    </svg>
+                  <% end %>
+
+                  <%= display_progress_amount(monthly_result, unit: completed_unit) %>
+                </span>
+                /
+                <%= display_completion_threshold(monthly_result, unit: completed_unit) %>
+                <% if display_hours_unit?(unit: completed_unit) %>
+                  <%= t(".hours") %>
+                <% end %>
+              <% else %>
+                <% [ :hours, :dollars ].each do |unit| %>
+                  <span
+                    data-progress-indicator-units-target="unitContent"
+                    data-unit="<%= unit %>"
+                    <% if unit != :hours %>hidden<% end %>
+                  >
+                    <span class="activity-flow-progress-indicator__progress-amount">
+                      <%= display_progress_amount(monthly_result, unit: unit) %>
+                    </span>
+                    /
+                    <%= display_completion_threshold(monthly_result, unit: unit) %>
+                    <% if display_hours_unit?(unit: unit) %>
+                      <%= t(".hours") %>
+                    <% end %>
+                  </span>
+                <% end %>
+              <% end %>
+            </span>
+          </div>
+        <% end %>
+
+        <% if can_toggle_units? && multi_month? %>
+          <div class="display-flex flex-justify-center margin-top-1">
+            <% [ :hours, :dollars ].each do |unit| %>
+              <button
+                type="button"
+                class="usa-button usa-button--unstyled"
+                data-action="progress-indicator-units#toggle"
+                data-progress-indicator-units-target="toggle"
+                data-unit="<%= unit %>"
+                data-next-unit="<%= unit == :hours ? :dollars : :hours %>"
+                <% if unit != :hours %>hidden<% end %>
+              >
+                <%= toggle_label(unit) %>
+              </button>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
@@ -25,13 +25,9 @@
 }
 
 .activity-flow-progress-indicator__title {
-  @include u-font("sans", "lg");
-
   align-items: center;
   display: flex;
-  font-weight: font-weight("bold");
   gap: units(1);
-  line-height: 1.3;
   margin: 0;
 }
 

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss
@@ -16,6 +16,14 @@
   }
 }
 
+.activity-flow-progress-indicator--review-collapsed {
+  background-color: color("success-lighter");
+  border: 1px solid color("success-dark");
+  border-radius: radius("md");
+  margin-top: units(2);
+  padding: units(3);
+}
+
 .activity-flow-progress-indicator__title {
   @include u-font("sans", "lg");
 

--- a/app/app/views/activities/summary/show.html.erb
+++ b/app/app/views/activities/summary/show.html.erb
@@ -29,9 +29,16 @@
   <% end %>
 </p>
 
-<%= render(ActivityFlowProgressIndicator.from_calculator(progress_calculator)) %>
+<% show_progress_unit_toggle = @self_attested_employment_activities.any? || @employment_payroll_accounts.any? %>
 
-<hr class="border-gray-30 border-top-0 margin-bottom-4">
+<%= render(
+  ActivityFlowProgressIndicator.from_calculator(
+    progress_calculator,
+    variant: @flow.renewal_reporting_window? ? :renewal : :application,
+    show_unit_toggle: show_progress_unit_toggle,
+    display_variant: :review
+  )
+) %>
 
 <div class="margin-top-4">
 <% @all_activities.each_with_index do |activity_data, index| %>

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
 
       render_inline(described_class.from_calculator(calculator, variant: :renewal))
 
-      expect(page).to have_css("h2", text: "1/1 months completed")
+      expect(page).to have_css("h3", text: "1/1 months completed")
     end
 
     it "passes show_unit_toggle through to the component" do
@@ -126,7 +126,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       render_inline(component)
 
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h2", text: "1/2 months completed")
+      expect(page).to have_css("h3", text: "1/2 months completed")
       expect(page).to have_css(".activity-flow-progress-indicator__progress-bar", count: 2)
     end
 
@@ -144,7 +144,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "uses the months completed title on the review page" do
         render_inline(component)
 
-        expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "0/1 months completed")
+        expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "0/1 months completed")
       end
     end
 
@@ -212,7 +212,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   it "renders the title without description for application variants" do
     render_inline(component)
 
-    expect(page).to have_css("h2", text: expected_title)
+    expect(page).to have_css("h3", text: expected_title)
     expect(page).not_to have_css(".activity-flow-progress-indicator__description")
   end
 
@@ -396,7 +396,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "falls back to application rendering" do
       render_inline(component)
 
-      expect(page).to have_css("h2", text: expected_title)
+      expect(page).to have_css("h3", text: expected_title)
       expect(page).not_to have_css(".activity-flow-progress-indicator__description")
     end
   end
@@ -441,7 +441,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "includes a 'months completed' message" do
       render_inline(component)
 
-      expect(page).to have_css("h2", text: "1/3 months completed")
+      expect(page).to have_css("h3", text: "1/3 months completed")
       expect(page).not_to have_css(".activity-flow-progress-indicator__months-completed")
     end
 
@@ -547,7 +547,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "renders the renewal title and subtitle" do
       render_inline(component)
 
-      expect(page).to have_css("h2", text: "4/3 months completed")
+      expect(page).to have_css("h3", text: "4/3 months completed")
       expect(page).to have_text(
         "Complete any 3 months between August-January to meet requirements."
       )
@@ -556,7 +556,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "shows a success icon in the header when renewal requirements are complete" do
       render_inline(component)
 
-      expect(page).to have_css("h2 .activity-flow-progress-indicator__success-icon")
+      expect(page).to have_css("h3 .activity-flow-progress-indicator__success-icon")
     end
 
     it "renders renewal months oldest to newest" do
@@ -618,7 +618,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "uses required_month_count as the denominator while remaining incomplete" do
         render_inline(component)
 
-        expect(page).to have_css("h2", text: "2/3 months completed")
+        expect(page).to have_css("h3", text: "2/3 months completed")
       end
     end
 
@@ -629,7 +629,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         render_inline(component)
 
         expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
-        expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "4/3 months completed")
+        expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "4/3 months completed")
       end
     end
 
@@ -683,7 +683,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "defaults required_month_count to the reporting window length" do
         render_inline(component)
 
-        expect(page).to have_css("h2", text: "4/6 months completed")
+        expect(page).to have_css("h3", text: "4/6 months completed")
         expect(page).not_to have_css(".activity-flow-progress-indicator__description")
       end
     end

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       monthly_calculation_results: monthly_calculation_results,
       variant: variant,
       required_month_count: required_month_count,
-      show_unit_toggle: show_unit_toggle
+      show_unit_toggle: show_unit_toggle,
+      display_variant: display_variant
     )
   end
 
@@ -25,6 +26,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   let(:variant) { :application }
   let(:required_month_count) { nil }
   let(:show_unit_toggle) { false }
+  let(:display_variant) { :default }
   let(:expected_title) do
     I18n.t(
       "activity_flow_progress_indicator.title",
@@ -76,6 +78,134 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       render_inline(described_class.from_calculator(calculator, show_unit_toggle: true))
 
       expect(page).to have_button(I18n.t("activity_flow_progress_indicator.switch_to_dollars"))
+    end
+
+    it "forwards display_variant" do
+      monthly_results = [
+        ActivityFlowProgressCalculator::MonthlyResult.new(
+          month: Date.new(2025, 12, 1),
+          total_hours: 84,
+          meets_requirements: true
+        ),
+        ActivityFlowProgressCalculator::MonthlyResult.new(
+          month: Date.new(2026, 1, 1),
+          total_hours: 20,
+          meets_requirements: false
+        )
+      ]
+      calculator = instance_double(
+        ActivityFlowProgressCalculator,
+        monthly_results: monthly_results,
+        required_month_count: 1
+      )
+
+      render_inline(described_class.from_calculator(calculator, display_variant: :review))
+
+      expect(page).to have_css(".activity-flow-progress-indicator__card--review")
+    end
+  end
+
+  context "when display variant is review" do
+    let(:display_variant) { :review }
+    let(:monthly_calculation_results) do
+      [
+        ActivityFlowProgressCalculator::MonthlyResult.new(
+          month: Date.new(2025, 12, 1),
+          total_hours: 20,
+          meets_requirements: false
+        ),
+        ActivityFlowProgressCalculator::MonthlyResult.new(
+          month: Date.new(2026, 1, 1),
+          total_hours: 84,
+          meets_requirements: true
+        )
+      ]
+    end
+
+    it "renders a review-width card with the months completed title" do
+      render_inline(component)
+
+      expect(page).to have_css(".activity-flow-progress-indicator__card--review")
+      expect(page).to have_css("h2", text: "1/2 months completed")
+      expect(page).to have_css(".activity-flow-progress-indicator__progress-bar", count: 2)
+    end
+
+    context "when there is a single incomplete month" do
+      let(:monthly_calculation_results) do
+        [
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2026, 1, 1),
+            total_hours: 20,
+            meets_requirements: false
+          )
+        ]
+      end
+
+      it "uses the months completed title on the review page" do
+        render_inline(component)
+
+        expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "0/1 months completed")
+      end
+    end
+
+    context "when unit toggle is enabled for incomplete months" do
+      let(:show_unit_toggle) { true }
+      let(:monthly_calculation_results) do
+        [
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 12, 1),
+            total_hours: 40,
+            total_earnings_cents: 500_00,
+            default_unit: :hours,
+            meets_requirements: false
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2026, 1, 1),
+            total_hours: 20,
+            total_earnings_cents: 200_00,
+            default_unit: :hours,
+            meets_requirements: false
+          )
+        ]
+      end
+
+      it "renders the toggle inside the review card" do
+        render_inline(component)
+
+        expect(page).to have_css(".activity-flow-progress-indicator__card--review [data-controller='progress-indicator-units']")
+        expect(page).to have_button(I18n.t("activity_flow_progress_indicator.see_progress_in_dollars"))
+      end
+    end
+
+    context "when all months are complete" do
+      let(:monthly_calculation_results) do
+        [
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 12, 1),
+            total_hours: 84,
+            meets_requirements: true
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2026, 1, 1),
+            total_hours: 90,
+            meets_requirements: true
+          )
+        ]
+      end
+
+      it "renders the collapsed completed message instead of progress bars" do
+        render_inline(component)
+
+        expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed", text: "2/2 months completed")
+        expect(page).not_to have_css(".activity-flow-progress-indicator__progress-bar")
+      end
+
+      it "does not render the unit toggle controller in the collapsed state" do
+        render_inline(component)
+
+        expect(page).not_to have_css("[data-controller='progress-indicator-units']")
+        expect(page).not_to have_css("[data-progress-indicator-units-target='toggle']")
+      end
     end
   end
 
@@ -489,6 +619,61 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         render_inline(component)
 
         expect(page).to have_css("h2", text: "2/3 months completed")
+      end
+    end
+
+    context "when display variant is review and requirements are met" do
+      let(:display_variant) { :review }
+
+      it "uses required_month_count in the collapsed review message" do
+        render_inline(component)
+
+        expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
+        expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "4/3 months completed")
+      end
+    end
+
+    context "when display variant is review and the renewal is incomplete" do
+      let(:display_variant) { :review }
+      let(:monthly_calculation_results) do
+        [
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2026, 1, 1),
+            total_hours: 0,
+            meets_requirements: false
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 12, 1),
+            total_hours: 90,
+            meets_requirements: true
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 11, 1),
+            total_hours: 95,
+            meets_requirements: true
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 10, 1),
+            total_hours: 40,
+            meets_requirements: false
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 9, 1),
+            total_hours: 20,
+            meets_requirements: false
+          ),
+          ActivityFlowProgressCalculator::MonthlyResult.new(
+            month: Date.new(2025, 8, 1),
+            total_hours: 35,
+            meets_requirements: false
+          )
+        ]
+      end
+
+      it "omits the renewal subtitle on the review page" do
+        render_inline(component)
+
+        expect(page).not_to have_css(".activity-flow-progress-indicator__description")
       end
     end
 

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
 
       render_inline(described_class.from_calculator(calculator, variant: :renewal))
 
-      expect(page).to have_css("h3", text: "1/1 months completed")
+      expect(page).to have_css("h2", text: "1/1 months completed")
     end
 
     it "passes show_unit_toggle through to the component" do
@@ -126,7 +126,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       render_inline(component)
 
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h3", text: "1/2 months completed")
+      expect(page).to have_css("h2", text: "1/2 months completed")
       expect(page).to have_css(".activity-flow-progress-indicator__progress-bar", count: 2)
     end
 
@@ -144,7 +144,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "uses the months completed title on the review page" do
         render_inline(component)
 
-        expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "0/1 months completed")
+        expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "0/1 months completed")
       end
     end
 
@@ -212,7 +212,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
   it "renders the title without description for application variants" do
     render_inline(component)
 
-    expect(page).to have_css("h3", text: expected_title)
+    expect(page).to have_css("h2", text: expected_title)
     expect(page).not_to have_css(".activity-flow-progress-indicator__description")
   end
 
@@ -396,7 +396,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "falls back to application rendering" do
       render_inline(component)
 
-      expect(page).to have_css("h3", text: expected_title)
+      expect(page).to have_css("h2", text: expected_title)
       expect(page).not_to have_css(".activity-flow-progress-indicator__description")
     end
   end
@@ -441,7 +441,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "includes a 'months completed' message" do
       render_inline(component)
 
-      expect(page).to have_css("h3", text: "1/3 months completed")
+      expect(page).to have_css("h2", text: "1/3 months completed")
       expect(page).not_to have_css(".activity-flow-progress-indicator__months-completed")
     end
 
@@ -547,7 +547,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "renders the renewal title and subtitle" do
       render_inline(component)
 
-      expect(page).to have_css("h3", text: "4/3 months completed")
+      expect(page).to have_css("h2", text: "4/3 months completed")
       expect(page).to have_text(
         "Complete any 3 months between August-January to meet requirements."
       )
@@ -556,7 +556,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     it "shows a success icon in the header when renewal requirements are complete" do
       render_inline(component)
 
-      expect(page).to have_css("h3 .activity-flow-progress-indicator__success-icon")
+      expect(page).to have_css("h2 .activity-flow-progress-indicator__success-icon")
     end
 
     it "renders renewal months oldest to newest" do
@@ -618,7 +618,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "uses required_month_count as the denominator while remaining incomplete" do
         render_inline(component)
 
-        expect(page).to have_css("h3", text: "2/3 months completed")
+        expect(page).to have_css("h2", text: "2/3 months completed")
       end
     end
 
@@ -629,7 +629,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
         render_inline(component)
 
         expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
-        expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "4/3 months completed")
+        expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "4/3 months completed")
       end
     end
 
@@ -683,7 +683,7 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
       it "defaults required_month_count to the reporting window length" do
         render_inline(component)
 
-        expect(page).to have_css("h3", text: "4/6 months completed")
+        expect(page).to have_css("h2", text: "4/6 months completed")
         expect(page).not_to have_css(".activity-flow-progress-indicator__description")
       end
     end

--- a/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
+++ b/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
@@ -102,6 +102,47 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     )
   end
 
+  def review_in_progress
+    results = []
+    results << make_result(Date.new(2026, 1, 1), 50)
+    results << make_result(Date.new(2026, 2, 1), 35, earnings_cents: 138_00)
+    results << make_result(Date.new(2026, 3, 1), 80)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: results,
+      display_variant: :review
+    )
+  end
+
+  def review_completed
+    results = []
+    results << make_result(Date.new(2026, 1, 1), 82)
+    results << make_result(Date.new(2026, 2, 1), 91)
+    results << make_result(Date.new(2026, 3, 1), 88)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: results,
+      display_variant: :review
+    )
+  end
+
+  def review_renewal_completed
+    results = []
+    results << make_result(Date.new(2025, 8, 1), 88)
+    results << make_result(Date.new(2025, 9, 1), 0)
+    results << make_result(Date.new(2025, 10, 1), 86)
+    results << make_result(Date.new(2025, 11, 1), 95)
+    results << make_result(Date.new(2025, 12, 1), 90)
+    results << make_result(Date.new(2026, 1, 1), 0)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: results,
+      variant: :renewal,
+      required_month_count: 4,
+      display_variant: :review
+    )
+  end
+
   private
 
   def make_result(month, hours, earnings_cents: 0)

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "1/2 months completed")
+      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "1/2 months completed")
     end
 
     it "does not show the unit toggle for non-employment activity-only flows" do
@@ -56,7 +56,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
-      expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "2/2 months completed")
+      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "2/2 months completed")
     end
 
     it "uses required_month_count as the renewal denominator on review" do
@@ -78,7 +78,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "4/4 months completed")
+      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "4/4 months completed")
     end
 
     it "uses required_month_count as the renewal denominator while review progress is still expanded" do
@@ -101,7 +101,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "3/4 months completed")
+      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "3/4 months completed")
       expect(page).to have_css(".activity-flow-progress-indicator__progress-bar")
     end
 

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -22,6 +22,89 @@ RSpec.describe Activities::SummaryController, type: :controller do
   end
 
   describe "GET #show" do
+    it "renders the review progress indicator at table width" do
+      activity_flow.update!(reporting_window_months: 2)
+      activity = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped")
+      create(:volunteering_activity_month, volunteering_activity: activity, month: activity_flow.reporting_months.first, hours: 80)
+      create(:volunteering_activity_month, volunteering_activity: activity, month: activity_flow.reporting_months.second, hours: 0)
+
+      get :show
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css(".activity-flow-progress-indicator__card--review")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "1/2 months completed")
+    end
+
+    it "does not show the unit toggle for non-employment activity-only flows" do
+      activity_flow.update!(reporting_window_months: 2)
+      activity = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped")
+      create(:volunteering_activity_month, volunteering_activity: activity, month: activity_flow.reporting_months.first, hours: 80)
+
+      get :show
+
+      page = Capybara.string(response.body)
+      expect(page).not_to have_css("[data-controller='progress-indicator-units']")
+    end
+
+    it "renders the collapsed review message when all review months are complete" do
+      activity_flow.update!(reporting_window_months: 2)
+      activity = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped")
+      create(:volunteering_activity_month, volunteering_activity: activity, month: activity_flow.reporting_months.first, hours: 80)
+      create(:volunteering_activity_month, volunteering_activity: activity, month: activity_flow.reporting_months.second, hours: 80)
+
+      get :show
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
+      expect(page).to have_css("p.activity-flow-progress-indicator__title--collapsed", text: "2/2 months completed")
+    end
+
+    it "uses required_month_count as the renewal denominator on review" do
+      activity_flow.update!(
+        reporting_window_type: "renewal",
+        reporting_window_months: 6,
+        renewal_required_months: 4
+      )
+      activity = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped")
+
+      activity_flow.reporting_months.first(4).each do |month|
+        create(:volunteering_activity_month, volunteering_activity: activity, month: month, hours: 80)
+      end
+
+      activity_flow.reporting_months.last(2).each do |month|
+        create(:volunteering_activity_month, volunteering_activity: activity, month: month, hours: 0)
+      end
+
+      get :show
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("p.activity-flow-progress-indicator__title--collapsed", text: "4/4 months completed")
+    end
+
+    it "uses required_month_count as the renewal denominator while review progress is still expanded" do
+      activity_flow.update!(
+        reporting_window_type: "renewal",
+        reporting_window_months: 6,
+        renewal_required_months: 4
+      )
+      activity = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped")
+
+      activity_flow.reporting_months.first(3).each do |month|
+        create(:volunteering_activity_month, volunteering_activity: activity, month: month, hours: 80)
+      end
+
+      activity_flow.reporting_months.last(3).each do |month|
+        create(:volunteering_activity_month, volunteering_activity: activity, month: month, hours: 0)
+      end
+
+      get :show
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css(".activity-flow-progress-indicator__card--review")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "3/4 months completed")
+      expect(page).to have_css(".activity-flow-progress-indicator__progress-bar")
+    end
+
     it "only shows activities belonging to the current activity flow" do
       visible_volunteering = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Scoped", hours: 1)
       create(:volunteering_activity, activity_flow: other_flow, organization_name: "Ignored", hours: 2)
@@ -368,6 +451,23 @@ RSpec.describe Activities::SummaryController, type: :controller do
         expect(response.body).to include(ActionController::Base.helpers.number_to_currency(activity_month.gross_income))
         expect(response.body).to include(activity_month.hours.to_s)
       end
+
+      it "shows the unit toggle on the review page" do
+        employment_activity = create(:employment_activity, activity_flow: activity_flow)
+        create(
+          :employment_activity_month,
+          employment_activity: employment_activity,
+          month: activity_flow.reporting_months.first.beginning_of_month,
+          hours: 40,
+          gross_income: 500
+        )
+
+        get :show
+
+        page = Capybara.string(response.body)
+        expect(page).to have_css("[data-controller='progress-indicator-units']")
+        expect(page).to have_css("[data-progress-indicator-units-target='toggle']")
+      end
     end
 
     context "with payroll accounts" do
@@ -416,6 +516,30 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
         expect(response.body).to include("Acme Employer")
         expect(response.body).to include("$123.45")
+      end
+
+      it "shows the unit toggle on the review page" do
+        payroll_account = create(:payroll_account, :pinwheel_fully_synced, flow: activity_flow, aggregator_account_id: "acct-123")
+        latest_month = activity_flow.reporting_months.max
+        activity_flow.reporting_months.each do |month|
+          create(
+            :activity_flow_monthly_summary,
+            activity_flow: activity_flow,
+            payroll_account: payroll_account,
+            month: month.beginning_of_month,
+            employer_name: "Acme Employer",
+            employment_type: "w2",
+            total_w2_hours: (month == latest_month ? 35.0 : 0.0),
+            accrued_gross_earnings_cents: (month == latest_month ? 222_22 : 0),
+            paychecks_count: (month == latest_month ? 2 : 0)
+          )
+        end
+
+        get :show
+
+        page = Capybara.string(response.body)
+        expect(page).to have_css("[data-controller='progress-indicator-units']")
+        expect(page).to have_css("[data-progress-indicator-units-target='toggle']")
       end
 
       it "renders successfully when no summaries are persisted" do

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "1/2 months completed")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "1/2 months completed")
     end
 
     it "does not show the unit toggle for non-employment activity-only flows" do
@@ -56,7 +56,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
-      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "2/2 months completed")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "2/2 months completed")
     end
 
     it "uses required_month_count as the renewal denominator on review" do
@@ -78,7 +78,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "4/4 months completed")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "4/4 months completed")
     end
 
     it "uses required_month_count as the renewal denominator while review progress is still expanded" do
@@ -101,7 +101,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator__card--review")
-      expect(page).to have_css("h3.activity-flow-progress-indicator__title", text: "3/4 months completed")
+      expect(page).to have_css("h2.activity-flow-progress-indicator__title", text: "3/4 months completed")
       expect(page).to have_css(".activity-flow-progress-indicator__progress-bar")
     end
 

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
 
       page = Capybara.string(response.body)
       expect(page).to have_css(".activity-flow-progress-indicator--review-collapsed")
-      expect(page).to have_css("p.activity-flow-progress-indicator__title--collapsed", text: "2/2 months completed")
+      expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "2/2 months completed")
     end
 
     it "uses required_month_count as the renewal denominator on review" do
@@ -78,7 +78,7 @@ RSpec.describe Activities::SummaryController, type: :controller do
       get :show
 
       page = Capybara.string(response.body)
-      expect(page).to have_css("p.activity-flow-progress-indicator__title--collapsed", text: "4/4 months completed")
+      expect(page).to have_css("p.activity-flow-progress-indicator__title", text: "4/4 months completed")
     end
 
     it "uses required_month_count as the renewal denominator while review progress is still expanded" do

--- a/app/spec/javascript/controllers/progress_indicator_units.spec.js
+++ b/app/spec/javascript/controllers/progress_indicator_units.spec.js
@@ -49,4 +49,22 @@ describe("ProgressIndicatorUnitsController", () => {
     expect(hoursToggle.hidden).toBe(false)
     expect(document.activeElement).toBe(hoursToggle)
   })
+
+  it("toggles visible content to match the selected unit", () => {
+    const dollarsToggle = document.querySelector("[data-next-unit='dollars']")
+    const hoursContent = document.querySelector(
+      "[data-unit='hours'][data-progress-indicator-units-target='unitContent']"
+    )
+    const dollarsContent = document.querySelector(
+      "[data-unit='dollars'][data-progress-indicator-units-target='unitContent']"
+    )
+
+    expect(hoursContent.hidden).toBe(false)
+    expect(dollarsContent.hidden).toBe(true)
+
+    dollarsToggle.click()
+
+    expect(hoursContent.hidden).toBe(true)
+    expect(dollarsContent.hidden).toBe(false)
+  })
 })


### PR DESCRIPTION
## [FFS-3920](https://jiraent.cms.gov/browse/FFS-3920)

## Changes
- Created review variant of the progress indicator for the review & submit page
- Added the collapsed completed state on review & submit that shows months completed
- For renewal review, we use `required_month_count` as the denominator
- Updated Lookbook with 2 new previews

### Context
It's out of scope and too much for this ticket, but the progress indicator erb has too many branches and is getting quite heavy. Might warrant some refactoring.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
 <details> 
<summary>Screenshots</summary>

<img width="924" height="357" alt="Screenshot 2026-04-21 at 3 06 33 PM" src="https://github.com/user-attachments/assets/4356f8a5-af33-493b-9731-20f28b1d99e2" />
<img width="923" height="514" alt="Screenshot 2026-04-21 at 3 00 17 PM" src="https://github.com/user-attachments/assets/725f7569-ddf9-4284-b54e-8ce9bcf49cdb" />
<img width="928" height="472" alt="Screenshot 2026-04-21 at 2 32 08 PM" src="https://github.com/user-attachments/assets/973334b9-1e8e-473a-842a-3ce2acf2d506" />
<img width="1001" height="296" alt="Screenshot 2026-04-21 at 2 26 37 PM" src="https://github.com/user-attachments/assets/ba837f78-b6f1-4d48-9a18-832d70ce3ac3" />
<img width="1040" height="308" alt="Screenshot 2026-04-21 at 2 19 18 PM" src="https://github.com/user-attachments/assets/be4b0fd7-2ca0-499b-a5fe-37784703b9e1" />

</details>

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->