### PR TITLE
FFS-3960: Change progress indicator label to "Sufficiently enrolled" for education activities

### DIFF
--- a/app/app/components/activity_flow_progress_indicator.rb
+++ b/app/app/components/activity_flow_progress_indicator.rb
@@ -65,6 +65,10 @@ class ActivityFlowProgressIndicator < ViewComponent::Base
 
   def display_hours_unit?(unit:) = unit == :hours
 
+  def sufficient_enrollment_label?(monthly_result, unit:)
+    unit == :hours && monthly_result.sufficient_enrollment
+  end
+
   def multi_month? = monthly_calculation_results.length > 1
 
   def complete_month_count = monthly_calculation_results.count(&:meets_requirements)

--- a/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
+++ b/app/app/components/activity_flow_progress_indicator/activity_flow_progress_indicator.erb
@@ -112,12 +112,18 @@
                     </svg>
                   <% end %>
 
-                  <%= display_progress_amount(monthly_result, unit: completed_unit) %>
+                  <% if sufficient_enrollment_label?(monthly_result, unit: completed_unit) %>
+                    <%= t(".sufficiently_enrolled") %>
+                  <% else %>
+                    <%= display_progress_amount(monthly_result, unit: completed_unit) %>
+                  <% end %>
                 </span>
-                /
-                <%= display_completion_threshold(monthly_result, unit: completed_unit) %>
-                <% if display_hours_unit?(unit: completed_unit) %>
-                  <%= t(".hours") %>
+                <% unless sufficient_enrollment_label?(monthly_result, unit: completed_unit) %>
+                  /
+                  <%= display_completion_threshold(monthly_result, unit: completed_unit) %>
+                  <% if display_hours_unit?(unit: completed_unit) %>
+                    <%= t(".hours") %>
+                  <% end %>
                 <% end %>
               <% else %>
                 <% [ :hours, :dollars ].each do |unit| %>

--- a/app/app/models/education_activity.rb
+++ b/app/app/models/education_activity.rb
@@ -150,6 +150,10 @@ class EducationActivity < Activity
     progress_calculator.routing_hours_for_month(month_start)
   end
 
+  def sufficient_enrollment_for_month?(month_start)
+    progress_calculator.sufficient_enrollment_for_month?(month_start)
+  end
+
   private
 
   # No date column -- skip the inherited date validation from Activity

--- a/app/app/services/activity_flow_progress_calculator.rb
+++ b/app/app/services/activity_flow_progress_calculator.rb
@@ -5,7 +5,15 @@ class ActivityFlowProgressCalculator
   PER_MONTH_EARNINGS_THRESHOLD = 580_00 # in cents
 
   OverallResult = Struct.new(:total_hours, :meets_requirements, :meets_routing_requirements, keyword_init: true)
-  MonthlyResult = Struct.new(:month, :total_hours, :total_earnings_cents, :default_unit, :meets_requirements, keyword_init: true)
+  MonthlyResult = Struct.new(
+    :month,
+    :total_hours,
+    :total_earnings_cents,
+    :default_unit,
+    :meets_requirements,
+    :sufficient_enrollment,
+    keyword_init: true
+  )
 
   def initialize(activity_flow)
     @activity_flow = activity_flow
@@ -34,7 +42,8 @@ class ActivityFlowProgressCalculator
         total_hours: hours,
         total_earnings_cents: earnings_cents,
         default_unit: default_unit_for_month(hours: hours, earnings_cents: earnings_cents),
-        meets_requirements: hours >= PER_MONTH_HOURS_THRESHOLD || earnings_cents >= PER_MONTH_EARNINGS_THRESHOLD
+        meets_requirements: hours >= PER_MONTH_HOURS_THRESHOLD || earnings_cents >= PER_MONTH_EARNINGS_THRESHOLD,
+        sufficient_enrollment: sufficient_enrollment_for_month?(month)
       )
     end
   end
