### PR TITLE
FFS-4239: update caseworker transmitter retry timing

### DIFF
--- a/app/app/jobs/application_job.rb
+++ b/app/app/jobs/application_job.rb
@@ -3,6 +3,8 @@ class ApplicationJob < ActiveJob::Base
 
   retry_on Exception, wait: :polynomially_longer, attempts: 5
 
+  class_attribute :max_attempts, default: 5
+
   def event_logger
     @event_logger ||= GenericEventTracker.new
   end
@@ -42,7 +44,7 @@ class ApplicationJob < ActiveJob::Base
       error_class: error.class.name,
       error_message: error.message,
       executions: self.executions,
-      max_attempts: 5
+      max_attempts: self.class.max_attempts
     }.merge(trace_metadata))
     raise error
   end

--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -3,6 +3,14 @@ class CaseWorkerTransmitterJob < ApplicationJob
 
   queue_as :default
 
+  RETRY_WAITS = [ 5.minutes, 10.minutes, 30.minutes, 1.hour, 4.hours ].freeze
+
+  retry_on Exception,
+    attempts: RETRY_WAITS.size + 1,
+    wait: ->(executions) { RETRY_WAITS[executions - 1] || RETRY_WAITS.last }
+
+  self.max_attempts = RETRY_WAITS.size + 1
+
   limits_concurrency to: 1,
     key: ->(flow_id) {
       flow = CbvFlow.find(flow_id)

--- a/app/spec/jobs/application_job_spec.rb
+++ b/app/spec/jobs/application_job_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe ApplicationJob do
         TestJob.perform_now
       end.to have_enqueued_job(TestJob)
     end
+
+    class MaxAttemptsOverrideTestJob < ApplicationJob
+      self.max_attempts = 99
+
+      def perform
+        raise StandardError, "failed"
+      end
+    end
+
+    it "reports the subclass's overridden max_attempts in the NewRelic event" do
+      expect(NewRelic::Agent).to receive(:record_custom_event).with(
+        "SolidQueueJobFailed",
+        hash_including(max_attempts: 99)
+      )
+
+      MaxAttemptsOverrideTestJob.perform_now
+    end
   end
 
   describe "#with_flow_tags" do

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -293,4 +293,58 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
       it_behaves_like "tracks an ApplicantSharedIncomeSummary event"
     end
   end
+
+  describe "retry schedule" do
+    let(:transmission_method) { "shared_email" }
+    let(:invalid_flow_id) { 99_999_999 }
+    let(:retry_test_time) { Time.zone.parse("2026-04-28 10:00:00") }
+
+    around do |ex|
+      Timecop.freeze(retry_test_time, &ex)
+    end
+
+    before do
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    it "exposes a RETRY_WAITS constant matching the agreed schedule" do
+      expect(described_class::RETRY_WAITS).to eq(
+        [ 5.minutes, 10.minutes, 30.minutes, 1.hour, 4.hours ]
+      )
+    end
+
+    it "schedules each retry with the wait corresponding to that execution" do
+      schedule = [
+        [ 0, 5.minutes ],
+        [ 1, 10.minutes ],
+        [ 2, 30.minutes ],
+        [ 3, 1.hour ],
+        [ 4, 4.hours ]
+      ]
+
+      schedule.each do |prev_failures, expected_wait|
+        job = described_class.new(invalid_flow_id)
+        job.exception_executions["[Exception]"] = prev_failures
+
+        expect { job.perform_now }
+          .to have_enqueued_job(described_class)
+          .with(invalid_flow_id)
+          .at(retry_test_time + expected_wait)
+
+        ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+      end
+    end
+
+    it "raises after the final attempt is exhausted (no further retry enqueued)" do
+      job = described_class.new(invalid_flow_id)
+      job.exception_executions["[Exception]"] = described_class::RETRY_WAITS.size
+
+      expect { job.perform_now }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to be_empty
+    end
+
+    it "sets max_attempts to RETRY_WAITS.size + 1 so the NewRelic event reports correctly" do
+      expect(described_class.max_attempts).to eq(described_class::RETRY_WAITS.size + 1)
+    end
+  end
 end


### PR DESCRIPTION
## [FFS-4239](https://jiraent.cms.gov/browse/FFS-4239)

## Changes
Previously, we would attempt to send a caseworker report 5 times with polynomial backoff. Now, we attempt 6 times, with retries happening with the following delays: 1m, 5m, 30m, 1h, 4h

## Context for reviewers
Polynomial backoff tended to happen too quickly; the failures we were seeing were fixed on a longer time scale. We expect this new backoff pattern will allow more of these jobs to succeed automatically.

## Testing notes
This will be hard to test manually; I suggest we observe the new pattern in live environments and check it that way. Open to opposition to this, though!

## Acceptance testing
- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
