### PR TITLE
FFS-4241: Silence 403, 408, 502 errors from LA

### DIFF
--- a/app/app/jobs/application_job.rb
+++ b/app/app/jobs/application_job.rb
@@ -1,4 +1,6 @@
 class ApplicationJob < ActiveJob::Base
+  class SilencedError < StandardError; end
+
   around_perform :with_error_reporting
 
   retry_on Exception, wait: :polynomially_longer, attempts: 5
@@ -43,6 +45,7 @@ class ApplicationJob < ActiveJob::Base
       failed_at: Time.now.to_s,
       error_class: error.class.name,
       error_message: error.message,
+      is_silenced: error.is_a?(ApplicationJob::SilencedError),
       executions: self.executions,
       max_attempts: self.class.max_attempts
     }.merge(trace_metadata))

--- a/app/app/services/transmitters/http_pdf_transmitter.rb
+++ b/app/app/services/transmitters/http_pdf_transmitter.rb
@@ -39,9 +39,24 @@ class Transmitters::HttpPdfTransmitter < Transmitters::BasePdfTransmitter
     end
 
     unless res.is_a?(Net::HTTPSuccess)
-      Rails.logger.error "Unexpected response from agency: code=#{res.code} message=#{res.message} body=#{res.body}"
-      raise HttpPdfTransmitterError.new("Unexpected response from agency: code=#{res.code} message=#{res.message} body=#{res.body}")
+      raise_response_error!(res, HttpPdfTransmitterError)
     end
+  end
+
+  private
+
+  def raise_response_error!(response, default_error_class)
+    message = "Unexpected response from agency: code=#{response.code} message=#{response.message} body=#{response.body}"
+    Rails.logger.error message
+
+    error_class = silence_errors_from_response_codes.include?(response.code.to_s) ?
+      ApplicationJob::SilencedError :
+      default_error_class
+    raise error_class, message
+  end
+
+  def silence_errors_from_response_codes
+    Array(@current_agency.transmission_method_configuration["silently_retry_error_codes"]).map(&:to_s)
   end
 
   class HttpPdfTransmitterError < StandardError; end

--- a/app/app/services/transmitters/json_transmitter.rb
+++ b/app/app/services/transmitters/json_transmitter.rb
@@ -26,8 +26,7 @@ class Transmitters::JsonTransmitter
       @cbv_flow.touch(:json_transmitted_at)
       "ok"
     else
-      Rails.logger.error "Unexpected response from agency: code=#{res.code} message=#{res.message} body=#{res.body}"
-      raise JsonTransmitterError.new("Unexpected response from agency: code=#{res.code} message=#{res.message} body=#{res.body}")
+      raise_response_error!(res, JsonTransmitterError)
     end
   end
 
@@ -43,6 +42,20 @@ class Transmitters::JsonTransmitter
   end
 
   private
+
+  def raise_response_error!(response, default_error_class)
+    message = "Unexpected response from agency: code=#{response.code} message=#{response.message} body=#{response.body}"
+    Rails.logger.error message
+
+    error_class = silence_errors_from_response_codes.include?(response.code.to_s) ?
+      ApplicationJob::SilencedError :
+      default_error_class
+    raise error_class, message
+  end
+
+  def silence_errors_from_response_codes
+    Array(@current_agency.transmission_method_configuration["silently_retry_error_codes"]).map(&:to_s)
+  end
 
   def _payload
     agency_partner_metadata = CbvApplicant.build_agency_partner_metadata(@current_agency.id) do |attr|

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -14,6 +14,10 @@
   transmission_method_configuration:
     json_api_url: <%= ENV["LA_LDH_INCOME_REPORT_URL"] %>
     pdf_api_url: <%= ENV["LA_LDH_PDF_API_URL"] %>
+    silently_retry_error_codes:
+      - 403
+      - 408
+      - 502
     custom_headers:
       X-Gateway-APIKey: <%= ENV["LA_LDH_INCOME_REPORT_APIKEY"] %>
       AccountCode: <%= ENV["LA_LDH_INCOME_REPORT_ACCOUNTCODE"] %>

--- a/app/config/newrelic.yml
+++ b/app/config/newrelic.yml
@@ -76,6 +76,7 @@ common: &default_settings
       - "ActionController::RoutingError"
       - "ActionController::UnknownHttpMethod"
       - "ActionDispatch::Http::MimeNegotiation::InvalidType"
+      - "ApplicationJob::SilencedError"
 
 
 # Environment-specific settings are in this section.