@@ -214,5 +223,9 @@ class ActivityFlowProgressCalculator
 
   def education_hours_for_month(month_start)
     @education_activities.sum { |education| education.progress_hours_for_month(month_start) }
+  end
+
+  def sufficient_enrollment_for_month?(month_start)
+    @education_activities.any? { |education| education.sufficient_enrollment_for_month?(month_start) }
   end
 end

--- a/app/app/services/education_activity_card_builder.rb
+++ b/app/app/services/education_activity_card_builder.rb
@@ -60,21 +60,14 @@ class EducationActivityCardBuilder
   def validated_month_data(month_start:, effective_term:)
     {
       month: month_start,
-      enrollment_status: effective_term ? effective_term.enrollment_status_display : I18n.t("activities.hub.cards.not_enrolled"),
-      community_engagement_hours: effective_term&.half_time_or_above? ? ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD : 0,
-      credit_hours: nil,
-      show_credit_hours: false
+      enrollment_status: effective_term ? effective_term.enrollment_status_display : I18n.t("activities.hub.cards.not_enrolled")
     }
   end
 
   def partial_self_attested_month_data(term:, month_start:)
-    credit_hours = @activity.review_term_credit_hours(term)
     {
       month: month_start,
-      enrollment_status: term.enrollment_status_display,
-      community_engagement_hours: @activity.community_engagement_hours(credit_hours),
-      credit_hours: credit_hours,
-      show_credit_hours: true
+      enrollment_status: term.enrollment_status_display
     }
   end
 

--- a/app/app/services/education_activity_progress_calculator.rb
+++ b/app/app/services/education_activity_progress_calculator.rb
@@ -1,5 +1,5 @@
 class EducationActivityProgressCalculator
-  MonthHours = Struct.new(:progress, :routing, keyword_init: true)
+  MonthHours = Struct.new(:progress, :routing, :sufficient_enrollment, keyword_init: true)
 
   def initialize(education_activity)
     @education_activity = education_activity
@@ -11,6 +11,10 @@ class EducationActivityProgressCalculator
 
   def routing_hours_for_month(month_start)
     monthly_hours_for(month_start).routing
+  end
+
+  def sufficient_enrollment_for_month?(month_start)
+    !!monthly_hours_for(month_start).sufficient_enrollment
   end
 
   private
@@ -49,13 +53,15 @@ class EducationActivityProgressCalculator
       # complete progress and routing calculation.
       MonthHours.new(
         progress: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
-        routing: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+        routing: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+        sufficient_enrollment: true
       )
     elsif month_has_half_time_or_above?(terms)
       # For activities where NSC returns half-time or greater, that's complete.
       MonthHours.new(
         progress: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
-        routing: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD
+        routing: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+        sufficient_enrollment: true
       )
     elsif @education_activity.partially_self_attested? && terms.present?
       # For partially self-attested activities (where the user had to

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -131,10 +131,6 @@
                   <div class="activity-month-details__data">
                     <% if month_data[:enrollment_status].present? %>
                       <p class="margin-y-0"><%= t("activities.hub.cards.enrollment_status", status: month_data[:enrollment_status]) %></p>
-                      <% if month_data[:show_credit_hours] %>
-                        <p class="margin-y-0"><%= t("activities.hub.cards.credit_hours", amount: month_data[:credit_hours]) %></p>
-                      <% end %>
-                      <p class="margin-y-0"><%= t("activities.hub.cards.hours", count: month_data[:community_engagement_hours]) %></p>
                     <% else %>
                       <p class="margin-y-0"><%= t("activities.hub.cards.credit_hours", amount: month_data[:credit_hours]) %></p>
                       <p class="margin-y-0"><%= t("activities.hub.cards.hours", count: month_data[:community_engagement_hours]) %></p>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -547,6 +547,7 @@ en:
     renewal_subtitle_no_range: Complete any %{required} months to meet requirements.
     see_progress_in_dollars: See progress in $
     see_progress_in_hours: See progress in hours
+    sufficiently_enrolled: Sufficiently enrolled
     switch_to_dollars: Switch to $
     switch_to_hours: Switch to hours
     title: Your %{month} progress

