### PR TITLE
FFS-3976: Display previously uploaded documents on activity review and review and submit pages

### DIFF
--- a/app/app/assets/stylesheets/document_uploads.scss
+++ b/app/app/assets/stylesheets/document_uploads.scss
@@ -8,6 +8,13 @@
   margin-bottom: units(4);
   margin-top: units(4);
 }
+.document-uploads--full-width {
+  max-width: 44rem;
+
+  .document-uploads__item {
+    max-width: none;
+  }
+}
 .document-uploads__heading {
   margin-bottom: units(2);
   margin-top: 0;

--- a/app/app/components/document_uploads_component.html.erb
+++ b/app/app/components/document_uploads_component.html.erb
@@ -1,5 +1,12 @@
-<section class="document-uploads" aria-labelledby="document-uploads-heading">
-  <%= content_tag :"h#{heading_level}", heading_text, id: "document-uploads-heading", class: "document-uploads__heading" %>
+<section class="<%= section_class %>" aria-labelledby="document-uploads-heading">
+  <% if edit_path.present? %>
+    <div class="display-flex flex-justify activity-review-edit-header">
+      <%= content_tag :"h#{heading_level}", heading_text, id: "document-uploads-heading", class: "document-uploads__heading margin-y-0" %>
+      <%= link_to edit_label, edit_path, class: "usa-link" %>
+    </div>
+  <% else %>
+    <%= content_tag :"h#{heading_level}", heading_text, id: "document-uploads-heading", class: "document-uploads__heading" %>
+  <% end %>
 
   <ul class="document-uploads__list">
     <% documents.each do |document| %>

--- a/app/app/components/document_uploads_component.html.erb
+++ b/app/app/components/document_uploads_component.html.erb
@@ -1,11 +1,11 @@
-<section class="<%= section_class %>" aria-labelledby="document-uploads-heading">
+<div class="<%= section_class %>">
   <% if edit_path.present? %>
     <div class="display-flex flex-justify activity-review-edit-header">
-      <%= content_tag :"h#{heading_level}", heading_text, id: "document-uploads-heading", class: "document-uploads__heading margin-y-0" %>
+      <%= content_tag :"h#{heading_level}", heading_text, class: "document-uploads__heading margin-y-0" %>
       <%= link_to edit_label, edit_path, class: "usa-link" %>
     </div>
   <% else %>
-    <%= content_tag :"h#{heading_level}", heading_text, id: "document-uploads-heading", class: "document-uploads__heading" %>
+    <%= content_tag :"h#{heading_level}", heading_text, class: "document-uploads__heading" %>
   <% end %>
 
   <ul class="document-uploads__list">
@@ -29,4 +29,4 @@
       </li>
     <% end %>
   </ul>
-</section>
+</div>

--- a/app/app/components/document_uploads_component.html.erb
+++ b/app/app/components/document_uploads_component.html.erb
@@ -1,7 +1,7 @@
 <div class="<%= section_class %>">
   <% if edit_path.present? %>
     <div class="display-flex flex-justify activity-review-edit-header">
-      <%= content_tag :"h#{heading_level}", heading_text, class: "document-uploads__heading margin-y-0" %>
+      <%= content_tag :"h#{heading_level}", heading_text, class: "document-uploads__heading" %>
       <%= link_to edit_label, edit_path, class: "usa-link" %>
     </div>
   <% else %>

--- a/app/app/components/document_uploads_component.rb
+++ b/app/app/components/document_uploads_component.rb
@@ -1,15 +1,24 @@
 # frozen_string_literal: true
 
 class DocumentUploadsComponent < ViewComponent::Base
-  def initialize(documents:, show_remove_file: false, heading_level: 2)
+  def initialize(documents:, show_remove_file: false, heading_level: 2, edit_path: nil, edit_label: nil, full_width: false)
     @documents = documents
     @show_remove_file = show_remove_file
     @heading_level = heading_level
+    @edit_path = edit_path
+    @edit_label = edit_label
+    @full_width = full_width
   end
 
   private
 
-  attr_reader :documents, :heading_level
+  attr_reader :documents, :heading_level, :edit_path
+
+  def section_class
+    classes = [ "document-uploads" ]
+    classes << "document-uploads--full-width" if @full_width
+    classes.join(" ")
+  end
 
   def heading_text
     I18n.t("activities.document_uploads.heading", document_count: documents.count)
@@ -17,6 +26,10 @@ class DocumentUploadsComponent < ViewComponent::Base
 
   def show_remove_file?
     @show_remove_file
+  end
+
+  def edit_label
+    @edit_label || I18n.t("activities.hub.edit")
   end
 
   def filename_for(document)

--- a/app/app/components/document_uploads_component.rb
+++ b/app/app/components/document_uploads_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DocumentUploadsComponent < ViewComponent::Base
-  def initialize(documents:, show_remove_file: false, heading_level: 2, edit_path: nil, edit_label: nil, full_width: false)
+  def initialize(documents:, show_remove_file: false, heading_level: 2, edit_path: nil, edit_label: nil, full_width: false, previously_uploaded: false)
     @documents = documents
     @show_remove_file = show_remove_file
     @heading_level = heading_level
     @edit_path = edit_path
     @edit_label = edit_label
     @full_width = full_width
+    @previously_uploaded = previously_uploaded
   end
 
   private
@@ -21,7 +22,10 @@ class DocumentUploadsComponent < ViewComponent::Base
   end
 
   def heading_text
-    I18n.t("activities.document_uploads.heading", document_count: documents.count)
+    # i18n-tasks-use t('activities.document_uploads.heading')
+    # i18n-tasks-use t('activities.document_uploads.heading_previous')
+    key = @previously_uploaded ? "activities.document_uploads.heading_previous" : "activities.document_uploads.heading"
+    I18n.t(key, document_count: documents.count)
   end
 
   def show_remove_file?

--- a/app/app/controllers/activities/document_uploads_controller.rb
+++ b/app/app/controllers/activities/document_uploads_controller.rb
@@ -99,13 +99,13 @@ class Activities::DocumentUploadsController < Activities::BaseController
 
   def upload_path
     if params[:community_service_id]
-      activities_flow_community_service_document_uploads_path(from_edit: params[:from_edit].presence)
+      activities_flow_community_service_document_uploads_path(from_edit: params[:from_edit].presence, from_review: params[:from_review].presence)
     elsif params[:job_training_id]
-      activities_flow_job_training_document_uploads_path(from_edit: params[:from_edit].presence)
+      activities_flow_job_training_document_uploads_path(from_edit: params[:from_edit].presence, from_review: params[:from_review].presence)
     elsif params[:education_id]
-      activities_flow_education_document_uploads_path(from_edit: params[:from_edit].presence)
+      activities_flow_education_document_uploads_path(from_edit: params[:from_edit].presence, from_review: params[:from_review].presence)
     elsif params[:employment_id]
-      activities_flow_income_employment_document_uploads_path(from_edit: params[:from_edit].presence)
+      activities_flow_income_employment_document_uploads_path(from_edit: params[:from_edit].presence, from_review: params[:from_review].presence)
     else
       raise <<~ERROR
         No activity param matched in DocumentUploadsController#upload_path.
@@ -119,22 +119,26 @@ class Activities::DocumentUploadsController < Activities::BaseController
     if params[:community_service_id]
       new_activities_flow_community_service_document_upload_path(
         community_service_id: @activity,
-        from_edit: params[:from_edit].presence
+        from_edit: params[:from_edit].presence,
+        from_review: params[:from_review].presence
       )
     elsif params[:job_training_id]
       new_activities_flow_job_training_document_upload_path(
         job_training_id: @activity,
-        from_edit: params[:from_edit].presence
+        from_edit: params[:from_edit].presence,
+        from_review: params[:from_review].presence
       )
     elsif params[:education_id]
       new_activities_flow_education_document_upload_path(
         education_id: @activity,
-        from_edit: params[:from_edit].presence
+        from_edit: params[:from_edit].presence,
+        from_review: params[:from_review].presence
       )
     elsif params[:employment_id]
       new_activities_flow_income_employment_document_upload_path(
         employment_id: @activity,
-        from_edit: params[:from_edit].presence
+        from_edit: params[:from_edit].presence,
+        from_review: params[:from_review].presence
       )
     else
       raise <<~ERROR

--- a/app/app/views/activities/document_uploads/new.html.erb
+++ b/app/app/views/activities/document_uploads/new.html.erb
@@ -63,5 +63,6 @@
       <%= t(@activity.document_upload_suggestion_text) %>
     <% end %>
   <% end %>
-  <%= f.submit t(".continue") %>
+  <% submit_label = params[:from_review].present? ? t("activities.hub.save") : t(".continue") %>
+  <%= f.submit submit_label %>
 <% end %>

--- a/app/app/views/activities/document_uploads/new.html.erb
+++ b/app/app/views/activities/document_uploads/new.html.erb
@@ -37,7 +37,8 @@
         remove_path: remove_document_upload_path(attachment)
       }
     end,
