### PR TITLE
FFS-4382: Disable generic links for NH

### DIFF
--- a/app/app/views/cbv/sessions/timeout.html.erb
+++ b/app/app/views/cbv/sessions/timeout.html.erb
@@ -16,6 +16,6 @@
     </div>
   </div>
 </div>
-<% if @current_agency.present? %>
+<% if @current_agency.present? && !@current_agency.generic_links_disabled %>
   <p data-controller="session-timeout" data-sessions-target="source" class="margin-top-8"><%= t("session_timeout.page.start_over_html", link: cbv_flow_new_path(client_agency_id: @current_agency.id), action: "click->session-timeout#trackEvent") %></p>
 <% end %>

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -63,6 +63,7 @@
     pdf_filename_format: CBV_%{case_number}_%{consent_timestamp}_%{confirmation_code}
   staff_portal_enabled: true
   pilot_ended: false
+  generic_links_disabled: true
   sso:
     client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>

--- a/app/spec/controllers/cbv/sessions_controller_spec.rb
+++ b/app/spec/controllers/cbv/sessions_controller_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe Cbv::SessionsController, type: :controller do
       end
     end
 
+    context 'when generic links are disabled for the agency' do
+      before do
+        stub_client_agency_config_value("sandbox", "generic_links_disabled", true)
+      end
+
+      it 'renders the timeout page without link to start over' do
+        get :timeout, params: { client_agency_id: 'sandbox' }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('click here')
+      end
+    end
+
     context 'without a client_agency_id param or domain match' do
       it 'renders the timeout page without link to start over' do
         get :timeout


### PR DESCRIPTION
## [FFS-4382](https://jiraent.cms.gov/browse/FFS-4382)
- Add `generic_links_disabled: true` to NH agency config
- Hide "start over" link on session timeout page when agency has generic links disabled
- Add controller spec covering the disabled-links timeout case

## Acceptance testing
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1720.navapbc.cloud/launcher/advanced
- Deployed commit: 1597f12d9d0f031f8a98d21ec51b6472088d38cc
<!-- end PR environment info -->