--- a/app/spec/components/activity_flow_progress_indicator_component_spec.rb
+++ b/app/spec/components/activity_flow_progress_indicator_component_spec.rb
@@ -323,6 +323,56 @@ RSpec.describe ActivityFlowProgressIndicator, type: :component do
     end
   end
 
+  context "when a completed month has sufficient education enrollment" do
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+        total_earnings_cents: 0,
+        default_unit: :hours,
+        meets_requirements: true,
+        sufficient_enrollment: true
+      )
+    end
+
+    it "renders the sufficient enrollment label instead of hours progress" do
+      render_inline(component)
+
+      row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
+      expect(row_text).to include(I18n.t("activity_flow_progress_indicator.sufficiently_enrolled"))
+      expect(row_text).not_to include(
+        "#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} / " \
+        "#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+        "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      )
+    end
+  end
+
+  context "when a completed month does not have sufficient education enrollment" do
+    let(:monthly_result) do
+      ActivityFlowProgressCalculator::MonthlyResult.new(
+        month: reporting_month,
+        total_hours: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+        total_earnings_cents: 0,
+        default_unit: :hours,
+        meets_requirements: true,
+        sufficient_enrollment: false
+      )
+    end
+
+    it "renders hours progress" do
+      render_inline(component)
+
+      row_text = page.find(".activity-flow-progress-indicator__progress-amount-container").text.squish
+      expect(row_text).to include(
+        "#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} / " \
+        "#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD} " \
+        "#{I18n.t("activity_flow_progress_indicator.hours")}"
+      )
+      expect(row_text).not_to include(I18n.t("activity_flow_progress_indicator.sufficiently_enrolled"))
+    end
+  end
+
   context "when a completed month omits default_unit" do
     let(:monthly_result) do
       ActivityFlowProgressCalculator::MonthlyResult.new(

--- a/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
+++ b/app/spec/components/previews/activity_flow_progress_indicator_preview.rb
@@ -55,6 +55,16 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
     )
   end
 
+  def education_sufficiently_enrolled
+    results = []
+    results << make_result(Date.new(2026, 1, 1), 80, sufficient_enrollment: true)
+    results << make_result(Date.new(2025, 12, 1), 32)
+
+    render ActivityFlowProgressIndicator.new(
+      monthly_calculation_results: results
+    )
+  end
+
   def many_months_mixed_units
     results = []
     results << make_result(Date.new(2026, 1, 1), 77, earnings_cents: 597_00) # dollars
@@ -145,7 +155,7 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
 
   private
 
-  def make_result(month, hours, earnings_cents: 0)
+  def make_result(month, hours, earnings_cents: 0, sufficient_enrollment: false)
     meets_threshold = hours.to_f >= ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD ||
       earnings_cents >= ActivityFlowProgressCalculator::PER_MONTH_EARNINGS_THRESHOLD
 
@@ -161,7 +171,8 @@ class ActivityFlowProgressIndicatorPreview < ApplicationPreview
       total_hours: hours.to_f,
       total_earnings_cents: earnings_cents,
       default_unit: default_unit,
-      meets_requirements: meets_threshold
+      meets_requirements: meets_threshold,
+      sufficient_enrollment: sufficient_enrollment
     )
   end
 end

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "shows enrollment data and not the empty-state copy" do
+    it "shows only enrollment data and not the empty-state copy" do
       expect(response.body).to include("Test University")
       expect(response.body).to include(
         I18n.t(
@@ -477,7 +477,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
           status: I18n.t("components.enrollment_term_table_component.status.half_time")
         )
       )
-      expect(response.body).to include(I18n.t("activities.hub.cards.hours", count: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD))
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.hours", count: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD))
       expect(response.body).not_to include(I18n.t("activities.hub.cards.credit_hours", amount: 12))
       expect(response.body).not_to include(I18n.t("activities.hub.empty.education"))
     end
