### PR TITLE
FFS-4319: Pre-populate employment data

### DIFF
--- a/app/app/assets/stylesheets/demo-launcher.scss
+++ b/app/app/assets/stylesheets/demo-launcher.scss
@@ -225,4 +225,54 @@
       display: none;
     }
   }
+
+  // -- Pre-populated activities accordion --
+  .demo-launcher__activity-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border: 1px solid color("base-lighter");
+    border-radius: radius("md");
+    overflow: hidden;
+  }
+
+  .demo-launcher__activity-row {
+    & + & {
+      border-top: 1px solid color("base-lighter");
+    }
+  }
+
+  .demo-launcher__activity-header {
+    display: flex;
+    align-items: center;
+    padding: units(1) units(1.5);
+    background-color: color("base-lightest");
+
+    .usa-checkbox__input,
+    .usa-checkbox__label {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    .usa-checkbox,
+    .usa-checkbox__label {
+      background: transparent;
+    }
+  }
+
+  .demo-launcher__activity-fields {
+    padding: units(1.5);
+    border-top: 1px solid color("base-lighter");
+
+    &.demo-launcher__activity-fields--hidden {
+      display: none;
+    }
+  }
+
+  .demo-launcher__activity-fields-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: units(1);
+    align-items: end;
+  }
 }

--- a/app/app/controllers/activities/activities_controller.rb
+++ b/app/app/controllers/activities/activities_controller.rb
@@ -12,6 +12,7 @@ class Activities::ActivitiesController < Activities::BaseController
 
     @employment_payroll_accounts = @flow.payroll_accounts.published.order(created_at: :desc).select(&:sync_succeeded?)
     @employment_activities = @flow.employment_activities.published.includes(:employment_activity_months).order(created_at: :desc)
+    @employment_draft_activities = @flow.employment_activities.where(draft: true, data_source: "validated").includes(:employment_activity_months).order(created_at: :desc)
     @persisted_report = PersistedReportAdapter.new(@flow) if @employment_payroll_accounts.any?
   end
 end

--- a/app/app/controllers/activities/activities_controller.rb
+++ b/app/app/controllers/activities/activities_controller.rb
@@ -6,13 +6,13 @@ class Activities::ActivitiesController < Activities::BaseController
     end
 
     @community_service_activities = @flow.volunteering_activities.published.includes(:volunteering_activity_months).order(created_at: :desc)
-    @community_service_draft_activities = @flow.volunteering_activities.where(draft: true, data_source: "validated").includes(:volunteering_activity_months).order(created_at: :desc)
+    @community_service_draft_activities = @flow.volunteering_activities.where(draft: true, data_source: "state_provided").includes(:volunteering_activity_months).order(created_at: :desc)
     @work_programs_activities = @flow.job_training_activities.published.includes(:job_training_activity_months).order(created_at: :desc)
     @education_activities = @flow.education_activities.published.includes(:education_activity_months, :nsc_enrollment_terms).order(created_at: :desc)
 
     @employment_payroll_accounts = @flow.payroll_accounts.published.order(created_at: :desc).select(&:sync_succeeded?)
     @employment_activities = @flow.employment_activities.published.includes(:employment_activity_months).order(created_at: :desc)
-    @employment_draft_activities = @flow.employment_activities.where(draft: true, data_source: "validated").includes(:employment_activity_months).order(created_at: :desc)
+    @employment_draft_activities = @flow.employment_activities.where(draft: true, data_source: "state_provided").includes(:employment_activity_months).order(created_at: :desc)
     @persisted_report = PersistedReportAdapter.new(@flow) if @employment_payroll_accounts.any?
   end
 end

--- a/app/app/controllers/activities/employment_controller.rb
+++ b/app/app/controllers/activities/employment_controller.rb
@@ -94,6 +94,6 @@ class Activities::EmploymentController < Activities::BaseController
   end
 
   def employment_activity_params
-    params.require(:employment_activity).permit(*EmploymentActivity::FIELDS, :is_self_employed)
+    params.require(:employment_activity).permit(*EmploymentActivity::FIELDS)
   end
 end

--- a/app/app/controllers/activities/employment_controller.rb
+++ b/app/app/controllers/activities/employment_controller.rb
@@ -94,10 +94,6 @@ class Activities::EmploymentController < Activities::BaseController
   end
 
   def employment_activity_params
-    params.require(:employment_activity).permit(
-      :employer_name, :street_address, :street_address_line_2,
-      :city, :state, :zip_code,
-      :is_self_employed, :contact_name, :contact_email, :contact_phone_number
-    )
+    params.require(:employment_activity).permit(*EmploymentActivity::FIELDS, :is_self_employed)
   end
 end

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -69,6 +69,7 @@ class Api::InvitationsController < ApplicationController
       entry.permit(
         :type,
         *VolunteeringActivity::FIELDS,
+        *EmploymentActivity::FIELDS,
         months: VolunteeringActivityMonth::FIELDS.map(&:to_sym)
       ).to_h
     end

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -70,7 +70,7 @@ class Api::InvitationsController < ApplicationController
         :type,
         *VolunteeringActivity::FIELDS,
         *EmploymentActivity::FIELDS,
-        months: VolunteeringActivityMonth::FIELDS.map(&:to_sym)
+        months: (VolunteeringActivityMonth::FIELDS | EmploymentActivityMonth::FIELDS).map(&:to_sym)
       ).to_h
     end
   end

--- a/app/app/controllers/demo_launcher_controller.rb
+++ b/app/app/controllers/demo_launcher_controller.rb
@@ -128,6 +128,45 @@ class DemoLauncherController < ApplicationController
     end
   end
 
