### PR TITLE
Fix PR environment DB access

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -178,8 +178,9 @@ RUN apt-get update -qq && \
         && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Install custom db migrate script
+# Install custom database scripts
 COPY bin/db-migrate /usr/bin/
+COPY bin/db-drop-schema /usr/bin/
 
 # Copy built artifacts: gems, application, binary dependencies
 COPY --from=release-build /usr/local/bundle /usr/local/bundle

--- a/app/bin/db-migrate
+++ b/app/bin/db-migrate
@@ -5,6 +5,7 @@ echo "  DB_PORT=$DB_PORT"
 echo "  DB_USER=$DB_USER"
 echo "  DB_NAME=$DB_NAME"
 echo "  DB_SCHEMA=$DB_SCHEMA"
+echo "  APP_USER=$APP_USER"
 
 if [ -n "$DB_SCHEMA" ] && [ "$DB_SCHEMA" != "public" ] && [ "$DB_SCHEMA" != "app" ]; then
   echo "Creating schema $DB_SCHEMA if it doesn't exist..."
@@ -12,3 +13,8 @@ if [ -n "$DB_SCHEMA" ] && [ "$DB_SCHEMA" != "public" ] && [ "$DB_SCHEMA" != "app
 fi
 
 ./bin/rake --trace db:migrate
+
+if [ -n "$DB_SCHEMA" ] && [ "$DB_SCHEMA" != "public" ] && [ "$DB_SCHEMA" != "app" ] && [ -n "$APP_USER" ]; then
+  echo "Granting app user '$APP_USER' privileges on $DB_SCHEMA..."
+  ./bin/rake db:grant_app_access
+fi

--- a/app/config/application.rb
+++ b/app/config/application.rb
@@ -62,8 +62,8 @@ module IvCbvPayroll
         ENV["DOMAIN_NAME"] == "verify-demo.navapbc.cloud" ||
         # "Demo" deployed environment
         ENV["DOMAIN_NAME"] == "demo.reportmyincome.org" ||
-        # PR review apps
-        ENV["DOMAIN_NAME"].match?(/^p-\d+-app-dev/)
+        # PR review apps (e.g. p-1709.navapbc.cloud)
+        ENV["DOMAIN_NAME"].match?(/\Ap-\d+\.navapbc\.cloud\z/)
       )
     )
 

--- a/app/config/initializers/pr_environment_webhooks.rb
+++ b/app/config/initializers/pr_environment_webhooks.rb
@@ -1,0 +1,41 @@
+# Register Pinwheel/Argyle webhook subscriptions for per-PR review apps.
+#
+# Each PR environment has its own database schema (see PR #1440), so webhooks
+# sent to dev/demo (where subscriptions are registered globally) would not
+# reach PR-env-created CbvFlow records. Without a dedicated subscription,
+# `Cbv::SynchronizationsController` hangs forever waiting for
+# `payroll_account.has_fully_synced?` to flip.
+#
+# Mirrors `ngrok_development.rb` but for production-mode containers running
+# on PR review apps. Teardown happens via `rake pr_webhooks:destroy`, invoked
+# by `bin/destroy-pr-environment`.
+Rails.application.config.to_prepare do
+  Rails.application.config.pr_env_webhooks_initialization_error = nil
+
+  domain = ENV["DOMAIN_NAME"]
+  pr_match = domain&.match(/\Ap-(\d+)-app-dev/)
+
+  if Rails.env.production? && pr_match && defined?(::Rails::Server)
+    begin
+      pr_number = pr_match[1]
+      receiver_base_url = "https://#{domain}"
+      subscription_name = "pr-#{pr_number}"
+
+      Rails.logger.info "Registering webhooks for PR environment ##{pr_number} at #{receiver_base_url}"
+
+      if Rails.application.config.supported_providers.include?(:pinwheel)
+        PinwheelWebhookManager.new
+          .create_subscription_if_necessary(receiver_base_url, subscription_name)
+      end
+
+      if Rails.application.config.supported_providers.include?(:argyle)
+        ArgyleWebhooksManager.new(logger: Rails.logger)
+          .create_subscriptions_if_necessary(receiver_base_url, subscription_name)
+      end
+    rescue => ex
+      Rails.application.config.pr_env_webhooks_initialization_error = ex.message
+      Rails.logger.error "🟥 Unable to configure webhooks for PR environment: #{ex}"
+      Rails.logger.error "🟥   in #{ex.backtrace.first}"
+    end
+  end
+end

