### PR TITLE
FFS-4384: Preserve applicant during redaction

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -1,6 +1,8 @@
 class CaseWorkerTransmitterJob < ApplicationJob
   attr_reader :cbv_flow
 
+  RedactedApplicantError = Class.new(StandardError)
+
   queue_as :default
 
   RETRY_WAITS = [ 5.minutes, 10.minutes, 30.minutes, 1.hour, 4.hours ].freeze
@@ -27,6 +29,11 @@ class CaseWorkerTransmitterJob < ApplicationJob
     @current_agency = current_agency(@cbv_flow)
 
     with_flow_tags(@cbv_flow) do
+      if @cbv_flow.cbv_applicant&.redacted_at.present?
+        raise RedactedApplicantError,
+          "Refusing to transmit cbv_flow #{cbv_flow_id}: applicant #{@cbv_flow.cbv_applicant_id} has been redacted"
+      end
+
       aggregator_report = AggregatorReportFetcher.new(@cbv_flow).report
 
       transmitter_class.new(@cbv_flow, @current_agency, aggregator_report).deliver

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -70,6 +70,8 @@ class DataRetentionService
       .find_each do |cbv_flow|
         cbv_flow.redact!
         applicant = cbv_flow.cbv_applicant
+        # `all?` returns true on an empty collection: applicants with no invitations
+        # can't receive new flows, so they're safe to redact.
         applicant.redact! if applicant && applicant.cbv_flow_invitations.all?(&:expired?)
         cbv_flow.payroll_accounts.each(&:redact!)
       end

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -66,10 +66,11 @@ class DataRetentionService
     CbvFlow
       .unredacted
       .where("transmitted_at < ?", REDACT_TRANSMITTED_CBV_FLOWS_AFTER.ago)
-      .includes(:cbv_flow_invitation, :payroll_accounts)
+      .includes(:payroll_accounts, cbv_applicant: :cbv_flow_invitations)
       .find_each do |cbv_flow|
         cbv_flow.redact!
-        cbv_flow.cbv_applicant&.redact!
+        applicant = cbv_flow.cbv_applicant
+        applicant.redact! if applicant && applicant.cbv_flow_invitations.all?(&:expired?)
         cbv_flow.payroll_accounts.each(&:redact!)
       end
   end

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -102,6 +102,25 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
       cbv_flow.update(consented_to_authorized_use_at: Time.now)
     end
 
