### PR TITLE
FFS-4012: Add validation error for blank less-than-half-time hours entry

### DIFF
--- a/app/app/controllers/activities/education/term_credit_hours_controller.rb
+++ b/app/app/controllers/activities/education/term_credit_hours_controller.rb
@@ -1,16 +1,19 @@
 class Activities::Education::TermCreditHoursController < Activities::BaseController
   before_action :set_education_activity
   before_action :set_term_credit_hours_vars, only: %i[edit update]
-  before_action :set_back_url, only: %i[edit]
+  before_action :set_back_url, only: %i[edit update]
 
   def edit
   end
 
   def update
-    if params[:no_hours] == "1"
-      @current_term.credit_hours = 0
-    else
-      @current_term.credit_hours = term_credit_hours_params[:credit_hours].to_i
+    assign_term_credit_hours_submission_values
+
+    if !valid_term_credit_hours_submission?
+      @error = true
+      add_term_credit_hours_submission_errors
+      render :edit, status: :unprocessable_content
+      return
     end
 
     @current_term.save!
@@ -36,6 +39,30 @@ class Activities::Education::TermCreditHoursController < Activities::BaseControl
   end
 
   private
+
+  def assign_term_credit_hours_submission_values
+    if params[:no_hours] == "1"
+      @current_term.credit_hours = 0
+    else
+      @current_term.credit_hours = term_credit_hours_params[:credit_hours].to_i
+    end
+  end
+
+  def valid_term_credit_hours_submission?
+    hours = @current_term.credit_hours.to_i
+
+    if @terms.length == 1
+      hours > 0
+    elsif params[:from_review].present? || @term_index == @terms.length - 1
+      @terms.sum { |term| term.id == @current_term.id ? hours : term.credit_hours.to_i } > 0
+    else
+      true
+    end
+  end
+
+  def add_term_credit_hours_submission_errors
+    @current_term.errors.add(:credit_hours, I18n.t("activities.education.term_credit_hours.field_error"))
+  end
 
   def set_education_activity
     @education_activity = @flow.education_activities.find(params[:education_id])

--- a/app/app/views/activities/education/term_credit_hours/edit.html.erb
+++ b/app/app/views/activities/education/term_credit_hours/edit.html.erb
@@ -29,6 +29,12 @@
   <%= t("activities.education.term_credit_hours.body_conversion") %>
 </p>
 