-    show_remove_file: true
+    show_remove_file: true,
+    previously_uploaded: true
   ) %>
 <% end %>
 

--- a/app/app/views/activities/education/review.html.erb
+++ b/app/app/views/activities/education/review.html.erb
@@ -40,6 +40,18 @@
   <%= render "review_validated" %>
 <% end %>
 
+<% if @education_activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: @education_activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    edit_path: new_activities_flow_education_document_upload_path(
+      education_id: @education_activity,
+      from_review: 1,
+      from_edit: params[:from_edit].presence
+    ),
+    full_width: true
+  ) %>
+<% end %>
+
 <%= form_with model: @education_activity,
       url: save_review_activities_flow_education_path(id: @education_activity, from_edit: params[:from_edit].presence),
       method: :patch,

--- a/app/app/views/activities/employment/review.html.erb
+++ b/app/app/views/activities/employment/review.html.erb
@@ -54,6 +54,18 @@
   <% end %>
 <% end %>
 
+<% if @employment_activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: @employment_activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    edit_path: new_activities_flow_income_employment_document_upload_path(
+      employment_id: @employment_activity,
+      from_review: 1,
+      from_edit: params[:from_edit].presence
+    ),
+    full_width: true
+  ) %>
+<% end %>
+
 <%= form_with model: @employment_activity,
       url: save_review_activities_flow_income_employment_path(id: @employment_activity, from_edit: params[:from_edit].presence),
       method: :patch,

