### PR TITLE
FFS-4059: Validated education activity routing skips enrollment details page

### DIFF
--- a/app/app/controllers/activities/education_controller.rb
+++ b/app/app/controllers/activities/education_controller.rb
@@ -193,7 +193,7 @@ class Activities::EducationController < Activities::BaseController
   end
 
   def education_sync_success_path
-    if @education_activity.partially_self_attested?
+    if @education_activity.partially_self_attested? || @education_activity.validated?
       edit_activities_flow_education_path(id: @education_activity.id)
     else
       after_activity_path

--- a/app/app/controllers/activities/education_controller.rb
+++ b/app/app/controllers/activities/education_controller.rb
@@ -35,7 +35,6 @@ class Activities::EducationController < Activities::BaseController
     if @education_activity.sync_failed? || @education_activity.sync_no_enrollments?
       redirect_to activities_flow_education_error_path
     elsif @education_activity.sync_succeeded? && !testing_synchronization_page?
-      @education_activity.publish! unless @education_activity.partially_self_attested?
       redirect_to education_sync_success_path
     else
       # sync is still in progress — render the polling page
@@ -89,7 +88,6 @@ class Activities::EducationController < Activities::BaseController
     elsif @wait_time < ARTIFICIAL_DELAY && !testing_synchronization_page?
       render turbo_stream: turbo_stream.replace(:synchronization, partial: "status")
     else
-      @education_activity.publish! unless @education_activity.partially_self_attested?
       render turbo_stream: turbo_stream.action(:redirect, education_sync_success_path)
     end
   end

--- a/app/spec/controllers/activities/education_controller_spec.rb
+++ b/app/spec/controllers/activities/education_controller_spec.rb
@@ -110,31 +110,19 @@ RSpec.describe Activities::EducationController, type: :controller do
       end
     end
 
-    context "when the EducationActivity has succeeded" do
-      before do
-        education_activity.update(status: :succeeded)
-        allow(controller).to receive(:testing_synchronization_page?)
-          .and_return(false)
-      end
-
-      it "redirects via after_activity_path" do
-        get :show, params: { id: education_activity.id }
-
-        expect(response).to redirect_to(activities_flow_root_path)
-      end
-    end
-
-    context "when the EducationActivity has succeeded and routing requirements are met" do
+    context "when the EducationActivity is validated and succeeded" do
       before do
         education_activity.update(status: :succeeded)
         create(:nsc_enrollment_term, education_activity: education_activity, enrollment_status: :half_time)
         allow(controller).to receive(:testing_synchronization_page?).and_return(false)
       end
 
-      it "redirects to summary" do
+      it "redirects to education edit to review NSC enrollment details first" do
         get :show, params: { id: education_activity.id }
 
-        expect(response).to redirect_to(activities_flow_summary_path)
+        expect(response).to redirect_to(
+          edit_activities_flow_education_path(id: education_activity.id)
+        )
       end
     end
 

--- a/app/spec/controllers/activities/education_controller_spec.rb
+++ b/app/spec/controllers/activities/education_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Activities::EducationController, type: :controller do
 
     context "when the EducationActivity is validated and succeeded" do
       before do
-        education_activity.update(status: :succeeded)
+        education_activity.update(status: :succeeded, draft: true)
         create(:nsc_enrollment_term, education_activity: education_activity, enrollment_status: :half_time)
         allow(controller).to receive(:testing_synchronization_page?).and_return(false)
       end
@@ -124,11 +124,17 @@ RSpec.describe Activities::EducationController, type: :controller do
           edit_activities_flow_education_path(id: education_activity.id)
         )
       end
+
+      it "does not publish the activity (defers until the review form is submitted)" do
+        get :show, params: { id: education_activity.id }
+
+        expect(education_activity.reload.draft).to be(true)
+      end
     end
 
     context "when the EducationActivity is partially self-attested and succeeded" do
       before do
-        education_activity.update(status: :succeeded, data_source: :partially_self_attested)
+        education_activity.update(status: :succeeded, data_source: :partially_self_attested, draft: true)
         create(:nsc_enrollment_term, :less_than_half_time, education_activity: education_activity)
         allow(controller).to receive(:testing_synchronization_page?)
           .and_return(false)
@@ -140,6 +146,44 @@ RSpec.describe Activities::EducationController, type: :controller do
         expect(response).to redirect_to(
           edit_activities_flow_education_path(id: education_activity.id)
         )
+      end
+
+      it "does not publish the activity (defers until the review form is submitted)" do
+        get :show, params: { id: education_activity.id }
+
+        expect(education_activity.reload.draft).to be(true)
+      end
+    end
+  end
+
+  describe "PATCH #sync" do
+    let(:education_activity) { create(:education_activity, activity_flow: activity_flow) }
+
+    context "when the EducationActivity is validated and succeeded" do
+      before do
+        education_activity.update(status: :succeeded, draft: true)
+        create(:nsc_enrollment_term, education_activity: education_activity, enrollment_status: :half_time)
+        allow(controller).to receive(:testing_synchronization_page?).and_return(false)
+      end
+
+      it "does not publish the activity (defers until the review form is submitted)" do
+        patch :sync, params: { education_id: education_activity.id }, format: :turbo_stream
+
+        expect(education_activity.reload.draft).to be(true)
+      end
+    end
+
+    context "when the EducationActivity is partially self-attested and succeeded" do
+      before do
+        education_activity.update(status: :succeeded, data_source: :partially_self_attested, draft: true)
+        create(:nsc_enrollment_term, :less_than_half_time, education_activity: education_activity)
+        allow(controller).to receive(:testing_synchronization_page?).and_return(false)
+      end
+
+      it "does not publish the activity (defers until the review form is submitted)" do
+        patch :sync, params: { education_id: education_activity.id }, format: :turbo_stream
+
+        expect(education_activity.reload.draft).to be(true)
       end
     end
   end


### PR DESCRIPTION
## [FFS-4059](https://jiraent.cms.gov/browse/FFS-4059)
- Route validated education activities to the edit/review page after sync (previously only `partially_self_attested?` activities hit review; fully validated ones skipped straight to `after_activity_path`).

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

<!-- begin PR environment info -->
## Preview environment
- Link to demo: http://p-1696-app-dev-1771841445.us-east-1.elb.amazonaws.com/demo
- Deployed commit: a2e41d646b838d7c4dca4f3d95168d9158a5677d
<!-- end PR environment info -->