@@ -507,7 +507,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "shows enrollment status with saved credit hours and CE hours on the education card" do
+    it "shows only enrollment status on the education card" do
       expect(response.body).to include("Test University")
       expect(response.body).to include(
         I18n.t(
@@ -515,8 +515,8 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
           status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         )
       )
-      expect(response.body).to include(I18n.t("activities.hub.cards.credit_hours", amount: 4))
-      expect(response.body).to include(I18n.t("activities.hub.cards.hours", count: 16))
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.credit_hours", amount: 4))
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.hours", count: 16))
       expect(response.body).not_to include(I18n.t("activities.hub.empty.education"))
     end
 
@@ -567,13 +567,19 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "renders one card for the school with both months of data" do
+    it "renders one card for the school with enrollment data for both months" do
       education_cards = Nokogiri::HTML.parse(response.body).css("[data-activity-type='education'] .activity-hub-card")
 
       expect(education_cards.length).to eq(1)
       expect(response.body).to include("River College")
-      expect(response.body).to include(I18n.t("activities.hub.cards.credit_hours", amount: 3))
-      expect(response.body).to include(I18n.t("activities.hub.cards.credit_hours", amount: 5))
+      expect(response.body.scan(
+        I18n.t(
+          "activities.hub.cards.enrollment_status",
+          status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
+        )
+      ).length).to eq(2)
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.credit_hours", amount: 3))
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.credit_hours", amount: 5))
     end
   end
 
@@ -617,7 +623,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index
     end
 
-    it "shows all enrollment statuses on education cards and uses 80 hours in monthly progress" do
+    it "shows only the qualifying enrollment on education cards and uses the sufficient enrollment progress label" do
       expect(response.body).to include(half_time_school_name)
       expect(response.body).not_to include(less_than_half_time_school_name)
       expect(response.body).to include(
@@ -632,9 +638,9 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
           status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         )
       )
-      progress_text = /80\s*\/\s*#{ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD}\s*#{I18n.t("activity_flow_progress_indicator.hours")}/
       page_text = Capybara.string(response.body).text
-      expect(page_text.scan(progress_text).count).to eq(2)
+      expect(page_text.scan(I18n.t("activity_flow_progress_indicator.sufficiently_enrolled")).count).to eq(2)
+      expect(response.body).not_to include(I18n.t("activities.hub.cards.hours", count: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD))
     end
   end
 

--- a/app/spec/e2e/activity_hub_spec.rb
+++ b/app/spec/e2e/activity_hub_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     expect(page).to have_content I18n.t("activities.success.show.download_pdf")
   end
 
-  it "shows less-than-half-time education card details on the hub" do
+  it "shows less-than-half-time education enrollment on the hub" do
     visit URI(root_url).request_uri
     visit activities_flow_entry_path(client_agency_id: "sandbox")
     verify_page(page, title: I18n.t("activities.entries.show.title", benefit: "Medicaid"))
@@ -335,8 +335,8 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
         status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
       )
     )
-    expect(page).to have_content I18n.t("activities.hub.cards.credit_hours", amount: 4)
-    expect(page).to have_content I18n.t("activities.hub.cards.hours", count: 16)
+    expect(page).to have_no_content I18n.t("activities.hub.cards.credit_hours", amount: 4)
+    expect(page).to have_no_content I18n.t("activities.hub.cards.hours", count: 16)
   end
 
   it "supports editing a community service activity through the full flow" do # rubocop:disable RSpec/ExampleLength

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -195,10 +195,16 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      result.first[:months].each do |month_data|
-        expect(month_data[:enrollment_status]).to eq(I18n.t("components.enrollment_term_table_component.status.full_time"))
-        expect(month_data[:community_engagement_hours]).to eq(80)
-      end
+      expect(result.first[:months]).to contain_exactly(
+        {
+          month: first_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.full_time")
+        },
+        {
+          month: second_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.full_time")
+        }
+      )
     end
 
     it "shows 'Not enrolled' for months without overlapping terms" do