--- a/app/app/views/activities/job_training/review.html.erb
+++ b/app/app/views/activities/job_training/review.html.erb
@@ -104,6 +104,18 @@
   <% end %>
 <% end %>
 
+<% if @job_training_activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: @job_training_activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    edit_path: new_activities_flow_job_training_document_upload_path(
+      job_training_id: @job_training_activity,
+      from_review: 1,
+      from_edit: params[:from_edit].presence
+    ),
+    full_width: true
+  ) %>
+<% end %>
+
 <%= form_with model: @job_training_activity,
       url: save_review_activities_flow_job_training_path(id: @job_training_activity, from_edit: params[:from_edit].presence),
       method: :patch,

--- a/app/app/views/activities/summary/_education_table.html.erb
+++ b/app/app/views/activities/summary/_education_table.html.erb
@@ -7,3 +7,11 @@
     <%= render(EnrollmentTermTableComponent.new(nsc_enrollment_term: enrollment_term)) %>
   <% end %>
 <% end %>
+
+<% if activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    heading_level: 3,
+    full_width: true
+  ) %>
+<% end %>

--- a/app/app/views/activities/summary/_job_training_table.html.erb
+++ b/app/app/views/activities/summary/_job_training_table.html.erb
@@ -71,3 +71,11 @@
     <% end %>
   <% end %>
 <% end %>