+<% if @error %>
+  <%= render Uswds::Alert.new(type: :error, heading: t("activities.education.term_credit_hours.error_heading"), class: "margin-bottom-4") do %>
+    <%= t("activities.education.term_credit_hours.error_body_multi_month") %>
+  <% end %>
+<% end %>
+
 <%= uswds_form_with(model: @current_term,
       url: activities_flow_education_term_credit_hour_path(
         education_id: @education_activity,

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -238,6 +238,9 @@ en:
         body_conversion: We will convert these credit hours into your community engagement progress.
         body_html: Enter the number of credit hours you were taking in the term from %{term_begin} to %{term_end}.
         continue: Continue
+        error_body_multi_month: You need to add credit hours for at least one month to continue.
+        error_heading: No hours entered
+        field_error: Add hours for at least one month
         heading: Add your credit hours for %{school_name}
         hours_label: Term credit hours
         no_hours_checkbox: I didn't take any classes at %{school_name} this term

--- a/app/spec/controllers/activities/education/term_credit_hours_controller_spec.rb
+++ b/app/spec/controllers/activities/education/term_credit_hours_controller_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
       expect(less_than_half_time_term.reload.credit_hours).to eq(4)
     end
 
-    it "saves 0 when no_hours checkbox is selected" do
+    it "renders an error when no credit hours are entered for a single term" do
       patch :update, params: {
         education_id: education_activity.id,
         id: 0,
@@ -226,7 +226,22 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
         nsc_enrollment_term: { credit_hours: "" }
       }
 
-      expect(less_than_half_time_term.reload.credit_hours).to eq(0)
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(I18n.t("activities.education.term_credit_hours.error_heading"))
+      expect(response.body).to include(I18n.t("activities.education.term_credit_hours.error_body_multi_month"))
+      expect(response.body).to include(I18n.t("activities.education.term_credit_hours.field_error"))
+      expect(less_than_half_time_term.reload.credit_hours).to be_nil
+    end
+
+    it "renders an error when 0 credit hours are entered for a single term" do
+      patch :update, params: {
+        education_id: education_activity.id,
+        id: 0,
+        nsc_enrollment_term: { credit_hours: 0 }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(less_than_half_time_term.reload.credit_hours).to be_nil
     end
 
     it "redirects to document upload on the final term" do
@@ -242,6 +257,15 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
     end
 
     context "with multiple terms" do
+      let(:second_less_than_half_time_term) {
+        range = activity_flow.reporting_window_range
+
+        create(:nsc_enrollment_term, :less_than_half_time,
+          education_activity: education_activity,
+          school_name: "State University",
+          term_begin: range.begin + 3.months,
+          term_end: range.end)
+      }
       let(:activity_flow) {
         create(
           :activity_flow,
@@ -253,12 +277,7 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
       }
 
       before do
-        range = activity_flow.reporting_window_range
-        create(:nsc_enrollment_term, :less_than_half_time,
-          education_activity: education_activity,
-          school_name: "State University",
-          term_begin: range.begin + 3.months,
-          term_end: range.end)
+        second_less_than_half_time_term
       end
 
       it "redirects to the next term when not the last term" do
@@ -275,6 +294,22 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
         )
       end
 
+      it "saves 0 when no_hours checkbox is selected before the final term" do
+        patch :update, params: {
+          education_id: education_activity.id,
+          id: 0,
+          no_hours: "1",
+          nsc_enrollment_term: { credit_hours: "" }
+        }
+
+        expect(response).to redirect_to(
+          edit_activities_flow_education_term_credit_hour_path(
+            education_id: education_activity, id: 1
+          )
+        )
+        expect(less_than_half_time_term.reload.credit_hours).to eq(0)
+      end
+
       it "redirects to document upload on the final term" do
         patch :update, params: {
           education_id: education_activity.id,
@@ -285,6 +320,39 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
         expect(response).to redirect_to(
           new_activities_flow_education_document_upload_path(education_id: education_activity)
         )
+      end
+
+      it "renders an error on the final term when all terms have 0 credit hours" do
+        less_than_half_time_term.update!(credit_hours: 0)
+
+        patch :update, params: {
+          education_id: education_activity.id,
+          id: 1,
+          no_hours: "1",
+          nsc_enrollment_term: { credit_hours: "" }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include(I18n.t("activities.education.term_credit_hours.error_heading"))
+        expect(response.body).to include(I18n.t("activities.education.term_credit_hours.error_body_multi_month"))
+        expect(response.body).to include(I18n.t("activities.education.term_credit_hours.field_error"))
+        expect(second_less_than_half_time_term.reload.credit_hours).to be_nil
+      end
+
+      it "redirects to document upload on the final term when a previous term has credit hours" do
+        less_than_half_time_term.update!(credit_hours: 4)
+
+        patch :update, params: {
+          education_id: education_activity.id,
+          id: 1,
+          no_hours: "1",
+          nsc_enrollment_term: { credit_hours: "" }
+        }
+
+        expect(response).to redirect_to(
+          new_activities_flow_education_document_upload_path(education_id: education_activity)
+        )
+        expect(second_less_than_half_time_term.reload.credit_hours).to eq(0)
       end
     end
 
@@ -313,6 +381,20 @@ RSpec.describe Activities::Education::TermCreditHoursController, type: :controll
       expect(response).to redirect_to(
         review_activities_flow_education_path(id: education_activity, from_edit: 1)
       )
+    end
+
+    it "renders an error when from_review edit leaves all terms with 0 credit hours" do
+      patch :update, params: {
+        education_id: education_activity.id,
+        id: 0,
+        from_review: 1,
+        no_hours: "1",
+        nsc_enrollment_term: { credit_hours: "" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(I18n.t("activities.education.term_credit_hours.error_heading"))
+      expect(less_than_half_time_term.reload.credit_hours).to be_nil
     end
   end
 


### PR DESCRIPTION
<!-- ---------------------------------------------------------------------------
Some examples of good, understandable PR titles:

FFS-1111: Fix missing translation on /entry page
FFS-2222: Implement invitation reminder emails

(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
--------------------------------------------------------------------------- -->
## [FFS-4012](https://jiraent.cms.gov/browse/FFS-4012)

## Changes
<!-- What was added, updated, or removed in this PR. -->
**FFS-4012: Add validation error for blank less-than-half-time hours entry**
> When the user has a partially self-attested education activity, we
> previously permitted them to answer "0" for all terms.

> This commit duplicates the validation logic in the shared hours input
> controller/partial into the Education::TermCreditHoursController so that
> we can validate that at least some credit hours have been reported.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<!-- begin PR environment info -->
## Preview environment
♻️ Environment destroyed ♻️
<!-- end PR environment info -->