### PR TITLE
Replace missing package in our Dockerfile

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -172,7 +172,7 @@ ENV PIDFILE="/rails/tmp/pids/server.pid"
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         libgpgme11t64=1.24.2-3 \
-        libvips42t64=8.16.1-1+b1 \
+        libvips42t64=8.16.1-1+deb13u1 \
         postgresql-client-17 \
         python-is-python3=3.13.3-1 \
         python3-venv=3.13.5-1 \

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -176,17 +176,17 @@ RSpec.describe ApplicationHelper do
     end
 
     it "returns '0-18' for a date of birth 10 years ago" do
-      date_of_birth = (Date.today - 10.years)
+      date_of_birth = (now - 10.years)
       expect(helper.get_age_range(date_of_birth, now: now)).to eq("0-18")
     end
 
     it "returns '19-25' for a date of birth 20 years ago" do
-      date_of_birth = (Date.today - 20.years)
+      date_of_birth = (now - 20.years)
       expect(helper.get_age_range(date_of_birth, now: now)).to eq("19-25")
     end
 
     it "returns '90+' for a date of birth 95 years ago" do
-      date_of_birth = (Date.today - 95.years)
+      date_of_birth = (now - 95.years)
       expect(helper.get_age_range(date_of_birth, now: now)).to eq("90+")
     end
   end


### PR DESCRIPTION
## Changes
- Pin `libvips42t64` to `8.16.1-1+deb13u1` in Dockerfile (replaces unavailable `+b1` build)
- Fix spec by tying it to `now` instead of flaky system time. 

## Context for reviewers
Docker pin bump unblocks image build — prior `+b1` version no longer in apt index.

## Acceptance testing
- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