+
+<% if activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    heading_level: 3,
+    full_width: true
+  ) %>
+<% end %>

--- a/app/app/views/activities/summary/_self_attested_employment_table.html.erb
+++ b/app/app/views/activities/summary/_self_attested_employment_table.html.erb
@@ -72,3 +72,11 @@
     <% end %>
   <% end %>
 <% end %>
+
+<% if activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    heading_level: 3,
+    full_width: true
+  ) %>
+<% end %>

--- a/app/app/views/activities/summary/_volunteering_table.html.erb
+++ b/app/app/views/activities/summary/_volunteering_table.html.erb
@@ -61,3 +61,11 @@
     <% end %>
   <% end %>
 <% end %>
+
+<% if activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    heading_level: 3,
+    full_width: true
+  ) %>
+<% end %>

--- a/app/app/views/activities/volunteering/review.html.erb
+++ b/app/app/views/activities/volunteering/review.html.erb
@@ -54,6 +54,18 @@
   <% end %>
 <% end %>
 
+<% if @volunteering_activity.document_uploads.any? %>
+  <%= render DocumentUploadsComponent.new(
+    documents: @volunteering_activity.document_uploads.map { |a| { filename: a.filename.to_s } },
+    edit_path: new_activities_flow_community_service_document_upload_path(
+      community_service_id: @volunteering_activity,
+      from_review: 1,
+      from_edit: params[:from_edit].presence
+    ),
+    full_width: true
+  ) %>
+<% end %>
+
 <%= form_with model: @volunteering_activity,
       url: save_review_activities_flow_community_service_path(id: @volunteering_activity, from_edit: params[:from_edit].presence),
       method: :patch,

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -138,7 +138,8 @@ en:
       title_singular: Community service
       zip_code: Zip code
     document_uploads:
-      heading: Previously uploaded documents (%{document_count})
+      heading: Uploaded documents (%{document_count})
+      heading_previous: Previously uploaded documents (%{document_count})
       new:
         continue: Continue to review
         description: 'Upload documents that verify the information you entered for:'

--- a/app/spec/components/document_uploads_component_spec.rb
+++ b/app/spec/components/document_uploads_component_spec.rb
@@ -33,4 +33,28 @@ RSpec.describe DocumentUploadsComponent, type: :component do
     expect(result).to have_link("Remove file", href: "/documents/1")
     expect(result.to_html).to include('data-turbo-method="delete"')
   end
+
+  it "renders an edit link next to the heading when edit_path is provided" do
+    result = render_inline(
+      described_class.new(
+        documents: [ { filename: "verification.pdf" } ],
+        edit_path: "/activities/employment/1/document_uploads/new"
+      )
+    )
+
+    expect(result).to have_link("Edit", href: "/activities/employment/1/document_uploads/new")
+    expect(result).not_to have_text("Remove file")
+  end
+
+  it "uses the provided edit_label when given" do
+    result = render_inline(
+      described_class.new(
+        documents: [ { filename: "verification.pdf" } ],
+        edit_path: "/edit",
+        edit_label: "Change documents"
+      )
+    )
+
+    expect(result).to have_link("Change documents", href: "/edit")
+  end
 end

--- a/app/spec/components/document_uploads_component_spec.rb
+++ b/app/spec/components/document_uploads_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DocumentUploadsComponent, type: :component do
       ])
     )
 