+  def build_pre_populated_activities
+    activities = []
+    month_strings = reporting_window_months_for_activities(launcher_params[:client_agency_id])
+
+    if launcher_params[:volunteering_enabled] == "1"
+      hours = launcher_params[:volunteering_hours_per_month].to_i
+      activities << {
+        "type" => "volunteering",
+        "organization_name" => launcher_params[:volunteering_organization_name].presence || "Red Cross",
+        "months" => month_strings.map { |m| { "month" => m, "hours" => hours } }
+      }
+    end
+
+    if launcher_params[:employment_enabled] == "1"
+      hours = launcher_params[:employment_hours_per_month].to_i
+      gross_income = launcher_params[:employment_gross_income_per_month].to_i
+      activities << {
+        "type" => "employment",
+        "employer_name" => launcher_params[:employment_employer_name].presence || "Acme Corp",
+        "months" => month_strings.map { |m| { "month" => m, "hours" => hours, "gross_income" => gross_income } }
+      }
+    end
+
+    activities
+  end
+
+  def reporting_window_months_for_activities(client_agency_id)
+    # Uses the agency's default application window regardless of the launcher's reporting_window
+    # setting, because ActivityFlowInvitation validates months against the same default range.
+    range = ActivityFlow.expected_reporting_window_range(client_agency_id)
+    months = []
+    current = range.begin.beginning_of_month
+    while current <= range.end
+      months << current.strftime("%Y-%m-%d")
+      current = current.next_month
+    end
+    months
+  end
+
   def launch_overrides(flow_type)
     overrides = if flow_type == "cbv"
                   launcher_params.slice(:demo_timeout).select { |_, v| v.present? }
@@ -154,7 +193,14 @@ class DemoLauncherController < ApplicationController
       :renewal_required_months,
       :reporting_window_start,
       :demo_timeout,
-      :launch_type
+      :launch_type,
+      :volunteering_enabled,
+      :volunteering_organization_name,
+      :volunteering_hours_per_month,
+      :employment_enabled,
+      :employment_employer_name,
+      :employment_hours_per_month,
+      :employment_gross_income_per_month
     )
   end
 
@@ -207,9 +253,11 @@ class DemoLauncherController < ApplicationController
   end
 
   def build_tokenized_url(client_agency_id, overrides)
