### PR TITLE
FFS-4011: Employment details pulling specific dates instead of months

### DIFF
--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -5,9 +5,14 @@
 <% variant = @flow.renewal_reporting_window? ? :renewal : :application %>
 <% title_key = activity_hub_title_key(state) %>
 <% description_key = activity_hub_description_key(state) %>
+<% single_month_reporting_window = @flow.reporting_months.one? %>
+<% reporting_window_display = single_month_reporting_window ? l(@flow.reporting_window_range.begin, format: :month_year) : @flow.reporting_window_display %>
+<% empty_state_description_key = single_month_reporting_window ? "activities.hub.empty_state_description_single_month" : "activities.hub.empty_state_description" %>
 <%# i18n-tasks-use t("activities.hub.empty_state_title") %>
 <%# i18n-tasks-use t("activities.hub.completed_state_title") %>
 <%# i18n-tasks-use t("activities.hub.in_progress_state_title") %>
+<%# i18n-tasks-use t("activities.hub.empty_state_description") %>
+<%# i18n-tasks-use t("activities.hub.empty_state_description_single_month") %>
 <%# i18n-tasks-use t("activities.hub.completed_state_description", agency_name: "Test Agency") %>
 <%# i18n-tasks-use t("activities.hub.in_progress_state_description", agency_name: "Test Agency") %>
 <%# i18n-tasks-use t("activities.hub.empty_state_months_required_any", required_month_count: 3) %>
@@ -24,7 +29,7 @@
     <% if state == :empty %>
       <p class="activity-hub-subheading margin-top-2">
         <strong><%= t("activities.hub.empty_state_reporting_period_label") %></strong>
-        <%= @flow.reporting_window_display %>
+        <%= reporting_window_display %>
       </p>
 
       <% if variant == :renewal %>
@@ -36,7 +41,7 @@
       <% end %>
 
       <p class="activity-hub-subheading">
-        <%= t("activities.hub.empty_state_description", reporting_window: @flow.reporting_window_display) %>
+        <%= t(empty_state_description_key, reporting_window: reporting_window_display) %>
       </p>
     <% else %>
       <p class="activity-hub-subheading margin-top-2">

--- a/app/app/views/activities/income/payment_details/show.html.erb
+++ b/app/app/views/activities/income/payment_details/show.html.erb
@@ -16,8 +16,12 @@
 <% reporting_window_range = @flow.reporting_window_range %>
 <% reporting_window_start_month = l(reporting_window_range.begin, format: :month_year) %>
 <% reporting_window_end_month = l(reporting_window_range.end, format: :month_year) %>
+<% subheader_key = reporting_window_start_month == reporting_window_end_month ? ".subheader_single_month_html" : ".subheader_html" %>
+<%# i18n-tasks-use t('activities.income.payment_details.show.subheader_html') %>
+<%# i18n-tasks-use t('activities.income.payment_details.show.subheader_single_month_html') %>
 