-    expect(result).to have_text("Previously uploaded documents (2)")
+    expect(result).to have_text("Uploaded documents (2)")
     expect(result).to have_text("verification.pdf")
     expect(result).to have_text("paystub.jpg")
     expect(result).to have_element(:use, href: /.svg#file_present/)

--- a/app/spec/controllers/activities/document_uploads_controller_spec.rb
+++ b/app/spec/controllers/activities/document_uploads_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Activities::DocumentUploadsController, type: :controller do
       expect(response.body).to include(I18n.t("activities.document_uploads.new.title", name: "Local Food Bank"))
       expect(response.body).to include(I18n.t("shared.hours", count: 6))
       expect(response.body).to include(activities_flow_community_service_document_uploads_path)
-      expect(response.body).not_to include(I18n.t("activities.document_uploads.heading", document_count: 0))
+      expect(response.body).not_to include(I18n.t("activities.document_uploads.heading_previous", document_count: 0))
       expect(response.body).to include(I18n.t("activities.document_uploads.new.input_label"))
     end
 
@@ -167,7 +167,7 @@ RSpec.describe Activities::DocumentUploadsController, type: :controller do
       get :new, params: { community_service_id: volunteering_activity.id }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(I18n.t("activities.document_uploads.heading", document_count: 1))
+      expect(response.body).to include(I18n.t("activities.document_uploads.heading_previous", document_count: 1))
       expect(response.body).to include("verification.pdf")
       expect(response.body).to include(I18n.t("activities.document_uploads.remove_file"))
       expect(response.body).to include("file_present")

--- a/app/spec/controllers/activities/document_uploads_controller_spec.rb
+++ b/app/spec/controllers/activities/document_uploads_controller_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe Activities::DocumentUploadsController, type: :controller do
       expect(response.body).to include(I18n.t("activities.document_uploads.new.input_label"))
     end
 
+    it "shows the Save changes label and preserves from_review in the form action when from_review is set" do
+      volunteering_activity = create(:volunteering_activity, activity_flow: activity_flow)
+      create(:volunteering_activity_month, volunteering_activity: volunteering_activity, hours: 6)
+
+      get :new, params: { community_service_id: volunteering_activity.id, from_review: 1 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(I18n.t("activities.hub.save"))
+      expect(response.body).to include(activities_flow_community_service_document_uploads_path(from_review: 1))
+    end
+
     it "renders the upload form for a job training activity" do
       job_training_activity = create(
         :job_training_activity,
@@ -314,6 +325,22 @@ RSpec.describe Activities::DocumentUploadsController, type: :controller do
 
       expect(response).to redirect_to(
         new_activities_flow_income_employment_document_upload_path(employment_id: employment_activity)
+      )
+    end
+
+    it "preserves from_review in the redirect when removing during edit-from-review" do
+      volunteering_activity = create(:volunteering_activity, activity_flow: activity_flow)
+      volunteering_activity.document_uploads.attach(
+        io: StringIO.new("%PDF-1.4"),
+        filename: "verification.pdf",
+        content_type: "application/pdf"
+      )
+      attachment_id = volunteering_activity.document_uploads_attachments.first.id
+
+      delete :destroy, params: { community_service_id: volunteering_activity.id, id: attachment_id, from_review: 1 }
+
+      expect(response).to redirect_to(
+        new_activities_flow_community_service_document_upload_path(community_service_id: volunteering_activity, from_review: 1)
       )
     end
   end

--- a/app/spec/controllers/activities/education_controller_spec.rb
+++ b/app/spec/controllers/activities/education_controller_spec.rb
@@ -303,6 +303,36 @@ RSpec.describe Activities::EducationController, type: :controller do
         edit_link = doc.find("a", text: I18n.t("activities.hub.edit"))
         expect(edit_link[:href]).to include("from_review=1")
       end
+
+      context "with previously uploaded documents" do
+        before do
+          Rails.application.config.active_storage.service = :local
+          education_activity.document_uploads.attach(
+            io: StringIO.new("%PDF-1.4"),
+            filename: "verification.pdf",
+            content_type: "application/pdf"
+          )
+        end
+
+        it "renders the uploaded documents section with an edit link" do
+          get :review, params: { id: education_activity.id }
+
+          expect(response.body).to include(I18n.t("activities.document_uploads.heading", document_count: 1))
+          expect(response.body).to include("verification.pdf")
+          expect(response.body).to include(
+            new_activities_flow_education_document_upload_path(education_id: education_activity, from_review: 1)
+          )
+          expect(response.body).not_to include(I18n.t("activities.document_uploads.remove_file"))
+        end
+      end
+
+      context "without uploaded documents" do
+        it "does not render the uploaded documents heading" do
+          get :review, params: { id: education_activity.id }
+
+          expect(response.body).not_to include(I18n.t("activities.document_uploads.heading", document_count: 0))
+        end
+      end
     end
 
     context "when partially self-attested" do

--- a/app/spec/controllers/activities/employment_controller_spec.rb
+++ b/app/spec/controllers/activities/employment_controller_spec.rb
@@ -205,6 +205,36 @@ RSpec.describe Activities::EmploymentController, type: :controller do
         edit_activities_flow_income_employment_month_path(employment_id: employment_activity, id: 0, from_review: 1)
       )
     end
+
+    context "with previously uploaded documents" do
+      before do
+        Rails.application.config.active_storage.service = :local
+        employment_activity.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "verification.pdf",
+          content_type: "application/pdf"
+        )
+      end
+
+      it "renders the uploaded documents section with an edit link" do
+        get :review, params: { id: employment_activity.id }
+
+        expect(response.body).to include(I18n.t("activities.document_uploads.heading", document_count: 1))
+        expect(response.body).to include("verification.pdf")
+        expect(response.body).to include(
+          new_activities_flow_income_employment_document_upload_path(employment_id: employment_activity, from_review: 1)
+        )
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.remove_file"))
+      end
+    end
+
+    context "without uploaded documents" do
+      it "does not render the uploaded documents heading" do
+        get :review, params: { id: employment_activity.id }
+
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.heading", document_count: 0))
+      end
+    end
   end
 
   describe "PATCH #save_review" do

--- a/app/spec/controllers/activities/job_training_controller_spec.rb
+++ b/app/spec/controllers/activities/job_training_controller_spec.rb
@@ -147,6 +147,36 @@ RSpec.describe Activities::JobTrainingController, type: :controller do
         edit_activities_flow_job_training_month_path(job_training_id: job_training_activity, id: 0, from_review: 1)
       )
     end