--- a/app/spec/jobs/application_job_spec.rb
+++ b/app/spec/jobs/application_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ApplicationJob do
       expect(NewRelic::Agent).to receive(:record_custom_event).with(
         "SolidQueueJobFailed",
         hash_including(
+          is_silenced: false,
           executions: 1,
           max_attempts: 5,
           job_id: anything
@@ -43,6 +44,29 @@ RSpec.describe ApplicationJob do
       )
 
       MaxAttemptsOverrideTestJob.perform_now
+    end
+
+    class SilentlyRetriableTestJob < ApplicationJob
+      def perform
+        raise ApplicationJob::SilencedError, "retry silently"
+      end
+    end
+
+    it "records silenceable errors with silenced=true" do
+      expect(NewRelic::Agent).to receive(:record_custom_event).with(
+        "SolidQueueJobFailed",
+        hash_including(
+          error_message: "retry silently",
+          is_silenced: true
+        )
+      )
+      SilentlyRetriableTestJob.perform_now
+    end
+
+    it "still retries silenceable errors" do
+      expect do
+        SilentlyRetriableTestJob.perform_now
+      end.to have_enqueued_job(SilentlyRetriableTestJob)
     end
   end
 

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
   let(:pinwheel_report) { build(:pinwheel_report, :with_pinwheel_account) }
   let(:fake_event_logger) { instance_double(GenericEventTracker, track: nil) }
   let(:mocked_client_logo_path) { "ldh_logo.svg" }
+  let(:mocked_client_agency_id) { mocked_client_id }
 
   let(:cbv_flow) do
     create(:cbv_flow,
@@ -46,7 +47,7 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
     allow(Aggregators::AggregatorReports::PinwheelReport).to receive(:new).and_return(pinwheel_report)
 
     allow_any_instance_of(described_class).to receive(:current_agency).and_return(mock_client_agency)
-    allow(mock_client_agency).to receive_messages(id: mocked_client_id, logo_path: mocked_client_logo_path, transmission_method: transmission_method, transmission_method_configuration: transmission_method_configuration)
+    allow(mock_client_agency).to receive_messages(id: mocked_client_agency_id, logo_path: mocked_client_logo_path, transmission_method: transmission_method, transmission_method_configuration: transmission_method_configuration)
 
     allow_any_instance_of(described_class)
       .to receive(:event_logger)
@@ -291,6 +292,56 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
       end
 
       it_behaves_like "tracks an ApplicantSharedIncomeSummary event"
+    end
+
+    context "when transmission fails with a silenceable error" do
+      let(:transmission_method) { Transmitters::HttpPdfTransmitter::TRANSMISSION_METHOD }
+      let(:error_message) { "Unexpected response from agency: code=403 message=Forbidden body=" }
+
+      before do
+        allow(NewRelic::Agent).to receive(:record_custom_event)
+        allow_any_instance_of(Transmitters::HttpPdfTransmitter)
+          .to receive(:deliver)
+          .and_raise(ApplicationJob::SilencedError, error_message)
+      end
+
+      it "retries and reports the failure as silenced" do
+        expect do
+          described_class.perform_now(cbv_flow.id)
+        end.to have_enqueued_job(described_class)
+
+        expect(NewRelic::Agent).to have_received(:record_custom_event).with(
+          "SolidQueueJobFailed",
+          hash_including(
+            error_message: error_message,
+            is_silenced: true
+          )
+        )
+      end
+    end
+
+    context "when transmission fails with a non-silenced error" do
+      let(:transmission_method) { Transmitters::HttpPdfTransmitter::TRANSMISSION_METHOD }
+      let(:error_message) { "Unexpected response from agency: code=500 message=Internal Server Error body=" }
+
+      before do
+        allow(NewRelic::Agent).to receive(:record_custom_event)
+        allow_any_instance_of(Transmitters::HttpPdfTransmitter)
+          .to receive(:deliver)
+          .and_raise(Transmitters::HttpPdfTransmitter::HttpPdfTransmitterError, error_message)
+      end
+
+      it "still reports to NewRelic" do
+        described_class.perform_now(cbv_flow.id)
+
+        expect(NewRelic::Agent).to have_received(:record_custom_event).with(
+          "SolidQueueJobFailed",
+          hash_including(
+            error_message: error_message,
+            is_silenced: false
+          )
+        )
+      end
     end
   end
 

--- a/app/spec/services/transmitters/http_pdf_transmitter_spec.rb
+++ b/app/spec/services/transmitters/http_pdf_transmitter_spec.rb
@@ -99,5 +99,43 @@ RSpec.describe Transmitters::HttpPdfTransmitter do
         expect(api_request).to have_been_made
       end
     end
+
+    context "when the response code is configured to be silenced" do
+      let(:transmission_method_configuration) do
+        super().merge("silently_retry_error_codes" => [ 403, 408, 502 ])
+      end
+
+      it "raises a silenceable error" do
+        stub_request(
+          :post,
+          transmission_method_configuration["pdf_api_url"]
+        ).to_return(status: [ 403, "Forbidden" ], body: "Forbidden")
+
+        expect { subject.deliver }
+          .to raise_error(
+            ApplicationJob::SilencedError,
+            /code=403 message=Forbidden body=Forbidden/
+          )
+      end
+    end
+
+    context "when the response code is not configured to retry silently" do
+      let(:transmission_method_configuration) do
+        super().merge("silently_retry_error_codes" => [ 403, 408, 502 ])
+      end
+
+      it "raises the transmitter-specific error" do
+        stub_request(
+          :post,
+          transmission_method_configuration["pdf_api_url"]
+        ).to_return(status: [ 500, "Internal Server Error" ], body: "Internal Server Error")
+
+        expect { subject.deliver }
+          .to raise_error(
+            Transmitters::HttpPdfTransmitter::HttpPdfTransmitterError,
+            /code=500 message=Internal Server Error body=Internal Server Error/
+          )
+      end
+    end
   end
 end

--- a/app/spec/services/transmitters/json_and_pdf_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_and_pdf_transmitter_spec.rb
@@ -122,6 +122,32 @@ RSpec.describe Transmitters::JsonAndPdfTransmitter do
         expect(failing_pdf_request).to have_been_made.once
       end
 
+      context "when the PDF status code is configured to be silenced" do
+        let(:transmission_method_configuration) do
+          super().merge("silently_retry_error_codes" => [ 403, 408, 502 ])
+        end
+
+        it "re-raises a silenceable error" do
+          json_request = stub_request(:post, transmission_method_configuration["json_api_url"])
+            .with(headers: { 'Content-Type' => 'application/json' })
+            .to_return(status: 200)
+
+          failing_pdf_request = stub_request(:post, transmission_method_configuration["pdf_api_url"])
+            .with(headers: { 'Content-Type' => 'application/pdf' })
+            .with(body: pdf_output.content)
+            .to_return(status: [ 502, "Bad Gateway" ], body: "Bad Gateway")
+
+          expect { subject.deliver }
+            .to raise_error(
+              ApplicationJob::SilencedError,
+              /code=502 message=Bad Gateway body=Bad Gateway/
+            )
+
+          expect(json_request).to have_been_made.once
+          expect(failing_pdf_request).to have_been_made.once
+        end
+      end
+
       it 'does not retry JSON transmission when job retries after PDF failure' do
         json_request = stub_request(:post, transmission_method_configuration["json_api_url"])
           .with(headers: { 'Content-Type' => 'application/json' })

--- a/app/spec/services/transmitters/json_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_transmitter_spec.rb
@@ -85,6 +85,23 @@ RSpec.describe Transmitters::JsonTransmitter do
     end
   end
 
+  context "when the response code is configured to be silenced" do
+    let(:transmission_method_configuration) do
+      super().merge("silently_retry_error_codes" => [ 403, 408, 502 ])
+    end
+
+    it "raises a silenceable error" do
+      stub_request(:post, transmission_method_configuration["json_api_url"])
+        .to_return(status: [ 408, "Request Timeout" ], body: "Request Timeout")
+
+      expect { described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver }
+        .to raise_error(
+          ApplicationJob::SilencedError,
+          /code=408 message=Request Timeout body=Request Timeout/
+        )
+    end
+  end
+
   context 'signature generation' do
     it 'generates signature with the request body' do
       expect(JsonApiSignature).to receive(:generate).with(


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## [FFS-4241](https://jiraent.cms.gov/browse/FFS-4241)

## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-4241: Silence 403, 408, 502 errors from LA**
> This adds a new configuration option,
> `silence_errors_from_response_codes`, which allows the JSON and HTTP PDF
> transmitters to raise a different class of exception upon receiving
> those response codes. This exception, the `ApplicationJob::SilencedError`
> then is not reported to NewRelic.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)