--- a/app/config/initializers/pr_environment_webhooks.rb
+++ b/app/config/initializers/pr_environment_webhooks.rb
@@ -13,7 +13,7 @@ Rails.application.config.to_prepare do
   Rails.application.config.pr_env_webhooks_initialization_error = nil
 
   domain = ENV["DOMAIN_NAME"]
-  pr_match = domain&.match(/\Ap-(\d+)-app-dev/)
+  pr_match = domain&.match(/\Ap-(\d+)\.navapbc\.cloud\z/)
 
   if Rails.env.production? && pr_match && defined?(::Rails::Server)
     begin

--- a/app/config/puma.rb
+++ b/app/config/puma.rb
@@ -41,3 +41,7 @@ preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+# Run Solid Queue inside Puma on environments that lack a dedicated worker
+# (per-PR review apps, where `aws_ecs_service.solid_queue` has count=0).
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] == "true"

--- a/app/lib/tasks/pr_webhooks.rake
+++ b/app/lib/tasks/pr_webhooks.rake
@@ -1,0 +1,32 @@
+namespace :pr_webhooks do
+  desc "Remove Pinwheel/Argyle webhook subscriptions for a PR environment"
+  task destroy: :environment do
+    pr_number = ENV["PR_NUMBER"]
+    abort("PR_NUMBER must be set") if pr_number.blank?
+
+    subscription_name = "pr-#{pr_number}"
+
+    if Rails.application.config.supported_providers.include?(:pinwheel)
+      manager = PinwheelWebhookManager.new
+      subs = manager.existing_subscriptions(subscription_name)
+      manager.remove_subscriptions(subs)
+      Rails.logger.info "Removed #{subs.size} Pinwheel webhook subscription(s) for #{subscription_name}"
+    end
+
+    if Rails.application.config.supported_providers.include?(:argyle)
+      manager = ArgyleWebhooksManager.new(logger: Rails.logger)
+      # ArgyleWebhooksManager#create_subscriptions_if_necessary creates 4
+      # subscriptions per name (one base + 3 partial/include-resource variants).
+      [
+        subscription_name,
+        "#{subscription_name}-partial",
+        "#{subscription_name}-partial-six-months",
+        "#{subscription_name}-include-resource"
+      ].each do |name|
+        subs = manager.existing_subscriptions_with_name(name)
+        manager.remove_subscriptions(subs)
+        Rails.logger.info "Removed #{subs.size} Argyle webhook subscription(s) for #{name}"
+      end
+    end
+  end
+end

--- a/app/lib/tasks/schema.rake
+++ b/app/lib/tasks/schema.rake
@@ -20,4 +20,27 @@ namespace :db do
     )
     Rails.logger.info("Schema '#{schema}' dropped.")
   end