+
+    context "with previously uploaded documents" do
+      before do
+        Rails.application.config.active_storage.service = :local
+        job_training_activity.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "verification.pdf",
+          content_type: "application/pdf"
+        )
+      end
+
+      it "renders the uploaded documents section with an edit link" do
+        get :review, params: { id: job_training_activity.id }
+
+        expect(response.body).to include(I18n.t("activities.document_uploads.heading", document_count: 1))
+        expect(response.body).to include("verification.pdf")
+        expect(response.body).to include(
+          new_activities_flow_job_training_document_upload_path(job_training_id: job_training_activity, from_review: 1)
+        )
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.remove_file"))
+      end
+    end
+
+    context "without uploaded documents" do
+      it "does not render the uploaded documents heading" do
+        get :review, params: { id: job_training_activity.id }
+
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.heading", document_count: 0))
+      end
+    end
   end
 
   describe "PATCH #save_review" do

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -486,6 +486,67 @@ RSpec.describe Activities::SummaryController, type: :controller do
       expect(response.body).to include("back-nav")
       expect(response.body).to have_link(href: activities_flow_root_path)
     end
+
+    context "with previously uploaded documents across activity types" do
+      before do
+        Rails.application.config.active_storage.service = :local
+      end
+
+      it "renders each activity's uploaded documents, read-only, without edit links" do
+        volunteering = create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Food Bank", hours: 1)
+        volunteering.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "volunteer-hours.pdf",
+          content_type: "application/pdf"
+        )
+
+        job_training = create(:job_training_activity, activity_flow: activity_flow, program_name: "Workshop", hours: 6)
+        job_training.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "training-cert.pdf",
+          content_type: "application/pdf"
+        )
+
+        education = create(
+          :education_activity,
+          activity_flow: activity_flow,
+          data_source: :fully_self_attested,
+          school_name: "University"
+        )
+        create(:education_activity_month, education_activity: education, month: activity_flow.reporting_months.first, hours: 4)
+        education.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "transcript.pdf",
+          content_type: "application/pdf"
+        )
+
+        employment = create(:employment_activity, activity_flow: activity_flow)
+        create(
+          :employment_activity_month,
+          employment_activity: employment,
+          month: activity_flow.reporting_months.first.beginning_of_month,
+          hours: 40,
+          gross_income: 500
+        )
+        employment.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "paystub.pdf",
+          content_type: "application/pdf"
+        )
+
+        get :show
+
+        expect(response.body).to include("volunteer-hours.pdf")
+        expect(response.body).to include("training-cert.pdf")
+        expect(response.body).to include("transcript.pdf")
+        expect(response.body).to include("paystub.pdf")
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.remove_file"))
+        expect(response.body).not_to include(new_activities_flow_income_employment_document_upload_path(employment_id: employment))
+        expect(response.body).not_to include(new_activities_flow_community_service_document_upload_path(community_service_id: volunteering))
+        expect(response.body).not_to include(new_activities_flow_job_training_document_upload_path(job_training_id: job_training))
+        expect(response.body).not_to include(new_activities_flow_education_document_upload_path(education_id: education))
+      end
+    end
   end
 
   describe "PATCH #update" do