+    pre_populated = build_pre_populated_activities
     invitation = ActivityFlowInvitation.create!(
       client_agency_id: client_agency_id,
-      reference_id: "demo-#{SecureRandom.hex(4)}"
+      reference_id: "demo-#{SecureRandom.hex(4)}",
+      pre_populated_activities: pre_populated
     )
     invitation.to_url(
       **launcher_url_options,

--- a/app/app/helpers/activities_helper.rb
+++ b/app/app/helpers/activities_helper.rb
@@ -111,9 +111,18 @@ module ActivitiesHelper
 
   def employment_activity_draft_cards(activities)
     activities.map do |activity|
+      months = activity.employment_activity_months.sort_by(&:month).filter_map do |month|
+        next unless month.gross_income.positive? || month.hours.positive?
+
+        {
+          month: month.month,
+          gross_earnings: month.gross_income * 100,
+          hours: activity_card_hours(month.hours)
+        }
+      end
       {
         name: activity.employer_name,
-        months: [],
+        months: months,
         edit_path: edit_activities_flow_income_employment_path(id: activity.id),
         pre_populated: true
       }

--- a/app/app/helpers/activities_helper.rb
+++ b/app/app/helpers/activities_helper.rb
@@ -109,6 +109,17 @@ module ActivitiesHelper
     end
   end
 
+  def employment_activity_draft_cards(activities)
+    activities.map do |activity|
+      {
+        name: activity.employer_name,
+        months: [],
+        edit_path: edit_activities_flow_income_employment_path(id: activity.id),
+        pre_populated: true
+      }
+    end
+  end
+
   def community_service_draft_cards(activities)
     activities.map do |activity|
       months = activity.volunteering_activity_months.sort_by(&:month).filter_map do |activity_month|

--- a/app/app/javascript/controllers/demo_launcher_controller.js
+++ b/app/app/javascript/controllers/demo_launcher_controller.js
@@ -57,6 +57,16 @@ export default class extends Controller {
     this.highlightButton(months)
   }
 
+  toggleActivity(event) {
+    const checkbox = event.currentTarget
+    const fields = checkbox
+      .closest(".demo-launcher__activity-row")
+      .querySelector(".demo-launcher__activity-fields")
+    if (fields) {
+      fields.classList.toggle("demo-launcher__activity-fields--hidden", !checkbox.checked)
+    }
+  }
+
   invalidateShareLink(event) {
     if (event.target === this.generatedUrlTarget) return
 

--- a/app/app/models/activity.rb
+++ b/app/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
 
   belongs_to :activity_flow
 
-  enum :data_source, { self_attested: "self_attested", validated: "validated" }, default: :self_attested
+  enum :data_source, { self_attested: "self_attested", validated: "validated", state_provided: "state_provided" }, default: :self_attested
 
   scope :published, -> { where(draft: false) }
 

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -49,9 +49,8 @@ class ActivityFlow < Flow
         next unless activity.persisted?
 
         Array(attrs["months"]).each do |month_entry|
-          next unless month_entry.is_a?(Hash) || month_entry.respond_to?(:to_h)
-          month_attrs = month_entry.respond_to?(:stringify_keys) ? month_entry.stringify_keys : month_entry.to_h.stringify_keys
-          activity.volunteering_activity_months.create(month_attrs.slice(*VolunteeringActivityMonth::FIELDS))
+          next unless month_entry.is_a?(Hash)
+          activity.volunteering_activity_months.create(month_entry.stringify_keys.slice(*VolunteeringActivityMonth::FIELDS))
         end
       when "employment"
         next if flow.employment_activities.exists?
@@ -63,9 +62,8 @@ class ActivityFlow < Flow
         next unless activity.persisted?
 
         Array(attrs["months"]).each do |month_entry|
-          next unless month_entry.is_a?(Hash) || month_entry.respond_to?(:to_h)
-          month_attrs = month_entry.respond_to?(:stringify_keys) ? month_entry.stringify_keys : month_entry.to_h.stringify_keys
-          activity.employment_activity_months.create(month_attrs.slice(*EmploymentActivityMonth::FIELDS))
+          next unless month_entry.is_a?(Hash)
+          activity.employment_activity_months.create(month_entry.stringify_keys.slice(*EmploymentActivityMonth::FIELDS))
         end
       end
     end

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -56,10 +56,17 @@ class ActivityFlow < Flow
       when "employment"
         next if flow.employment_activities.exists?
 
-        flow.employment_activities.create(
+        activity = flow.employment_activities.create(
           attrs.slice(*EmploymentActivity::FIELDS)
             .merge("draft" => true, "data_source" => "validated")
         )
+        next unless activity.persisted?
+
+        Array(attrs["months"]).each do |month_entry|
+          next unless month_entry.is_a?(Hash) || month_entry.respond_to?(:to_h)
+          month_attrs = month_entry.respond_to?(:stringify_keys) ? month_entry.stringify_keys : month_entry.to_h.stringify_keys
+          activity.employment_activity_months.create(month_attrs.slice(*EmploymentActivityMonth::FIELDS))
+        end
       end
     end
   end

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -35,12 +35,13 @@ class ActivityFlow < Flow
     entries = invitation.pre_populated_activities
     return unless entries.is_a?(Array)
     return if entries.empty?
-    return if flow.volunteering_activities.exists?
 
     entries.each do |entry|
       attrs = entry.respond_to?(:stringify_keys) ? entry.stringify_keys : entry.to_h.stringify_keys
       case attrs["type"].to_s
       when "volunteering"
+        next if flow.volunteering_activities.exists?
+
         activity = flow.volunteering_activities.create(
           attrs.slice(*VolunteeringActivity::FIELDS)
             .merge("draft" => true, "data_source" => "validated")
@@ -52,6 +53,13 @@ class ActivityFlow < Flow
           month_attrs = month_entry.respond_to?(:stringify_keys) ? month_entry.stringify_keys : month_entry.to_h.stringify_keys
           activity.volunteering_activity_months.create(month_attrs.slice(*VolunteeringActivityMonth::FIELDS))
         end
+      when "employment"
+        next if flow.employment_activities.exists?
+
+        flow.employment_activities.create(
+          attrs.slice(*EmploymentActivity::FIELDS)
+            .merge("draft" => true, "data_source" => "validated")
+        )
       end
     end
   end

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -44,7 +44,7 @@ class ActivityFlow < Flow
 
         activity = flow.volunteering_activities.create(
           attrs.slice(*VolunteeringActivity::FIELDS)
-            .merge("draft" => true, "data_source" => "validated")
+            .merge("draft" => true, "data_source" => "state_provided")
         )
         next unless activity.persisted?
 
@@ -58,7 +58,7 @@ class ActivityFlow < Flow
 
         activity = flow.employment_activities.create(
           attrs.slice(*EmploymentActivity::FIELDS)
-            .merge("draft" => true, "data_source" => "validated")
+            .merge("draft" => true, "data_source" => "state_provided")
         )
         next unless activity.persisted?
 

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -39,17 +39,10 @@ class ActivityFlowInvitation < ApplicationRecord
         next
       end
 
-      case type.to_s
-      when "volunteering"
-        organization_name = entry["organization_name"] || entry[:organization_name]
-        if organization_name.blank?
-          errors.add("pre_populated_activities[#{idx}].organization_name", "can't be blank")
-        end
-      when "employment"
-        employer_name = entry["employer_name"] || entry[:employer_name]
-        if employer_name.blank?
-          errors.add("pre_populated_activities[#{idx}].employer_name", "can't be blank")
-        end
+      name_field = { "volunteering" => "organization_name", "employment" => "employer_name" }[type.to_s]
+      name = entry[name_field] || entry[name_field.to_sym]
+      if name.blank?
+        errors.add("pre_populated_activities[#{idx}].#{name_field}", "can't be blank")
       end
     end
   end

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -1,5 +1,6 @@
 class ActivityFlowInvitation < ApplicationRecord
   SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES = %w[volunteering employment].freeze
+  PRE_POPULATED_NAME_FIELDS = { "volunteering" => "organization_name", "employment" => "employer_name" }.freeze
 
   belongs_to :cbv_applicant, optional: true
   has_many :activity_flows
@@ -39,7 +40,7 @@ class ActivityFlowInvitation < ApplicationRecord
         next
       end
 
-      name_field = { "volunteering" => "organization_name", "employment" => "employer_name" }[type.to_s]
+      name_field = PRE_POPULATED_NAME_FIELDS[type.to_s]
       name = entry[name_field] || entry[name_field.to_sym]
       if name.blank?
         errors.add("pre_populated_activities[#{idx}].#{name_field}", "can't be blank")

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -1,5 +1,5 @@
 class ActivityFlowInvitation < ApplicationRecord
-  SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES = %w[volunteering].freeze
+  SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES = %w[volunteering employment].freeze
 
   belongs_to :cbv_applicant, optional: true
   has_many :activity_flows
@@ -39,9 +39,17 @@ class ActivityFlowInvitation < ApplicationRecord
         next
       end
 
-      organization_name = entry["organization_name"] || entry[:organization_name]
-      if organization_name.blank?
-        errors.add("pre_populated_activities[#{idx}].organization_name", "can't be blank")
+      case type.to_s
+      when "volunteering"
+        organization_name = entry["organization_name"] || entry[:organization_name]
+        if organization_name.blank?
+          errors.add("pre_populated_activities[#{idx}].organization_name", "can't be blank")
+        end
+      when "employment"
+        employer_name = entry["employer_name"] || entry[:employer_name]
+        if employer_name.blank?
+          errors.add("pre_populated_activities[#{idx}].employer_name", "can't be blank")
+        end
       end
     end
   end

--- a/app/app/models/employment_activity.rb
+++ b/app/app/models/employment_activity.rb
@@ -4,6 +4,7 @@ class EmploymentActivity < Activity
 
   FIELDS = %w[
     employer_name
+    is_self_employed
     street_address
     street_address_line_2
     city

--- a/app/app/models/employment_activity.rb
+++ b/app/app/models/employment_activity.rb
@@ -2,6 +2,18 @@ class EmploymentActivity < Activity
   include HasActivityMonths
   include DocumentUploadable
 
+  FIELDS = %w[
+    employer_name
+    street_address
+    street_address_line_2
+    city
+    state
+    zip_code
+    contact_name
+    contact_email
+    contact_phone_number
+  ].freeze
+
   has_many :employment_activity_months, dependent: :destroy
   has_activity_months :employment_activity_months
 

--- a/app/app/models/employment_activity_month.rb
+++ b/app/app/models/employment_activity_month.rb
@@ -1,4 +1,6 @@
 class EmploymentActivityMonth < ApplicationRecord
+  FIELDS = %w[month hours gross_income].freeze
+
   belongs_to :employment_activity
 
   validates :month, presence: true

--- a/app/app/services/activity_flow_progress_calculator.rb
+++ b/app/app/services/activity_flow_progress_calculator.rb
@@ -203,7 +203,7 @@ class ActivityFlowProgressCalculator
   end
 
   def validated_volunteering_hours_for_month(month_start)
-    @volunteering_activities.select(&:validated?).sum do |a|
+    @volunteering_activities.select { |a| a.validated? || a.state_provided? }.sum do |a|
       a.volunteering_activity_months
         .where(month: month_start.beginning_of_month)
         .sum(:hours)

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -73,8 +73,11 @@
   </div>
   <div class="activity-hub-columns__activities">
     <% if activity_type_enabled?(:employment) %>
+      <%# i18n-tasks-use t("activities.hub.cards.pre_populated_notice") %>
+      <%# i18n-tasks-use t("activities.hub.cards.complete_action") %>
+      <% employment_draft_card_data = employment_activity_draft_cards(@employment_draft_activities || []) %>
       <% persisted_report = @persisted_report; employment_activities = @employment_activities %>
-      <% employment_card_data = combined_employment_card_data(
+      <% employment_card_data = employment_draft_card_data + combined_employment_card_data(
         reporting_range: @flow.reporting_window_range,
         payroll_accounts: @employment_payroll_accounts,
         persisted_report:,
@@ -89,9 +92,12 @@
         <% employment_card_data.each do |card_data| %>
           <%= render(Uswds::Card.new(heading_text: card_data[:name], heading_level: 3, class: "activity-hub-card")) do |card| %>
             <% card.with_header do %>
-              <%= link_to t("activities.hub.edit"), card_data[:edit_path], class: "usa-link" %>
+              <%= link_to (card_data[:pre_populated] ? t("activities.hub.cards.complete_action") : t("activities.hub.edit")), card_data[:edit_path], class: "usa-link" %>
             <% end %>
             <% card.with_body do %>
+              <% if card_data[:pre_populated] %>
+                <p class="margin-y-0"><%= t("activities.hub.cards.pre_populated_notice") %></p>
+              <% end %>
               <% if card_data[:months].none? %>
                 <div class="margin-top-2">
                   <%= t("activities.hub.cards.no_employment_data") %>

--- a/app/app/views/demo_launcher/advanced.html.erb
+++ b/app/app/views/demo_launcher/advanced.html.erb
@@ -225,6 +225,61 @@
             <span>minutes</span>
           </div>
         <% end %>
+        <div data-demo-launcher-target="ceOnly">
+          <%= render DemoLauncher::SettingComponent.new(title: "Pre-populated activities", hint: "Specify what data should appear automatically when visiting the hub for the first time. This is used to simulate the state sending us the data they have for this applicant. Note that this only works with tokenized links.") do %>
+            <div class="demo-launcher__activity-rows">
+              <div class="demo-launcher__activity-row">
+                <div class="demo-launcher__activity-header">
+                  <div class="usa-checkbox">
+                    <input class="usa-checkbox__input" type="checkbox" id="volunteering_enabled" name="volunteering_enabled" value="1"
+                           data-action="change->demo-launcher#toggleActivity">
+                    <label class="usa-checkbox__label" for="volunteering_enabled">Volunteering</label>
+                  </div>
+                </div>
+                <div class="demo-launcher__activity-fields demo-launcher__activity-fields--hidden">
+                  <div class="demo-launcher__activity-fields-grid">
+                    <div>
+                      <label class="usa-label" for="volunteering_organization_name">Org name</label>
+                      <input class="usa-input" type="text" id="volunteering_organization_name" name="volunteering_organization_name" value="Red Cross" autocomplete="off">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="volunteering_hours_per_month">Hours / month</label>
+                      <input class="usa-input usa-input--sm" type="number" id="volunteering_hours_per_month" name="volunteering_hours_per_month" value="12" min="1" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="demo-launcher__activity-row">
+                <div class="demo-launcher__activity-header">
+                  <div class="usa-checkbox">
+                    <input class="usa-checkbox__input" type="checkbox" id="employment_enabled" name="employment_enabled" value="1"
+                           data-action="change->demo-launcher#toggleActivity">
+                    <label class="usa-checkbox__label" for="employment_enabled">Employment</label>
+                  </div>
+                </div>
+                <div class="demo-launcher__activity-fields demo-launcher__activity-fields--hidden">
+                  <div class="demo-launcher__activity-fields-grid">
+                    <div>
+                      <label class="usa-label" for="employment_employer_name">Employer name</label>
+                      <input class="usa-input" type="text" id="employment_employer_name" name="employment_employer_name" value="Acme Corp" autocomplete="off">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="employment_hours_per_month">Hours / month</label>
+                      <input class="usa-input usa-input--sm" type="number" id="employment_hours_per_month" name="employment_hours_per_month" value="40" min="1" autocomplete="off">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="employment_gross_income_per_month">Gross income / month</label>
+                      <div class="demo-launcher__inline-field">
+                        <span>$</span>
+                        <input class="usa-input usa-input--sm" type="number" id="employment_gross_income_per_month" name="employment_gross_income_per_month" value="1200" min="0" autocomplete="off">
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -145,6 +145,15 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
 
       expect(assigns(:community_service_draft_activities)).to contain_exactly(api_draft)
     end
+
+    it "surfaces only validated employment drafts (API pre-populated), not self-attested user drafts" do
+      api_draft = create(:employment_activity, activity_flow: current_flow, draft: true, data_source: "validated")
+      _user_draft = create(:employment_activity, activity_flow: current_flow, draft: true, data_source: "self_attested")
+
+      get :index
+
+      expect(assigns(:employment_draft_activities)).to contain_exactly(api_draft)
+    end
   end
 
   context "when no activities are added" do
@@ -860,6 +869,32 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
 
       expect(rendered).to have_css("[data-controller='progress-indicator-units']")
       expect(rendered).to have_css("[data-progress-indicator-units-target='toggle']")
+    end
+  end
+
+  context "when a pre-populated employment activity exists" do
+    let(:current_flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
+
+    before do
+      create(:employment_activity, activity_flow: current_flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "assigns the draft employment activity" do
+      expect(assigns(:employment_draft_activities)).not_to be_empty
+      expect(assigns(:employment_draft_activities).first.employer_name).to eq("Acme Corp")
+    end
+
+    it "renders the pre-populated notice on the hub" do
+      expect(response.body).to include(I18n.t("activities.hub.cards.pre_populated_notice"))
+    end
+
+    it "renders the Complete CTA instead of Edit for the draft card" do
+      employment_cards = Nokogiri::HTML.parse(response.body).css("[data-activity-type='employment'] .activity-hub-card")
+      expect(employment_cards.text).to include(I18n.t("activities.hub.cards.complete_action"))
+      expect(employment_cards.text).not_to include(I18n.t("activities.hub.edit"))
     end
   end
 end

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(response.body).to include(I18n.t("activities.hub.review_and_submit"))
     end
 
-    it "surfaces only validated drafts (API pre-populated) on the hub, not self-attested user drafts" do
+    it "surfaces only validated community service drafts (API pre-populated), not self-attested user drafts" do
       api_draft = create(:volunteering_activity, activity_flow: current_flow, draft: true, data_source: "validated")
       _user_draft = create(:volunteering_activity, activity_flow: current_flow, draft: true, data_source: "self_attested")
 

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(response.body).to include(I18n.t("activities.hub.review_and_submit"))
     end
 
-    it "surfaces only validated community service drafts (API pre-populated), not self-attested user drafts" do
-      api_draft = create(:volunteering_activity, activity_flow: current_flow, draft: true, data_source: "validated")
+    it "surfaces only state-provided community service drafts (pre-populated), not self-attested user drafts" do
+      api_draft = create(:volunteering_activity, activity_flow: current_flow, draft: true, data_source: "state_provided")
       _user_draft = create(:volunteering_activity, activity_flow: current_flow, draft: true, data_source: "self_attested")
 
       get :index
@@ -146,8 +146,8 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(assigns(:community_service_draft_activities)).to contain_exactly(api_draft)
     end
 
-    it "surfaces only validated employment drafts (API pre-populated), not self-attested user drafts" do
-      api_draft = create(:employment_activity, activity_flow: current_flow, draft: true, data_source: "validated")
+    it "surfaces only state-provided employment drafts (pre-populated), not self-attested user drafts" do
+      api_draft = create(:employment_activity, activity_flow: current_flow, draft: true, data_source: "state_provided")
       _user_draft = create(:employment_activity, activity_flow: current_flow, draft: true, data_source: "self_attested")
 
       get :index
@@ -876,7 +876,7 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
     let(:current_flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
 
     before do
-      create(:employment_activity, activity_flow: current_flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      create(:employment_activity, activity_flow: current_flow, employer_name: "Acme Corp", draft: true, data_source: "state_provided")
       session[:flow_id] = current_flow.id
       session[:flow_type] = :activity
       get :index

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -295,6 +295,18 @@ RSpec.describe Api::InvitationsController do
         expect(parsed_response["errors"].map { |e| e["field"] })
           .to include("activities[0].employer_name")
       end
+
+      it "returns an error when an employment month falls outside the reporting window" do
+        out_of_window_date = (Date.current + 60.days).iso8601
+        entry_with_bad_month = employment_entry.merge(months: [ { month: out_of_window_date, hours: 40, gross_income: 3000 } ])
+
+        post :create, params: valid_params.merge(activities: [ entry_with_bad_month ])
+
+        expect(response).to have_http_status(:unprocessable_content)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"].map { |e| e["field"] })
+          .to include("activities[0].months[0].month")
+      end
     end
   end
 end

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -256,5 +256,45 @@ RSpec.describe Api::InvitationsController do
         end
       end
     end
+
+    context "with a pre-populated employment activity" do
+      let(:employment_entry) do
+        {
+          type: "employment",
+          employer_name: "Acme Corp",
+          street_address: "123 Main St",
+          city: "Boston",
+          state: "MA",
+          zip_code: "02101",
+          contact_name: "Jane Doe",
+          contact_email: "jane@acme.com",
+          contact_phone_number: "555-0100"
+        }
+      end
+      let(:params_with_employment) { valid_params.merge(activities: [ employment_entry ]) }
+
+      it "mints both invitations and returns activity_tokenized_url" do
+        expect {
+          post :create, params: params_with_employment
+        }.to change(CbvFlowInvitation, :count).by(1)
+          .and change(ActivityFlowInvitation, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to include("tokenized_url", "activity_tokenized_url")
+
+        activity_invitation = ActivityFlowInvitation.last
+        expect(activity_invitation.pre_populated_activities.first["employer_name"]).to eq("Acme Corp")
+      end
+
+      it "returns an error when employer_name is missing" do
+        post :create, params: valid_params.merge(activities: [ employment_entry.except(:employer_name) ])
+
+        expect(response).to have_http_status(:unprocessable_content)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"].map { |e| e["field"] })
+          .to include("activities[0].employer_name")
+      end
+    end
   end
 end

--- a/app/spec/controllers/demo_launcher_controller_spec.rb
+++ b/app/spec/controllers/demo_launcher_controller_spec.rb
@@ -585,44 +585,40 @@ RSpec.describe DemoLauncherController, type: :controller do
       end
 
       it "creates an invitation with an employment activity when employment is enabled" do
-        Timecop.freeze(Date.new(2026, 5, 13)) do
-          expect {
-            post :create, params: {
-              client_agency_id: "sandbox",
-              launch_type: "tokenized",
-              employment_enabled: "1",
-              employment_employer_name: "Globex",
-              employment_hours_per_month: "20",
-              employment_gross_income_per_month: "800"
-            }
-          }.to change(ActivityFlowInvitation, :count).by(1)
-
-          invitation = ActivityFlowInvitation.last
-          activities = invitation.pre_populated_activities
-          expect(activities.length).to eq(1)
-          expect(activities[0]["type"]).to eq("employment")
-          expect(activities[0]["employer_name"]).to eq("Globex")
-          expect(activities[0]["months"]).to all(include("hours" => 20, "gross_income" => 800))
-        end
-      end
-
-      it "creates an invitation with both activity types when both are enabled" do
-        Timecop.freeze(Date.new(2026, 5, 13)) do
+        expect {
           post :create, params: {
             client_agency_id: "sandbox",
             launch_type: "tokenized",
-            volunteering_enabled: "1",
-            volunteering_organization_name: "Red Cross",
-            volunteering_hours_per_month: "12",
             employment_enabled: "1",
-            employment_employer_name: "Acme Corp",
-            employment_hours_per_month: "40",
-            employment_gross_income_per_month: "1200"
+            employment_employer_name: "Globex",
+            employment_hours_per_month: "20",
+            employment_gross_income_per_month: "800"
           }
+        }.to change(ActivityFlowInvitation, :count).by(1)
 
-          activities = ActivityFlowInvitation.last.pre_populated_activities
-          expect(activities.map { |a| a["type"] }).to contain_exactly("volunteering", "employment")
-        end
+        invitation = ActivityFlowInvitation.last
+        activities = invitation.pre_populated_activities
+        expect(activities.length).to eq(1)
+        expect(activities[0]["type"]).to eq("employment")
+        expect(activities[0]["employer_name"]).to eq("Globex")
+        expect(activities[0]["months"]).to all(include("hours" => 20, "gross_income" => 800))
+      end
+
+      it "creates an invitation with both activity types when both are enabled" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "tokenized",
+          volunteering_enabled: "1",
+          volunteering_organization_name: "Red Cross",
+          volunteering_hours_per_month: "12",
+          employment_enabled: "1",
+          employment_employer_name: "Acme Corp",
+          employment_hours_per_month: "40",
+          employment_gross_income_per_month: "1200"
+        }
+
+        activities = ActivityFlowInvitation.last.pre_populated_activities
+        expect(activities.map { |a| a["type"] }).to contain_exactly("volunteering", "employment")
       end
 
       it "creates an invitation with empty pre_populated_activities when neither is enabled" do

--- a/app/spec/controllers/demo_launcher_controller_spec.rb
+++ b/app/spec/controllers/demo_launcher_controller_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe DemoLauncherController, type: :controller do
       expect(rendered).to match(/Sage Testuser/)
       expect(rendered).to match(/Spring carryover for summer months/)
     end
+
+    it "displays the pre-populated activities section for CE flow" do
+      get :advanced
+      rendered = response.body
+      expect(rendered).to include("Pre-populated activities")
+      expect(rendered).to include('name="volunteering_enabled"')
+      expect(rendered).to include('name="volunteering_organization_name"')
+      expect(rendered).to include('name="employment_enabled"')
+      expect(rendered).to include('name="employment_employer_name"')
+      expect(rendered).to include('name="employment_gross_income_per_month"')
+    end
   end
 
   describe "POST #create" do
@@ -547,6 +558,79 @@ RSpec.describe DemoLauncherController, type: :controller do
         expect(invitation.reference_id).to eq("demo-summer_term_carryover_sage")
         expect(response).to redirect_to(%r{/activities/start/#{invitation.auth_token}})
         expect(response.location).to include("reporting_window_start=2025-07-01")
+      end
+    end
+
+    context "with pre-populated activities" do
+      it "creates an invitation with a volunteering activity when volunteering is enabled" do
+        Timecop.freeze(Date.new(2026, 5, 13)) do
+          expect {
+            post :create, params: {
+              client_agency_id: "sandbox",
+              launch_type: "tokenized",
+              volunteering_enabled: "1",
+              volunteering_organization_name: "Food Bank",
+              volunteering_hours_per_month: "8"
+            }
+          }.to change(ActivityFlowInvitation, :count).by(1)
+
+          invitation = ActivityFlowInvitation.last
+          activities = invitation.pre_populated_activities
+          expect(activities.length).to eq(1)
+          expect(activities[0]["type"]).to eq("volunteering")
+          expect(activities[0]["organization_name"]).to eq("Food Bank")
+          expect(activities[0]["months"]).to all(include("hours" => 8))
+          expect(activities[0]["months"].map { |m| m["month"] }).to include("2026-03-01", "2026-04-01")
+        end
+      end
+
+      it "creates an invitation with an employment activity when employment is enabled" do
+        Timecop.freeze(Date.new(2026, 5, 13)) do
+          expect {
+            post :create, params: {
+              client_agency_id: "sandbox",
+              launch_type: "tokenized",
+              employment_enabled: "1",
+              employment_employer_name: "Globex",
+              employment_hours_per_month: "20",
+              employment_gross_income_per_month: "800"
+            }
+          }.to change(ActivityFlowInvitation, :count).by(1)
+
+          invitation = ActivityFlowInvitation.last
+          activities = invitation.pre_populated_activities
+          expect(activities.length).to eq(1)
+          expect(activities[0]["type"]).to eq("employment")
+          expect(activities[0]["employer_name"]).to eq("Globex")
+          expect(activities[0]["months"]).to all(include("hours" => 20, "gross_income" => 800))
+        end
+      end
+
+      it "creates an invitation with both activity types when both are enabled" do
+        Timecop.freeze(Date.new(2026, 5, 13)) do
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "tokenized",
+            volunteering_enabled: "1",
+            volunteering_organization_name: "Red Cross",
+            volunteering_hours_per_month: "12",
+            employment_enabled: "1",
+            employment_employer_name: "Acme Corp",
+            employment_hours_per_month: "40",
+            employment_gross_income_per_month: "1200"
+          }
+
+          activities = ActivityFlowInvitation.last.pre_populated_activities
+          expect(activities.map { |a| a["type"] }).to contain_exactly("volunteering", "employment")
+        end
+      end
+
+      it "creates an invitation with empty pre_populated_activities when neither is enabled" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "tokenized"
+        }
+        expect(ActivityFlowInvitation.last.pre_populated_activities).to eq([])
       end
     end
 

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe ActivitiesHelper do
     let(:flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
 
     it "returns a card with pre_populated: true and edit path pointing to employment edit page" do
-      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "state_provided")
 
       result = helper.employment_activity_draft_cards([ activity ])
 
@@ -164,7 +164,7 @@ RSpec.describe ActivitiesHelper do
     end
 
     it "includes month data when employment_activity_months have hours or gross_income" do
-      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "state_provided")
       first_month = flow.reporting_months.first.beginning_of_month
       create(:employment_activity_month, employment_activity: activity, month: first_month, hours: 20, gross_income: 500)
 
@@ -176,7 +176,7 @@ RSpec.describe ActivitiesHelper do
     end
 
     it "excludes months where both hours and gross_income are zero" do
-      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "state_provided")
       first_month = flow.reporting_months.first.beginning_of_month
       create(:employment_activity_month, employment_activity: activity, month: first_month, hours: 0, gross_income: 0)
 
@@ -191,7 +191,7 @@ RSpec.describe ActivitiesHelper do
     let(:first_month) { flow.reporting_window_range.begin.beginning_of_month }
 
     it "filters out months with no hours" do
-      activity = create(:volunteering_activity, activity_flow: flow, organization_name: "Food Pantry", draft: true, data_source: "validated")
+      activity = create(:volunteering_activity, activity_flow: flow, organization_name: "Food Pantry", draft: true, data_source: "state_provided")
       create(:volunteering_activity_month, volunteering_activity: activity, month: first_month, hours: 0)
       create(:volunteering_activity_month, volunteering_activity: activity, month: first_month + 1.month, hours: 5)
 

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -162,6 +162,28 @@ RSpec.describe ActivitiesHelper do
     it "returns empty array for empty input" do
       expect(helper.employment_activity_draft_cards([])).to eq([])
     end
+
+    it "includes month data when employment_activity_months have hours or gross_income" do
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      first_month = flow.reporting_months.first.beginning_of_month
+      create(:employment_activity_month, employment_activity: activity, month: first_month, hours: 20, gross_income: 500)
+
+      result = helper.employment_activity_draft_cards([ activity ])
+
+      expect(result.first[:months]).to eq([
+        { month: first_month, gross_earnings: 50_000, hours: 20 }
+      ])
+    end
+
+    it "excludes months where both hours and gross_income are zero" do
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+      first_month = flow.reporting_months.first.beginning_of_month
+      create(:employment_activity_month, employment_activity: activity, month: first_month, hours: 0, gross_income: 0)
+
+      result = helper.employment_activity_draft_cards([ activity ])
+
+      expect(result.first[:months]).to be_empty
+    end
   end
 
   describe "#community_service_draft_cards" do

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -140,6 +140,30 @@ RSpec.describe ActivitiesHelper do
     end
   end
 
+  describe "#employment_activity_draft_cards" do
+    let(:flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
+
+    it "returns a card with pre_populated: true and edit path pointing to employment edit page" do
+      activity = create(:employment_activity, activity_flow: flow, employer_name: "Acme Corp", draft: true, data_source: "validated")
+
+      result = helper.employment_activity_draft_cards([ activity ])
+
+      expect(result.length).to eq(1)
+      expect(result.first).to include(
+        name: "Acme Corp",
+        months: [],
+        pre_populated: true
+      )
+      expect(result.first[:edit_path]).to eq(
+        helper.edit_activities_flow_income_employment_path(id: activity.id)
+      )
+    end
+
+    it "returns empty array for empty input" do
+      expect(helper.employment_activity_draft_cards([])).to eq([])
+    end
+  end
+
   describe "#community_service_draft_cards" do
     let(:flow) { create(:activity_flow, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
     let(:first_month) { flow.reporting_window_range.begin.beginning_of_month }

--- a/app/spec/models/activity_flow_invitation_spec.rb
+++ b/app/spec/models/activity_flow_invitation_spec.rb
@@ -122,5 +122,31 @@ RSpec.describe ActivityFlowInvitation, type: :model do
       expect(invitation.errors.attribute_names.map(&:to_s))
         .to include("pre_populated_activities[0].months[0].month")
     end
+
+    it "is valid when an employment entry's months fall within the expected reporting window" do
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        {
+          "type" => "employment",
+          "employer_name" => "Acme Corp",
+          "months" => [ { "month" => in_window_date, "hours" => 40, "gross_income" => 3000 } ]
+        }
+      ])
+
+      expect(invitation).to be_valid
+    end
+
+    it "is invalid when an employment entry's month falls outside the expected reporting window" do
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        {
+          "type" => "employment",
+          "employer_name" => "Acme Corp",
+          "months" => [ { "month" => out_of_window_date, "hours" => 40, "gross_income" => 3000 } ]
+        }
+      ])
+
+      expect(invitation).not_to be_valid
+      expect(invitation.errors.attribute_names.map(&:to_s))
+        .to include("pre_populated_activities[0].months[0].month")
+    end
   end
 end

--- a/app/spec/models/activity_flow_invitation_spec.rb
+++ b/app/spec/models/activity_flow_invitation_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe ActivityFlowInvitation, type: :model do
 
       expect(invitation).to be_valid
     end
+
+    it "is valid with a well-formed employment entry" do
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "employment", "employer_name" => "Acme Corp" }
+      ])
+
+      expect(invitation).to be_valid
+    end
+
+    it "is invalid when an employment entry is missing employer_name" do
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "employment" }
+      ])
+
+      expect(invitation).not_to be_valid
+      expect(invitation.errors.attribute_names.map(&:to_s))
+        .to include("pre_populated_activities[0].employer_name")
+    end
   end
 
   describe "month-in-window validation" do

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -101,6 +101,59 @@ RSpec.describe ActivityFlow, type: :model do
       end
     end
 
+    context "with a pre-populated employment activity" do
+      let(:invitation) do
+        create(:activity_flow_invitation, pre_populated_activities: [
+          {
+            "type" => "employment",
+            "employer_name" => "Acme Corp",
+            "street_address" => "123 Main St",
+            "city" => "Boston",
+            "state" => "MA",
+            "zip_code" => "02101",
+            "contact_name" => "Jane Doe",
+            "contact_email" => "jane@acme.com",
+            "contact_phone_number" => "555-0100"
+          }
+        ])
+      end
+
+      it "hydrates a draft employment activity from the invitation payload" do
+        flow = described_class.create_from_invitation(invitation, device_id)
+
+        expect(flow.employment_activities.count).to eq(1)
+        activity = flow.employment_activities.first
+        expect(activity).to be_draft
+        expect(activity.data_source).to eq("validated")
+        expect(activity.employer_name).to eq("Acme Corp")
+        expect(activity.contact_email).to eq("jane@acme.com")
+      end
+
+      it "is idempotent — does not double-hydrate if employment activities already exist" do
+        flow = described_class.create_from_invitation(invitation, device_id)
+        expect(flow.employment_activities.count).to eq(1)
+
+        described_class.hydrate_pre_populated_activities!(flow, invitation)
+        expect(flow.employment_activities.reload.count).to eq(1)
+      end
+    end
+
+    context "with a mixed volunteering and employment invitation" do
+      let(:invitation) do
+        create(:activity_flow_invitation, pre_populated_activities: [
+          { "type" => "volunteering", "organization_name" => "Red Cross" },
+          { "type" => "employment", "employer_name" => "Acme Corp" }
+        ])
+      end
+
+      it "hydrates one activity of each type" do
+        flow = described_class.create_from_invitation(invitation, device_id)
+
+        expect(flow.volunteering_activities.count).to eq(1)
+        expect(flow.employment_activities.count).to eq(1)
+      end
+    end
+
     it "creates no activities when pre_populated_activities is empty" do
       invitation = create(:activity_flow_invitation, pre_populated_activities: [])
 

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -138,6 +138,31 @@ RSpec.describe ActivityFlow, type: :model do
       end
     end
 
+    context "with pre_populated_activities including employment monthly hours and income" do
+      let(:in_window_date) { described_class.expected_reporting_window_range("sandbox").end.beginning_of_month.iso8601 }
+      let(:invitation) do
+        create(:activity_flow_invitation, pre_populated_activities: [
+          {
+            "type" => "employment",
+            "employer_name" => "Acme Corp",
+            "months" => [
+              { "month" => in_window_date, "hours" => 40, "gross_income" => 3000 }
+            ]
+          }
+        ])
+      end
+
+      it "hydrates EmploymentActivityMonth records from the months array" do
+        flow = described_class.create_from_invitation(invitation, device_id)
+
+        activity = flow.employment_activities.first
+        months = activity.employment_activity_months.order(:month)
+        expect(months.map(&:hours)).to eq([ 40 ])
+        expect(months.map(&:gross_income)).to eq([ 3000 ])
+        expect(months.map { |m| m.month.iso8601 }).to eq([ in_window_date ])
+      end
+    end
+
     context "with a mixed volunteering and employment invitation" do
       let(:invitation) do
         create(:activity_flow_invitation, pre_populated_activities: [

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ActivityFlow, type: :model do
         expect(flow.volunteering_activities.count).to eq(1)
         activity = flow.volunteering_activities.first
         expect(activity).to be_draft
-        expect(activity.data_source).to eq("validated")
+        expect(activity.data_source).to eq("state_provided")
         expect(activity.organization_name).to eq("Red Cross")
         expect(activity.coordinator_email).to eq("pat@redcross.org")
       end
@@ -125,7 +125,7 @@ RSpec.describe ActivityFlow, type: :model do
         expect(flow.employment_activities.count).to eq(1)
         activity = flow.employment_activities.first
         expect(activity).to be_draft
-        expect(activity.data_source).to eq("validated")
+        expect(activity.data_source).to eq("state_provided")
         expect(activity.employer_name).to eq("Acme Corp")
         expect(activity.is_self_employed).to be false
         expect(activity.street_address).to eq("123 Main St")

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe ActivityFlow, type: :model do
           {
             "type" => "employment",
             "employer_name" => "Acme Corp",
+            "is_self_employed" => false,
             "street_address" => "123 Main St",
             "city" => "Boston",
             "state" => "MA",
@@ -126,7 +127,14 @@ RSpec.describe ActivityFlow, type: :model do
         expect(activity).to be_draft
         expect(activity.data_source).to eq("validated")
         expect(activity.employer_name).to eq("Acme Corp")
+        expect(activity.is_self_employed).to be false
+        expect(activity.street_address).to eq("123 Main St")
+        expect(activity.city).to eq("Boston")
+        expect(activity.state).to eq("MA")
+        expect(activity.zip_code).to eq("02101")
+        expect(activity.contact_name).to eq("Jane Doe")
         expect(activity.contact_email).to eq("jane@acme.com")
+        expect(activity.contact_phone_number).to eq("555-0100")
       end
 
       it "is idempotent — does not double-hydrate if employment activities already exist" do

--- a/app/spec/models/employment_activity_spec.rb
+++ b/app/spec/models/employment_activity_spec.rb
@@ -1,23 +1,6 @@
 require "rails_helper"
 
 RSpec.describe EmploymentActivity, type: :model do
-  describe "FIELDS" do
-    it "defines the permitted pre-populated fields" do
-      expect(EmploymentActivity::FIELDS).to match_array(%w[
-        employer_name
-        is_self_employed
-        street_address
-        street_address_line_2
-        city
-        state
-        zip_code
-        contact_name
-        contact_email
-        contact_phone_number
-      ])
-    end
-  end
-
   it "has fields for employer information" do
     activity = create(:employment_activity, employer_name: "Acme Corp")
 

--- a/app/spec/models/employment_activity_spec.rb
+++ b/app/spec/models/employment_activity_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe EmploymentActivity, type: :model do
     it "defines the permitted pre-populated fields" do
       expect(EmploymentActivity::FIELDS).to match_array(%w[
         employer_name
+        is_self_employed
         street_address
         street_address_line_2
         city

--- a/app/spec/models/employment_activity_spec.rb
+++ b/app/spec/models/employment_activity_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe EmploymentActivity, type: :model do
+  describe "FIELDS" do
+    it "defines the permitted pre-populated fields" do
+      expect(EmploymentActivity::FIELDS).to match_array(%w[
+        employer_name
+        street_address
+        street_address_line_2
+        city
+        state
+        zip_code
+        contact_name
+        contact_email
+        contact_phone_number
+      ])
+    end
+  end
+
   it "has fields for employer information" do
     activity = create(:employment_activity, employer_name: "Acme Corp")
 

--- a/app/spec/services/activity_flow_progress_calculator_spec.rb
+++ b/app/spec/services/activity_flow_progress_calculator_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ActivityFlowProgressCalculator do
       end
 
       it "applies the required-month threshold to routing requirements" do
-        validated_activity = create(:volunteering_activity, activity_flow: flow, data_source: "validated")
+        validated_activity = create(:volunteering_activity, activity_flow: flow, data_source: "state_provided")
         create(:volunteering_activity_month, volunteering_activity: validated_activity, month: reporting_months.first.beginning_of_month, hours: 80)
         create(:volunteering_activity_month, volunteering_activity: validated_activity, month: reporting_months.second.beginning_of_month, hours: 80)
 
@@ -140,7 +140,7 @@ RSpec.describe ActivityFlowProgressCalculator do
       end
 
       it "does not meet routing requirements when validated months are below the required count" do
-        validated_activity = create(:volunteering_activity, activity_flow: flow, data_source: "validated")
+        validated_activity = create(:volunteering_activity, activity_flow: flow, data_source: "state_provided")
         create(:volunteering_activity_month, volunteering_activity: validated_activity, month: reporting_months.first.beginning_of_month, hours: 80)
 
         expect(result.meets_routing_requirements).to be(false)


### PR DESCRIPTION
## [FFS-4319](https://jiraent.cms.gov/browse/FFS-4319)

## Changes
* Enabled pre-populated data for the Employment activity type.
* Added an easy way to test pre-populated data on the /launcher/advanced page.

## Acceptance testing
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1710.navapbc.cloud/launcher/advanced
- Deployed commit: 8ac36893954b8cc8353120cf0d010da187a4c2fc
<!-- end PR environment info -->