### PR TITLE
Deploy script always includes CE/Income category

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -12,6 +12,8 @@ require "json"
 require "open-uri"
 require "open3"
 
+NO_CHANGES_PLACEHOLDER = "  • No changes, nothing to review!"
+
 def linkify_jira(text)
   linked_text = text.gsub(/\(#(\d+)\)/) do
     "([##{$1}](https://github.com/DSACMS/iv-cbv-payroll/pull/#{$1}))"
@@ -74,20 +76,12 @@ def copy_to_clipboard(text)
   IO.popen("pbcopy", "w") { |io| io.write(text) }
 end
 
-def append_changes(output, heading, changes)
-  return output if changes.empty?
+def append_changes(output, heading, changes, empty_message: nil)
+  return output if changes.empty? && empty_message.nil?
 
-  output << "#{heading}\n"
-  changes.each do |change|
-    output << "#{linkify_jira("  • #{change}")}\n"
-  end
-  output
-end
-
-def append_changes_with_placeholder(output, heading, changes)
   output << "#{heading}\n"
   if changes.empty?
-    output << "  • No changes, nothing to review!\n"
+    output << "#{empty_message}\n"
   else
     changes.each do |change|
       output << "#{linkify_jira("  • #{change}")}\n"
@@ -158,8 +152,18 @@ output = +""
 output << "🚀 Will deploy `#{current_sha[0, 7]}` to production: 🚀 (cc #{tags})\n"
 output << "🧪 *[Launch the demo →](https://la-verify-demo.navapbc.cloud/demo)*\n\n"
 append_changes(output, "👥 *User facing changes to Emmy Income + Emmy CE*", both_changes)
-append_changes_with_placeholder(output, "📝 *Emmy Income only user facing changes*", income_changes)
-append_changes_with_placeholder(output, "🏆 *Emmy CE only user facing changes*", ce_changes)
+append_changes(
+  output,
+  "📝 *Emmy Income only user facing changes*",
+  income_changes,
+  empty_message: NO_CHANGES_PLACEHOLDER
+)
+append_changes(
+  output,
+  "🏆 *Emmy CE only user facing changes*",
+  ce_changes,
+  empty_message: NO_CHANGES_PLACEHOLDER
+)
 append_changes(output, "⚙️ *Other/Maintenance (Not user facing)*", other_changes)
 output << "\n"
 output << "See the [full diff on Github](https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}).\n"

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -84,6 +84,18 @@ def append_changes(output, heading, changes)
   output
 end
 
+def append_changes_with_placeholder(output, heading, changes)
+  output << "#{heading}\n"
+  if changes.empty?
+    output << "  • No changes, nothing to review!\n"
+  else
+    changes.each do |change|
+      output << "#{linkify_jira("  • #{change}")}\n"
+    end
+  end
+  output
+end
+
 if ARGV.first == "--test"
   puts linkify_jira("1234: Foo bar baz")
   puts linkify_jira("FFS-1234: Foo bar baz")
@@ -117,6 +129,13 @@ commit_lines(prod, current_sha).each do |commit_line|
     warn "Commit: https://github.com/DSACMS/iv-cbv-payroll/commit/#{commit_hash}"
   end
 
+  if commit.end_with?("[bot]")
+    warn "Auto-categorizing bot-authored change as Other/Maintenance..."
+    other_changes << commit
+    warn ""
+    next
+  end
+
   case prompt_for_category
   when "b"
     both_changes << commit
@@ -139,8 +158,8 @@ output = +""
 output << "🚀 Will deploy `#{current_sha[0, 7]}` to production: 🚀 (cc #{tags})\n"
 output << "🧪 *[Launch the demo →](https://la-verify-demo.navapbc.cloud/demo)*\n\n"
 append_changes(output, "👥 *User facing changes to Emmy Income + Emmy CE*", both_changes)
-append_changes(output, "📝 *Emmy Income only user facing changes*", income_changes)
-append_changes(output, "🏆 *Emmy CE only user facing changes*", ce_changes)
+append_changes_with_placeholder(output, "📝 *Emmy Income only user facing changes*", income_changes)
+append_changes_with_placeholder(output, "🏆 *Emmy CE only user facing changes*", ce_changes)
 append_changes(output, "⚙️ *Other/Maintenance (Not user facing)*", other_changes)
 output << "\n"
 output << "See the [full diff on Github](https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}).\n"


### PR DESCRIPTION
## Changes
- If no changes to CE/Income are listed we still want to inform reviewers that way they know there's nothing to look at.
- Automatically put bot fixes in the maintenance category

## Acceptance testing
- [X] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
You can run this locally to see for yourself. 