--- a/app/spec/controllers/activities/volunteering_controller_spec.rb
+++ b/app/spec/controllers/activities/volunteering_controller_spec.rb
@@ -125,6 +125,36 @@ RSpec.describe Activities::VolunteeringController, type: :controller do
         edit_activities_flow_community_service_month_path(community_service_id: volunteering_activity, id: 0, from_review: 1)
       )
     end
+
+    context "with previously uploaded documents" do
+      before do
+        Rails.application.config.active_storage.service = :local
+        volunteering_activity.document_uploads.attach(
+          io: StringIO.new("%PDF-1.4"),
+          filename: "verification.pdf",
+          content_type: "application/pdf"
+        )
+      end
+
+      it "renders the uploaded documents section with an edit link" do
+        get :review, params: { id: volunteering_activity.id }
+
+        expect(response.body).to include(I18n.t("activities.document_uploads.heading", document_count: 1))
+        expect(response.body).to include("verification.pdf")
+        expect(response.body).to include(
+          new_activities_flow_community_service_document_upload_path(community_service_id: volunteering_activity, from_review: 1)
+        )
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.remove_file"))
+      end
+    end
+
+    context "without uploaded documents" do
+      it "does not render the uploaded documents heading" do
+        get :review, params: { id: volunteering_activity.id }
+
+        expect(response.body).not_to include(I18n.t("activities.document_uploads.heading", document_count: 0))
+      end
+    end
   end
 
   describe "PATCH #save_review" do

--- a/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_education_self_attestation_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "e2e Education self-attestation review flow", :js, type: :feature
       title: I18n.t("activities.document_uploads.new.title", name: "University of Illinois"),
       skip_axe_rules: %w[heading-order]
     )
-    expect(page).to have_content(I18n.t("activities.document_uploads.heading", document_count: 1))
+    expect(page).to have_content(I18n.t("activities.document_uploads.heading_previous", document_count: 1))
     expect(page).to have_content("document_upload.pdf")
     click_link I18n.t("activities.document_uploads.remove_file")
     expect(page).not_to have_content("document_upload.pdf")


### PR DESCRIPTION
## [FFS-3976](https://jiraent.cms.gov/browse/FFS-3976)

## Changes
- Render a read only version of `DocumentUploadsComponent` on each activity review page (volunteering, job training, employment, education) with edit link back to upload page

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->