+
+  # Per-PR schemas are created by db:create_schema and owned by the migrator
+  # user, so the runtime app user has no access by default. The role_manager
+  # Lambda only configures grants for the env-level schema (e.g. "app"), not
+  # per-PR schemas, so we grant here after migrations have created the tables.
+  desc "Grant the app user privileges on DB_SCHEMA after migrations"
+  task grant_app_access: :environment do
+    schema = ENV["DB_SCHEMA"]
+    app_user = ENV["APP_USER"]
+    abort("DB_SCHEMA must be set to a non-'public' value (got: #{schema.inspect})") if schema.blank? || schema == "public"
+    abort("APP_USER must be set (got: #{app_user.inspect})") if app_user.blank?
+
+    conn = ActiveRecord::Base.connection
+    quoted_schema = conn.quote_column_name(schema)
+    quoted_user = conn.quote_column_name(app_user)
+
+    conn.execute("GRANT USAGE ON SCHEMA #{quoted_schema} TO #{quoted_user}")
+    conn.execute("GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA #{quoted_schema} TO #{quoted_user}")
+    conn.execute("GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA #{quoted_schema} TO #{quoted_user}")
+    conn.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA #{quoted_schema} GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER ON TABLES TO #{quoted_user}")
+    conn.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA #{quoted_schema} GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO #{quoted_user}")
+    Rails.logger.info("Granted app user '#{app_user}' privileges on schema '#{schema}'.")
+  end
 end

--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -27,6 +27,16 @@ if ! terraform -chdir="infra/${app_name}/service" workspace select "${workspace}
   exit 0
 fi
 
+echo "::group::Remove webhook subscriptions"
+./bin/run-command \
+  --workspace "${workspace}" \
+  --environment-variables "[{\"name\":\"PR_NUMBER\",\"value\":\"${pr_number}\"}]" \
+  "${app_name}" "${environment}" '["bin/rails", "pr_webhooks:destroy"]'
+echo "::endgroup::"
+
+# Re-select workspace after run-command reinitializes terraform
+terraform -chdir="infra/${app_name}/service" workspace select "${workspace}"
+
 echo "::group::Drop PR database schema"
 terraform -chdir="infra/${app_name}/app-config" init > /dev/null
 terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null

--- a/bin/run-database-migrations
+++ b/bin/run-database-migrations
@@ -54,6 +54,7 @@ if [ "${has_database}" = "false" ]; then
 fi
 
 db_migrator_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.migrator_username")
+db_app_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.app_username")
 
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
 
@@ -91,7 +92,8 @@ command='["db-migrate"]'
 
 # Indent the later lines more to make the output of run-command prettier
 environment_variables=$(cat << EOF
-[{ "name" : "DB_USER", "value" : "${db_migrator_user}" }]
+[{ "name" : "DB_USER", "value" : "${db_migrator_user}" },
+                        { "name" : "APP_USER", "value" : "${db_app_user}" }]
 EOF
 )
 

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -43,6 +43,23 @@ echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 
 service_endpoint="$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)"