@@ -212,9 +218,9 @@ RSpec.describe ActivitiesHelper do
       first_month_data = result.first[:months].find { |m| m[:month] == first_month }
 
       expect(first_month_data[:enrollment_status]).to eq(I18n.t("components.enrollment_term_table_component.status.half_time"))
-      expect(first_month_data[:community_engagement_hours]).to eq(80)
+      expect(first_month_data).not_to have_key(:community_engagement_hours)
       expect(second_month_data[:enrollment_status]).to eq(I18n.t("activities.hub.cards.not_enrolled"))
-      expect(second_month_data[:community_engagement_hours]).to eq(0)
+      expect(second_month_data).not_to have_key(:community_engagement_hours)
     end
 
     it "does not build a card for a term with no reporting-window overlap" do
@@ -294,22 +300,16 @@ RSpec.describe ActivitiesHelper do
       expect(result.first[:months]).to contain_exactly(
         {
           month: first_month,
-          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time"),
-          community_engagement_hours: 12,
-          credit_hours: 3,
-          show_credit_hours: true
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         },
         {
           month: second_month,
-          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time"),
-          community_engagement_hours: 20,
-          credit_hours: 5,
-          show_credit_hours: true
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         }
       )
     end
 
-    it "shows saved term credit hours for partially self-attested months" do
+    it "shows enrollment status only for partially self-attested months" do
       activity = create(:education_activity, activity_flow: flow, data_source: :partially_self_attested)
       create(
         :nsc_enrollment_term,
@@ -323,11 +323,16 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      result.first[:months].each do |month_data|
-        expect(month_data[:credit_hours]).to eq(6)
-        expect(month_data[:community_engagement_hours]).to eq(24)
-        expect(month_data[:show_credit_hours]).to be(true)
-      end
+      expect(result.first[:months]).to contain_exactly(
+        {
+          month: first_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
+        },
+        {
+          month: second_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
+        }
+      )
     end
 
     it "only includes overlapping months for partially self-attested terms" do
@@ -345,10 +350,15 @@ RSpec.describe ActivitiesHelper do
       result = helper.education_cards([ activity.reload ], reporting_months)
 
       expect(result.first[:months].map { |m| m[:month] }).to eq([ first_month ])
-      expect(result.first[:months].first[:credit_hours]).to eq(4)
+      expect(result.first[:months].first).to eq(
+        {
+          month: first_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
+        }
+      )
     end
 
-    it "shows saved term credit hours for enrolled partially self-attested months" do
+    it "shows enrollment status only for enrolled partially self-attested months" do
       activity = create(:education_activity, activity_flow: flow, data_source: :partially_self_attested)
       create(
         :nsc_enrollment_term,
@@ -362,11 +372,16 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      result.first[:months].each do |month_data|
-        expect(month_data[:credit_hours]).to eq(5)
-        expect(month_data[:community_engagement_hours]).to eq(20)
-        expect(month_data[:show_credit_hours]).to be(true)
-      end
+      expect(result.first[:months]).to contain_exactly(
+        {
+          month: first_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.enrolled")
+        },
+        {
+          month: second_month,
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.enrolled")
+        }
+      )
     end
 
     it "builds a fully self-attested card from activity months" do
@@ -415,10 +430,16 @@ RSpec.describe ActivitiesHelper do
       result = helper.education_cards([ activity.reload ], summer_months)
 
       expect(result.length).to eq(1)
-      expect(result.first[:months].map { |month| month[:enrollment_status] })
-        .to all(eq(I18n.t("components.enrollment_term_table_component.status.half_time")))
-      expect(result.first[:months].map { |month| month[:community_engagement_hours] })
-        .to all(eq(ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD))
+      expect(result.first[:months]).to contain_exactly(
+        {
+          month: Date.new(2025, 7, 1),
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
+        },
+        {
+          month: Date.new(2025, 8, 1),
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
+        }
+      )
     end
 
     it "shows the spring enrollment status on the summer card when no summer term exists" do
@@ -437,10 +458,16 @@ RSpec.describe ActivitiesHelper do
       result = helper.education_cards([ activity.reload ], summer_months)
 
       expect(result.length).to eq(1)
-      expect(result.first[:months].map { |month| month[:enrollment_status] })
-        .to all(eq(I18n.t("components.enrollment_term_table_component.status.half_time")))
-      expect(result.first[:months].map { |month| month[:community_engagement_hours] })
-        .to all(eq(ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD))
+      expect(result.first[:months]).to contain_exactly(
+        {
+          month: Date.new(2025, 7, 1),
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
+        },
+        {
+          month: Date.new(2025, 8, 1),
+          enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
+        }
+      )
     end
 
     it "builds one validated card when two terms overlap the same reporting month" do
@@ -469,9 +496,9 @@ RSpec.describe ActivitiesHelper do
       july_data = result.first[:months].find { |month| month[:month] == Date.new(2025, 7, 1) }
 
       expect(june_data[:enrollment_status]).to eq(I18n.t("components.enrollment_term_table_component.status.half_time"))
-      expect(june_data[:community_engagement_hours]).to eq(ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD)
+      expect(june_data).not_to have_key(:community_engagement_hours)
       expect(july_data[:enrollment_status]).to eq(I18n.t("components.enrollment_term_table_component.status.half_time"))
-      expect(july_data[:community_engagement_hours]).to eq(ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD)
+      expect(july_data).not_to have_key(:community_engagement_hours)
     end
   end
 

--- a/app/spec/services/activity_flow_progress_calculator_spec.rb
+++ b/app/spec/services/activity_flow_progress_calculator_spec.rb
@@ -512,6 +512,113 @@ RSpec.describe ActivityFlowProgressCalculator do
       end
     end
 
+    context "when a month is complete through sufficient education enrollment" do
+      let(:flow) do
+        create(
+          :activity_flow,
+          reporting_window_months: 1,
+          volunteering_activities_count: 0,
+          job_training_activities_count: 0,
+          education_activities_count: 0
+        )
+      end
+      let(:education_activity) { create(:education_activity, activity_flow: flow, status: "succeeded") }
+
+      before do
+        create(
+          :nsc_enrollment_term,
+          education_activity: education_activity,
+          enrollment_status: "half_time",
+          term_begin: flow.reporting_months.first,
+          term_end: flow.reporting_months.first.end_of_month
+        )
+      end
+
+      it "marks the monthly result with sufficient enrollment" do
+        expect(result.first).to have_attributes(
+          total_hours: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+          meets_requirements: true,
+          sufficient_enrollment: true
+        )
+      end
+    end
+
+    context "when a month is complete through self-attested education credit hours" do
+      let(:flow) do
+        create(
+          :activity_flow,
+          reporting_window_months: 1,
+          volunteering_activities_count: 0,
+          job_training_activities_count: 0,
+          education_activities_count: 0
+        )
+      end
+      let(:education_activity) do
+        create(
+          :education_activity,
+          activity_flow: flow,
+          data_source: :fully_self_attested,
+          status: "unknown",
+          school_name: "Test U"
+        )
+      end
+
+      before do
+        create(
+          :education_activity_month,
+          education_activity: education_activity,
+          month: flow.reporting_months.first.beginning_of_month,
+          hours: 20
+        )
+      end
+
+      it "does not mark the monthly result with sufficient enrollment" do
+        expect(result.first).to have_attributes(
+          total_hours: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD,
+          meets_requirements: true,
+          sufficient_enrollment: false
+        )
+      end
+    end
+
+    context "when a month has sufficient education enrollment and volunteering hours" do
+      let(:flow) do
+        create(
+          :activity_flow,
+          reporting_window_months: 1,
+          volunteering_activities_count: 0,
+          job_training_activities_count: 0,
+          education_activities_count: 0
+        )
+      end
+      let(:education_activity) { create(:education_activity, activity_flow: flow, status: "succeeded") }
+      let(:volunteering_activity) { create(:volunteering_activity, activity_flow: flow) }
+
+      before do
+        create(
+          :nsc_enrollment_term,
+          education_activity: education_activity,
+          enrollment_status: "half_time",
+          term_begin: flow.reporting_months.first,
+          term_end: flow.reporting_months.first.end_of_month
+        )
+        create(
+          :volunteering_activity_month,
+          volunteering_activity: volunteering_activity,
+          month: flow.reporting_months.first.beginning_of_month,
+          hours: 30
+        )
+      end
+
+      it "keeps sufficient enrollment while including other activity hours" do
+        expect(result.first).to have_attributes(
+          total_hours: ActivityFlowProgressCalculator::PER_MONTH_HOURS_THRESHOLD + 30,
+          meets_requirements: true,
+          sufficient_enrollment: true
+        )
+      end
+    end
+
     context "when a month is below both thresholds" do
       let(:flow) { create(:activity_flow, reporting_window_months: 1) }
       let(:month) { flow.reporting_window_range.begin }

--- a/app/spec/services/education_activity_progress_calculator_spec.rb
+++ b/app/spec/services/education_activity_progress_calculator_spec.rb
@@ -221,4 +221,59 @@ RSpec.describe EducationActivityProgressCalculator do
       end
     end
   end
+
+  describe "#sufficient_enrollment_for_month?" do
+    it "returns true when the month has half-time or above enrollment" do
+      create(
+        :nsc_enrollment_term,
+        education_activity: education_activity,
+        enrollment_status: "half_time",
+        term_begin: month_start,
+        term_end: month_start.end_of_month
+      )
+
+      expect(calculator).to be_sufficient_enrollment_for_month(month_start)
+    end
+
+    it "returns false when the month uses self-attested credit hours" do
+      education_activity.update!(data_source: :fully_self_attested, school_name: "Test U", status: "unknown")
+      create(
+        :education_activity_month,
+        education_activity: education_activity,
+        month: month_start.beginning_of_month,
+        # 20 credit hours * CREDIT_HOUR_CE_MULTIPLIER (4) meets the 80-hour threshold.
+        hours: 20
+      )
+
+      expect(calculator).not_to be_sufficient_enrollment_for_month(month_start)
+    end
+
+    it "returns true when summer carryover applies" do
+      flow.update!(reporting_window_months: 2)
+      flow.shift_reporting_window_start!("2025-07-01")
+      july = Date.new(2025, 7, 1)
+      create(
+        :nsc_enrollment_term,
+        education_activity: education_activity,
+        enrollment_status: "half_time",
+        term_begin: Date.new(2025, 3, 1),
+        term_end: Date.new(2025, 6, 15)
+      )
+
+      expect(calculator).to be_sufficient_enrollment_for_month(july)
+    end
+
+    it "returns false when the month has less-than-half-time enrollment" do
+      create(
+        :nsc_enrollment_term,
+        :less_than_half_time,
+        education_activity: education_activity,
+        term_begin: month_start,
+        term_end: month_start.end_of_month,
+        credit_hours: 20
+      )
+
+      expect(calculator).not_to be_sufficient_enrollment_for_month(month_start)
+    end
+  end
 end


### PR DESCRIPTION
## [FFS-3960](https://jiraent.cms.gov/browse/FFS-3960)

## Changes
- We now have "sufficiently enrolled" label for education months in the progress indicator
- X / 80 hours still works for less-than-half-time and self-attested credit hours
- Updated education hub cards to show enrollment only when enrollment data is present
- Removed some dead code from CE card data education with enrollment
- New Lookbook

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
  
<img width="1023" height="1083" alt="Screenshot 2026-04-29 at 2 27 52 PM" src="https://github.com/user-attachments/assets/62f5d187-ac82-4508-9bd5-617e3c6e7fbc" />
<img width="994" height="586" alt="Screenshot 2026-04-29 at 1 16 55 PM" src="https://github.com/user-attachments/assets/37d52f9f-4ec0-4dd8-a2f5-02af2a3628da" />

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->