-<%= t(".subheader_html",
+<%= t(subheader_key,
+      month: reporting_window_start_month,
       start_month: reporting_window_start_month,
       end_month: reporting_window_end_month,
       agency_acronym: agency_translation("shared.agency_acronym"),

--- a/app/app/views/activities/income/payment_details/show.html.erb
+++ b/app/app/views/activities/income/payment_details/show.html.erb
@@ -13,9 +13,13 @@
   <%= header %>
 </h1>
 
+<% reporting_window_range = @flow.reporting_window_range %>
+<% reporting_window_start_month = l(reporting_window_range.begin, format: :month_year) %>
+<% reporting_window_end_month = l(reporting_window_range.end, format: :month_year) %>
+
 <%= t(".subheader_html",
-      start_date: format_date(@aggregator_report.from_date),
-      end_date: format_date(@aggregator_report.to_date),
+      start_month: reporting_window_start_month,
+      end_month: reporting_window_end_month,
       agency_acronym: agency_translation("shared.agency_acronym"),
     ) %>
 
@@ -27,8 +31,8 @@
   <% else %>
     <%= render Uswds::Alert.new(type: :info, heading: t(".none_found"), class: "margin-top-5") do %>
       <%= t(".none_found_description",
-        start_date: format_date(@aggregator_report.from_date),
-        end_date: format_date(@aggregator_report.to_date),
+        start_month: reporting_window_start_month,
+        end_month: reporting_window_end_month,
       ) %>
     <% end %>
   <% end %>

--- a/app/app/views/activities/income/payment_details/show.html.erb
+++ b/app/app/views/activities/income/payment_details/show.html.erb
@@ -16,7 +16,7 @@
 <% reporting_window_range = @flow.reporting_window_range %>
 <% reporting_window_start_month = l(reporting_window_range.begin, format: :month_year) %>
 <% reporting_window_end_month = l(reporting_window_range.end, format: :month_year) %>
-<% subheader_key = reporting_window_start_month == reporting_window_end_month ? ".subheader_single_month_html" : ".subheader_html" %>
+<% subheader_key = @flow.reporting_months.one? ? ".subheader_single_month_html" : ".subheader_html" %>
 <%# i18n-tasks-use t('activities.income.payment_details.show.subheader_html') %>
 <%# i18n-tasks-use t('activities.income.payment_details.show.subheader_single_month_html') %>
 

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -385,6 +385,7 @@ en:
           none_found: We didn't find any payments from this employer
           none_found_description: This typically happens when you haven't received income from this job between %{start_month} and %{end_month}. If you believe this is an error, add a comment below.
           subheader_html: "<p>We have gathered your records from %{start_month} to %{end_month}.</p><p>Please review your information. If something is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your community engagement report.</p>"
+          subheader_single_month_html: "<p>We have gathered your records for %{month}.</p><p>Please review your information. If something is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your community engagement report.</p>"
           unknown: Unknown
       synchronization_failures:
         show:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -383,8 +383,8 @@ en:
           header: Review your information from %{employer_name}
           header_no_employer_name: Your information from your employer
           none_found: We didn't find any payments from this employer
-          none_found_description: This typically happens when you haven't received income from this job between %{start_date} and %{end_date}. If you believe this is an error, add a comment below.
-          subheader_html: "<p>We have gathered your records from %{start_date} to %{end_date}.</p><p>Please review your information. If something is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your community engagement report.</p>"
+          none_found_description: This typically happens when you haven't received income from this job between %{start_month} and %{end_month}. If you believe this is an error, add a comment below.
+          subheader_html: "<p>We have gathered your records from %{start_month} to %{end_month}.</p><p>Please review your information. If something is missing or inaccurate, add a comment for %{agency_acronym}. This will be included in your community engagement report.</p>"
           unknown: Unknown
       synchronization_failures:
         show:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -339,6 +339,7 @@ en:
         employment: No employment added
         work_programs: No work programs added
       empty_state_description: Add employment, education, community service, or work program activities you've done between %{reporting_window}.
+      empty_state_description_single_month: Add employment, education, community service, or work program activities you've done in %{reporting_window}.
       empty_state_months_required_all: all %{required_month_count} months in the reporting period
       empty_state_months_required_any: any %{required_month_count} months in the reporting period
       empty_state_months_required_label: 'Months required:'

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -184,6 +184,32 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       )
     end
 
+    context "with a single-month reporting window" do
+      let(:current_flow) do
+        create(
+          :activity_flow,
+          volunteering_activities_count: 0,
+          job_training_activities_count: 0,
+          education_activities_count: 0,
+          reporting_window_months: 1
+        )
+      end
+
+      it "shows the empty-state reporting period with one month label" do
+        page_text = Capybara.string(response.body).text
+        reporting_month = I18n.l(current_flow.reporting_window_range.begin, format: :month_year)
+
+        expect(page_text).to include(I18n.t("activities.hub.empty_state_reporting_period_label"))
+        expect(page_text).to include(reporting_month)
+        expect(page_text).to include(
+          I18n.t(
+            "activities.hub.empty_state_description_single_month",
+            reporting_window: reporting_month
+          )
+        )
+      end
+    end
+
     it "renders the two-column container" do
       expect(response.body).to include("activity-hub-columns")
     end

--- a/app/spec/controllers/activities/income/payment_details_controller_spec.rb
+++ b/app/spec/controllers/activities/income/payment_details_controller_spec.rb
@@ -51,13 +51,22 @@ RSpec.describe Activities::Income::PaymentDetailsController do
         expect(response.body).to include("back-nav")
       end
 
-      it "describes the reporting window with month labels" do
+      it "describes a multi-month reporting window with month labels" do
         get :show, params: { user: { account_id: account_id } }
 
         start_month = I18n.l(flow.reporting_window_range.begin, format: :month_year)
         end_month = I18n.l(flow.reporting_window_range.end, format: :month_year)
 
         expect(response.body).to include("We have gathered your records from #{start_month} to #{end_month}.")
+      end
+
+      it "describes a single-month reporting window with one month label" do
+        flow.update!(reporting_window_months: 1)
+
+        get :show, params: { user: { account_id: account_id } }
+
+        month = I18n.l(flow.reporting_window_range.begin, format: :month_year)
+        expect(response.body).to include("We have gathered your records for #{month}.")
       end
 
       it "tracks viewed payment details with activity_flow_id" do

--- a/app/spec/controllers/activities/income/payment_details_controller_spec.rb
+++ b/app/spec/controllers/activities/income/payment_details_controller_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Activities::Income::PaymentDetailsController do
         expect(response.body).to include("back-nav")
       end
 
+      it "describes the reporting window with month labels" do
+        get :show, params: { user: { account_id: account_id } }
+
+        start_month = I18n.l(flow.reporting_window_range.begin, format: :month_year)
+        end_month = I18n.l(flow.reporting_window_range.end, format: :month_year)
+
+        expect(response.body).to include("We have gathered your records from #{start_month} to #{end_month}.")
+      end
+
       it "tracks viewed payment details with activity_flow_id" do
         allow(EventTrackingJob).to receive(:perform_later).with(TrackEvent::CbvPageView, anything, anything)
         expect(EventTrackingJob).to receive(:perform_later).with(TrackEvent::ApplicantViewedPaymentDetails, anything, hash_including(
@@ -111,6 +120,13 @@ RSpec.describe Activities::Income::PaymentDetailsController do
       it "renders successfully" do
         expect(response).to be_successful
         expect(response.body).to have_text(I18n.t("activities.income.payment_details.show.none_found"))
+      end
+
+      it "describes the missing income range with month labels" do
+        start_month = I18n.l(flow.reporting_window_range.begin, format: :month_year)
+        end_month = I18n.l(flow.reporting_window_range.end, format: :month_year)
+
+        expect(response.body).to include("between #{start_month} and #{end_month}")
       end
     end
   end


### PR DESCRIPTION
## [FFS-4011](https://jiraent.cms.gov/browse/FFS-4011)

## Changes
Update requested content on employment details page to use months.

## Context for reviewers
Not mentioned in the ticket, but also updated the none found content because that would have displayed specific dates rather than months, as well.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
  
<img width="693" height="198" alt="Screenshot 2026-05-06 at 2 28 44 PM" src="https://github.com/user-attachments/assets/adc56722-e0b7-442a-b546-8701a19f2cad" />

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->