### PR TITLE
Anchore fix PR no longer auto-removes packages

### DIFF
--- a/.github/scripts/patch-dockerfile.rb
+++ b/.github/scripts/patch-dockerfile.rb
@@ -1,16 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Bidirectional Dockerfile OS package patcher.
+# Add-only Dockerfile OS package patcher.
 #
 # Usage: ruby patch-dockerfile.rb <trivy-results.json> <Dockerfile>
 #
-# Reads Trivy JSON output and reconciles the auto-managed RUN block in the
-# Dockerfile's BASE stage:
-#   - Adds packages Trivy flags as fixable that aren't already patched
-#   - Removes packages from the auto-fix block that are no longer flagged
-#     (meaning the base image update resolved them)
-#   - Removes the entire auto-fix block if it becomes empty
+# Reads Trivy JSON output and adds any packages Trivy flags as fixable to the
+# auto-managed RUN block in the Dockerfile's BASE stage. Removal is intentionally
+# manual — Trivy with --ignore-unfixed cannot distinguish "fix shipped in the
+# new base image" from "fix already applied by this auto-fix block", so
+# auto-removing risks reintroducing the CVE on the next build. Clear the block
+# manually when bumping the base Ruby image.
 #
 # Only manages blocks marked with the AUTOFIX_MARKER comment.
 # Never touches the manually-maintained "Upgrade packages in base image" block.
@@ -89,26 +89,13 @@ def set_github_output(key, value)
   File.open(output_file, "a") { |f| f.puts("#{key}=#{value}") }
 end
 
-def write_summary(added, removed)
+def write_summary(added)
   summary_file = ENV["PATCH_SUMMARY_FILE"]
   return unless summary_file
 
-  out = +""
-
-  if added.any?
-    out << "### Packages added\n\n"
-    added.sort.each { |pkg| out << "- `#{pkg}`\n" }
-    out << "\n"
-  else
-    out << "### Packages added\n\nNone\n\n"
-  end
-
-  if removed.any?
-    out << "### Packages removed _(resolved by base image update)_\n\n"
-    out << "| Package |\n|---------|\n"
-    removed.sort.each { |pkg| out << "| `#{pkg}` |\n" }
-    out << "\n"
-  end
+  out = +"### Packages added\n\n"
+  added.sort.each { |pkg| out << "- `#{pkg}`\n" }
+  out << "\n"
 
   File.write(summary_file, out)
 end
@@ -122,31 +109,22 @@ def main(trivy_path, dockerfile_path)
   block_start, block_end, currently_patched = parse_autofix_block(lines)
   puts "Currently in auto-fix block: #{currently_patched.sort}"
 
-  to_add    = needed - currently_patched
-  to_remove = currently_patched - needed
+  to_add = needed - currently_patched
+  stale  = currently_patched - needed
+  puts "Already-patched packages no longer flagged by Trivy (kept; manual cleanup at base image bump): #{stale.sort}" if stale.any?
 
-  if to_add.empty? && to_remove.empty?
-    puts "No changes needed."
+  if to_add.empty?
+    puts "No new packages to add."
     set_github_output("changes_made", "false")
     return
   end
 
-  puts "Adding: #{to_add.sort}"     if to_add.any?
-  puts "Removing (resolved by base image update): #{to_remove.sort}" if to_remove.any?
+  puts "Adding: #{to_add.sort}"
 
-  new_packages = (currently_patched - to_remove) | to_add
+  new_packages = currently_patched | to_add
 
   if block_start != -1
-    if new_packages.any?
-      lines[block_start..block_end] = build_autofix_block(new_packages)
-    else
-      # All packages resolved — remove the block entirely.
-      # Also remove a trailing blank line after the block if present.
-      del_end = block_end + 1
-      del_end += 1 if del_end < lines.size && lines[del_end].strip.empty?
-      lines.slice!(block_start...del_end)
-      puts "Auto-fix block removed (all packages resolved by base image update)."
-    end
+    lines[block_start..block_end] = build_autofix_block(new_packages)
   else
     insert_at = find_insertion_index(lines)
     if insert_at == -1
@@ -160,7 +138,7 @@ def main(trivy_path, dockerfile_path)
   File.write(dockerfile_path, lines.join)
   puts "Dockerfile updated: #{dockerfile_path}"
 
-  write_summary(to_add, to_remove)
+  write_summary(to_add)
   set_github_output("changes_made", "true")
 end
 

--- a/.github/workflows/auto-fix-vulnerabilities.yml
+++ b/.github/workflows/auto-fix-vulnerabilities.yml
@@ -123,9 +123,11 @@ jobs:
             echo ""
             echo "Once CI passes and confirms Trivy/Anchore are green, this PR is safe to merge."
             echo ""
-            echo "_The auto-fix block in the Dockerfile is temporary — remove it when the base_"
-            echo "_Ruby image is next upgraded to a version that includes these fixes (see upgrade_"
-            echo "_instructions at the top of the Dockerfile)._"
+            echo "_The auto-fix block in the Dockerfile is temporary and add-only. This workflow_"
+            echo "_will not auto-remove packages — Trivy with \`--ignore-unfixed\` cannot tell a_"
+            echo "_base-image fix apart from one already applied by this block, so removing_"
+            echo "_would risk reintroducing the CVE. Clear the block manually when the base_"
+            echo "_Ruby image is bumped (see upgrade instructions at the top of the Dockerfile)._"
           } > pr-body.md
 
       - name: Check for existing open fix PR


### PR DESCRIPTION
## Changes
- Switch `patch-dockerfile.rb` from bidirectional (add+remove) to add-only reconciliation of the Dockerfile auto-fix block
- Log stale already-patched packages instead of removing them
- Update PR body copy in `auto-fix-vulnerabilities.yml` to explain add-only behavior

## Context for reviewers
As you can see in #1647 and #1618, Trivy with `--ignore-unfixed` cannot distinguish "fix shipped in new base image" from "fix already applied by auto-fix block." Auto-removing risked reintroducing CVEs on next build. Cleanup of the auto-fix block has to be a manual process whenever we bump the Ruby base image.

## Acceptance testing
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)