+    context "when the applicant has been redacted" do
+      let(:transmission_method) { "shared_email" }
+
+      before do
+        cbv_flow.cbv_applicant.redact!
+      end
+
+      it "raises RedactedApplicantError" do
+        expect { described_class.new.perform(cbv_flow.id) }
+          .to raise_error(CaseWorkerTransmitterJob::RedactedApplicantError)
+      end
+
+      it "does not update transmitted_at" do
+        expect { described_class.new.perform(cbv_flow.id) }
+          .to raise_error(CaseWorkerTransmitterJob::RedactedApplicantError)
+        expect(cbv_flow.reload.transmitted_at).to be_nil
+      end
+    end
+
     context "when transmission method is shared_email" do
       let(:transmission_method) { "shared_email" }
       let(:transmission_method_configuration) { {

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -267,6 +267,8 @@ RSpec.describe DataRetentionService do
       let(:now) { deletion_threshold + 1.minute }
 
       context "when the invitation is still valid" do
+        # The factory default expires_at is several days from now (creation time),
+        # so no setup is needed — the invitation is live by default.
         it "does not redact the associated applicant" do
           service.redact_complete_cbv_flows
           expect(cbv_flow.cbv_applicant.reload.redacted_at).to be_nil

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -266,6 +266,13 @@ RSpec.describe DataRetentionService do
     context "after the deletion threshold" do
       let(:now) { deletion_threshold + 1.minute }
 
+      context "when the invitation is still valid" do
+        it "does not redact the associated applicant" do
+          service.redact_complete_cbv_flows
+          expect(cbv_flow.cbv_applicant.reload.redacted_at).to be_nil
+        end
+      end
+
       it "redacts the incomplete CbvFlow" do
         service.redact_complete_cbv_flows
         expect(cbv_flow.reload).to have_attributes(
@@ -278,11 +285,17 @@ RSpec.describe DataRetentionService do
         expect(cbv_flow_invitation.reload.redacted_at).to be_nil
       end
 
-      it "redacts the associated applicant" do
-        service.redact_complete_cbv_flows
-        expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-          first_name: "REDACTED"
-        )
+      context "when the invitation has expired" do
+        before do
+          cbv_flow_invitation.update!(expires_at: cbv_flow.transmitted_at - 1.day)
+        end
+
+        it "redacts the associated applicant" do
+          service.redact_complete_cbv_flows
+          expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+            first_name: "REDACTED"
+          )
+        end
       end
 
       it "redacts an associated PayrollAccount" do


### PR DESCRIPTION
## [FFS-4384](https://jiraent.cms.gov/browse/FFS-4384)

## Changes
Now, Applicants will not be redacted if they have an Invitation that has not expired. They will be redacted once the invitation expires.

## Context for reviewers
We encountered an issue in the following workflow:
1. Invitation is sent and used for a completed flow
2. 7 days pass and the flow is redacted, triggering the applicant to also be redacted
3. A subsequent person in the household uses the invitation again to complete a flow
At this point, the flow sent in step 3 is sent with [REDACTED] demographic information in the report, since the applicant object was redacted too early.

## Testing Instructions
I created a few rails c scripts I used to test manually; feel free to use these as-is, or modify them to create other tests!

**Script 1: Invitation still live → applicant should NOT be redacted**

```ruby
ActiveRecord::Base.transaction do
  applicant = CbvApplicant.create!(
    client_agency_id: "nh_dhhs",
    first_name: "Jane",
    last_name: "Doe",
    date_of_birth: Date.new(1985, 3, 20),
    case_number: "TEST-#{SecureRandom.hex(4)}"
  )

  invitation = CbvFlowInvitation.new(
    client_agency_id: "nh_dhhs",
    email_address: "test@example.com",
    language: "en",
    user: User.first,
    cbv_applicant: applicant,
    expires_at: 30.days.from_now   # still live
  )
  invitation.save!(validate: false)

  CbvFlow.create!(
    cbv_applicant: applicant,
    cbv_flow_invitation: invitation,
    confirmation_code: "NHTEST#{SecureRandom.hex(4).upcase}",
    transmitted_at: 8.days.ago,
    end_user_id: SecureRandom.uuid
  )

  DataRetentionService.new.redact_complete_cbv_flows
  applicant.reload

  if applicant.redacted_at.nil?
    puts "✅ PASS: applicant not redacted — invitation is still live"
  else
    puts "❌ FAIL: applicant was redacted despite live invitation"
  end

  raise ActiveRecord::Rollback
end
```

---

**Script 2: Invitation expired → applicant SHOULD be redacted**

```ruby
ActiveRecord::Base.transaction do
  applicant = CbvApplicant.create!(
    client_agency_id: "nh_dhhs",
    first_name: "John",
    last_name: "Smith",
    date_of_birth: Date.new(1980, 7, 4),
    case_number: "TEST-#{SecureRandom.hex(4)}"
  )

  invitation = CbvFlowInvitation.new(
    client_agency_id: "nh_dhhs",
    email_address: "test@example.com",
    language: "en",
    user: User.first,
    cbv_applicant: applicant,
    expires_at: 10.days.ago   # expired
  )
  invitation.save!(validate: false)

  CbvFlow.create!(
    cbv_applicant: applicant,
    cbv_flow_invitation: invitation,
    confirmation_code: "NHTEST#{SecureRandom.hex(4).upcase}",
    transmitted_at: 8.days.ago,
    end_user_id: SecureRandom.uuid
  )

  DataRetentionService.new.redact_complete_cbv_flows
  applicant.reload

  if applicant.first_name == "REDACTED"
    puts "✅ PASS: applicant redacted — invitation was expired"
  else
    puts "❌ FAIL: applicant was not redacted (first_name: #{applicant.first_name.inspect})"
  end

  raise ActiveRecord::Rollback
end
```

---

**Script 3: Job guard — redacted applicant raises RedactedApplicantError**

```ruby
ActiveRecord::Base.transaction do
  applicant = CbvApplicant.create!(
    client_agency_id: "nh_dhhs",
    first_name: "Jane",
    last_name: "Doe",
    date_of_birth: Date.new(1985, 3, 20),
    case_number: "TEST-#{SecureRandom.hex(4)}"
  )
  applicant.redact!   # simulate data retention having already run

  flow = CbvFlow.create!(
    cbv_applicant: applicant,
    confirmation_code: "NHTEST#{SecureRandom.hex(4).upcase}",
    end_user_id: SecureRandom.uuid
  )

  begin
    CaseWorkerTransmitterJob.new.perform(flow.id)
    puts "❌ FAIL: job completed without raising"
  rescue CaseWorkerTransmitterJob::RedactedApplicantError => e
    puts "✅ PASS: raised RedactedApplicantError"
    puts "   #{e.message}"
  rescue => e
    puts "❌ UNEXPECTED: #{e.class}: #{e.message}"
  end

  raise ActiveRecord::Rollback
end
```

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [X] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)