+
+# Wait for DNS propagation + HTTPS readiness before declaring the env ready.
+# The PR subdomain is a freshly-created Route53 alias under the wildcard cert;
+# until it resolves and the ALB serves /health, Pinwheel webhook delivery and
+# user requests will fail. Bound to 5 minutes to avoid hanging CI indefinitely.
+echo "::group::Wait for ${service_endpoint} to become reachable"
+deadline=$(($(date +%s) + 300))
+until curl --silent --show-error --fail --max-time 5 "${service_endpoint}/health" > /dev/null; do
+  if [ "$(date +%s)" -gt "${deadline}" ]; then
+    echo "Timed out waiting for ${service_endpoint}/health"
+    exit 1
+  fi
+  echo "  ${service_endpoint}/health not ready yet, retrying in 10s..."
+  sleep 10
+done
+echo "${service_endpoint}/health is responding 200"
+echo "::endgroup::"
 pr_info=$(cat <<EOF
 <!-- begin PR environment info -->
 ## Preview environment

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -181,6 +181,11 @@ module "service" {
   certificate_arn    = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
   additional_domains = local.service_config.additional_domains
 
+  # PR review apps need a hostname covered by the env-level wildcard cert so
+  # external webhooks (Pinwheel/Argyle) can deliver over HTTPS. The cert SAN
+  # `*.navapbc.cloud` covers single-label subdomains like `p-1709`.
+  pr_subdomain = local.is_temporary ? "${terraform.workspace}.navapbc.cloud" : null
+
   cpu                               = local.service_config.cpu
   memory                            = local.service_config.memory
   desired_instance_count            = local.is_temporary ? 1 : local.service_config.desired_instance_count

--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -26,3 +26,21 @@ resource "aws_route53_record" "additional_domains" {
     evaluate_target_health = true
   }
 }
+
+# Per-PR subdomain (e.g. p-1709.navapbc.cloud) aliased to the PR env's ALB so
+# external callers that strictly verify TLS (Pinwheel/Argyle webhook senders)
+# can reach the PR env via a hostname the wildcard ACM cert covers. The dev
+# env's wildcard A-record for `*.navapbc.cloud` still resolves all other
+# subdomains; this specific record takes precedence for its label.
+resource "aws_route53_record" "pr_subdomain" {
+  count = var.pr_subdomain != null ? 1 : 0
+
+  name    = var.pr_subdomain
+  zone_id = var.hosted_zone_id
+  type    = "A"
+  alias {
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -10,13 +10,18 @@ locals {
   task_executor_role_name = "${var.service_name}-task-executor"
   image_url               = "${var.image_repository_url}:${var.image_tag}"
 
-  base_environment_variables = [
-    { name : "DOMAIN_NAME", value : var.is_temporary ? aws_lb.alb.dns_name : tostring(var.domain_name) },
-    { name : "PORT", value : tostring(var.container_port) },
-    { name : "AWS_DEFAULT_REGION", value : data.aws_region.current.name },
-    { name : "AWS_REGION", value : data.aws_region.current.name },
-    { name : "IMAGE_TAG", value : var.image_tag },
-  ]
+  base_environment_variables = concat(
+    [
+      { name : "DOMAIN_NAME", value : var.is_temporary ? aws_lb.alb.dns_name : tostring(var.domain_name) },
+      { name : "PORT", value : tostring(var.container_port) },
+      { name : "AWS_DEFAULT_REGION", value : data.aws_region.current.name },
+      { name : "AWS_REGION", value : data.aws_region.current.name },
+      { name : "IMAGE_TAG", value : var.image_tag },
+    ],
+    # PR review apps don't run the dedicated solid_queue ECS service
+    # (see async_workers.tf), so run the supervisor inside Puma instead.
+    var.is_temporary ? [{ name : "SOLID_QUEUE_IN_PUMA", value : "true" }] : [],
+  )
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },
     { name : "DB_PORT", value : var.db_vars.connection_info.port },

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -10,9 +10,16 @@ locals {
   task_executor_role_name = "${var.service_name}-task-executor"
   image_url               = "${var.image_repository_url}:${var.image_tag}"
 
+  # PR review apps use a per-PR subdomain under the wildcard cert
+  # (see dns.tf#pr_subdomain) so HTTPS-validating callers can reach them.
+  effective_domain_name = coalesce(
+    var.pr_subdomain,
+    var.is_temporary ? aws_lb.alb.dns_name : tostring(var.domain_name),
+  )
+
   base_environment_variables = concat(
     [
-      { name : "DOMAIN_NAME", value : var.is_temporary ? aws_lb.alb.dns_name : tostring(var.domain_name) },
+      { name : "DOMAIN_NAME", value : local.effective_domain_name },
       { name : "PORT", value : tostring(var.container_port) },
       { name : "AWS_DEFAULT_REGION", value : data.aws_region.current.name },
       { name : "AWS_REGION", value : data.aws_region.current.name },

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -22,5 +22,5 @@ output "migrator_role_arn" {
 
 output "public_endpoint" {
   description = "The public endpoint for the service."
-  value       = "http://${aws_lb.alb.dns_name}"
+  value       = var.pr_subdomain != null ? "https://${var.pr_subdomain}" : "http://${aws_lb.alb.dns_name}"
 }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -141,6 +141,12 @@ variable "memory" {
   description = "Amount (in MiB) of memory used by the task. e.g. 2048"
 }
 
+variable "pr_subdomain" {
+  description = "For PR review apps: a per-PR hostname (e.g. p-1709.navapbc.cloud) covered by the env-level ACM cert. When set, a Route53 alias to the PR ALB is created and used as DOMAIN_NAME so HTTPS-validating callers (Pinwheel/Argyle webhooks) can reach the PR env."
+  type        = string
+  default     = null
+}
+
 variable "private_subnet_ids" {
   type        = list(any)
   description = "Private subnet ids in VPC"


### PR DESCRIPTION
## [FFS-XXXX](https://jiraent.cms.gov/browse/FFS-XXXX)

## Changes
- **DB access on PR envs**: add `db:grant_app_access` rake task and wire it into `db-migrate` to grant runtime app-user privileges on per-PR schemas (the `role_manager` Lambda only covers env-level schemas).
- **Background jobs on PR envs**: run Solid Queue inside Puma when `SOLID_QUEUE_IN_PUMA=true` (set automatically on temporary envs in Terraform). PR envs don't get a dedicated `solid_queue` ECS service, so jobs queued by web requests (e.g. `NscSynchronizationJob` from the Education flow) had nothing draining them.
- **Webhook delivery to PR envs**:
  - New `WebhookRegistrar` extracted from the existing ngrok-development setup; new `pr_environment_webhooks.rb` initializer registers Pinwheel/Argyle subscriptions under the name `pr-<pr_number>` on PR-env web boot.
  - New `pr_webhooks:destroy` rake task and wired into `bin/destroy-pr-environment` to clean up subscriptions on PR close.
- **HTTPS reachability for PR envs**: introduce a `pr_subdomain` module variable (`p-<pr_number>.navapbc.cloud`) covered by the existing `*.navapbc.cloud` wildcard cert. Route53 alias to the PR ALB; `DOMAIN_NAME` env var and `service_endpoint` output now resolve to the HTTPS subdomain. Without this, Pinwheel/Argyle webhook delivery fails TLS validation against the ELB DNS hostname.
- **Deploy gate**: `bin/update-pr-environment` polls `${service_endpoint}/health` until 200 (5 min deadline) before declaring the env ready, so DNS propagation and HTTPS readiness are confirmed before the PR description is updated.

## Context for reviewers
Merging #1440 split each PR environment into its own database schema (`p_<pr_number>`). Three subsystems were silently relying on PR envs sharing the `app` schema with dev/demo:

| Subsystem | How it worked before #1440 | How it broke |
|---|---|---|
| DB permissions | `role_manager` Lambda granted on env-level schemas; PR envs used the shared `app` schema and inherited grants | New per-PR schemas had no grants; app user couldn't query |
| Background jobs | PR enqueued into `app.solid_queue_jobs`; dev/demo's worker drained it | PR now writes `p_N.solid_queue_jobs`; no worker polls that schema |
| Webhook events | Pinwheel sent webhooks to dev's URL; demo's webhook controller updated `app.cbv_flows` (where PR's rows lived) | PR's `cbv_flows` row lives in `p_N`; demo's handler queries `app.*`, finds nothing |

Each subsystem is fixed inside the PR env now instead of relying on demo. The HTTPS subdomain change is required for Pinwheel/Argyle to accept the webhook delivery target.

## Acceptance testing
- [x] Acceptance testing in PR Environment
  * Verified end-to-end against this PR's own environment: open https://p-1709.navapbc.cloud/demo, launch with the **Rick Banas** tokenized link, add an **Education** activity (NSC sync flow), then a **Pinwheel** connection in the income flow. Both should advance past the "We're gathering details…" loading page within seconds instead of hanging.

## Infrastructure Changes
- [x] Plan reviewed

Plan reviewed, no apply needed — changes are no-ops for dev (gated on is_temporary)