### PR TITLE
Dockerfile autofix PRs include Grype/Anchore fixes

### DIFF
--- a/.github/scripts/patch-dockerfile.rb
+++ b/.github/scripts/patch-dockerfile.rb
@@ -20,24 +20,25 @@
 # Only manages blocks marked with the AUTOFIX_MARKER comment.
 # Never touches the manually-maintained "Upgrade packages in base image" block.
 
-require "json"
-require "set"
 
-AUTOFIX_MARKER    = "# Auto-fix: OS package vulnerabilities detected by Trivy and Grype"
-INSERTION_ANCHOR  = "# Rails app lives here"
-OS_PACKAGE_TYPES  = Set["deb", "apk", "rpm"].freeze
+
+require 'json'
+
+AUTOFIX_MARKER    = '# Auto-fix: OS package vulnerabilities detected by Trivy and Grype'
+INSERTION_ANCHOR  = '# Rails app lives here'
+OS_PACKAGE_TYPES  = Set['deb', 'apk', 'rpm'].freeze
 
 def parse_trivy(trivy_path)
   data = JSON.parse(File.read(trivy_path))
   needed = Set.new
 
-  (data["Results"] || []).each do |result|
-    next unless result["Class"] == "os-pkgs"
+  (data['Results'] || []).each do |result|
+    next unless result['Class'] == 'os-pkgs'
 
-    (result["Vulnerabilities"] || []).each do |vuln|
-      next if vuln["FixedVersion"].to_s.empty?
+    (result['Vulnerabilities'] || []).each do |vuln|
+      next if vuln['FixedVersion'].to_s.empty?
 
-      needed.add(vuln["PkgName"])
+      needed.add(vuln['PkgName'])
     end
   end
 
@@ -48,14 +49,14 @@ def parse_grype(grype_path)
   data = JSON.parse(File.read(grype_path))
   needed = Set.new
 
-  (data["matches"] || []).each do |match|
-    next unless OS_PACKAGE_TYPES.include?(match.dig("artifact", "type"))
+  (data['matches'] || []).each do |match|
+    next unless OS_PACKAGE_TYPES.include?(match.dig('artifact', 'type'))
 
-    fix = match.dig("vulnerability", "fix") || {}
-    next unless fix["state"] == "fixed"
-    next if (fix["versions"] || []).empty?
+    fix = match.dig('vulnerability', 'fix') || {}
+    next unless fix['state'] == 'fixed'
+    next if (fix['versions'] || []).empty?
 
-    name = match.dig("artifact", "name")
+    name = match.dig('artifact', 'name')
     needed.add(name) if name
   end
 
@@ -70,17 +71,17 @@ def parse_autofix_block(lines)
   lines.each_with_index do |line, i|
     start_idx = i if line.include?(AUTOFIX_MARKER)
 
-    if start_idx != -1 && end_idx == -1
-      # Package lines look like: '      pkgname \' or '      pkgname=version \'
-      if (m = line.match(/^\s{6}([a-z0-9][a-z0-9.+\-]*)(?:=[^\s\\]+)?\s*\\?\s*$/))
-        packages.add(m[1])
-      end
+    next unless start_idx != -1 && end_idx == -1
 
-      # The block ends at the apt cleanup line
-      if line.include?("rm -rf /var/lib/apt/lists")
-        end_idx = i
-        break
-      end
+    # Package lines look like: '      pkgname \' or '      pkgname=version \'
+    if (m = line.match(/^\s{6}([a-z0-9][a-z0-9.+-]*)(?:=[^\s\\]+)?\s*\\?\s*$/))
+      packages.add(m[1])
+    end
+
+    # The block ends at the apt cleanup line
+    if line.include?('rm -rf /var/lib/apt/lists')
+      end_idx = i
+      break
     end
   end
 
@@ -107,14 +108,14 @@ def find_insertion_index(lines)
 end
 
 def set_github_output(key, value)
-  output_file = ENV["GITHUB_OUTPUT"]
+  output_file = ENV['GITHUB_OUTPUT']
   return unless output_file
 
-  File.open(output_file, "a") { |f| f.puts("#{key}=#{value}") }
+  File.open(output_file, 'a') { |f| f.puts("#{key}=#{value}") }
 end
 
 def write_summary(added)
-  summary_file = ENV["PATCH_SUMMARY_FILE"]
+  summary_file = ENV['PATCH_SUMMARY_FILE']
   return unless summary_file
 
   out = +"### Packages added\n\n"
@@ -140,11 +141,13 @@ def main(trivy_path, grype_path, dockerfile_path)
 
   to_add = needed - currently_patched
   stale  = currently_patched - needed
-  puts "Already-patched packages no longer flagged (kept; manual cleanup at base image bump): #{stale.sort}" if stale.any?
+  if stale.any?
+    puts "Already-patched packages no longer flagged (kept; manual cleanup at base image bump): #{stale.sort}"
+  end
 
   if to_add.empty?
-    puts "No new packages to add."
-    set_github_output("changes_made", "false")
+    puts 'No new packages to add.'
+    set_github_output('changes_made', 'false')
     return
   end
 
@@ -168,12 +171,14 @@ def main(trivy_path, grype_path, dockerfile_path)
   puts "Dockerfile updated: #{dockerfile_path}"
 
   write_summary(to_add)
-  set_github_output("changes_made", "true")
+  set_github_output('changes_made', 'true')
 end
 
-if ARGV.size != 3
-  warn "Usage: #{$PROGRAM_NAME} <trivy-results.json> <grype-results.json> <Dockerfile>"
-  exit 1
-end
+if $PROGRAM_NAME == __FILE__
+  if ARGV.size != 3
+    warn "Usage: #{$PROGRAM_NAME} <trivy-results.json> <grype-results.json> <Dockerfile>"
+    exit 1
+  end
 
-main(ARGV[0], ARGV[1], ARGV[2])
+  main(ARGV[0], ARGV[1], ARGV[2])
+end

--- a/.github/scripts/patch-dockerfile.rb
+++ b/.github/scripts/patch-dockerfile.rb
@@ -9,6 +9,9 @@
 # as fixable to the auto-managed RUN block in the Dockerfile's BASE stage. The
 # union is taken because Trivy and Grype use different vulnerability databases
 # and routinely disagree on which CVEs apply to a given package version.
+# Both parsers restrict results to OS packages — Trivy via Class == "os-pkgs",
+# Grype via artifact.type in {deb, apk, rpm} — so only apt-installable names
+# reach the RUN block.
 # Removal is intentionally manual — scanners run with --ignore-unfixed / only-fixed
 # cannot distinguish "fix shipped in the new base image" from "fix already
 # applied by this auto-fix block", so auto-removing risks reintroducing the CVE
@@ -22,6 +25,7 @@ require "set"
 
 AUTOFIX_MARKER    = "# Auto-fix: OS package vulnerabilities detected by Trivy and Grype"
 INSERTION_ANCHOR  = "# Rails app lives here"
+OS_PACKAGE_TYPES  = Set["deb", "apk", "rpm"].freeze
 
 def parse_trivy(trivy_path)
   data = JSON.parse(File.read(trivy_path))
@@ -45,6 +49,8 @@ def parse_grype(grype_path)
   needed = Set.new
 
   (data["matches"] || []).each do |match|
+    next unless OS_PACKAGE_TYPES.include?(match.dig("artifact", "type"))
+
     fix = match.dig("vulnerability", "fix") || {}
     next unless fix["state"] == "fixed"
     next if (fix["versions"] || []).empty?

--- a/.github/scripts/patch-dockerfile.rb
+++ b/.github/scripts/patch-dockerfile.rb
@@ -3,14 +3,16 @@
 
 # Add-only Dockerfile OS package patcher.
 #
-# Usage: ruby patch-dockerfile.rb <trivy-results.json> <Dockerfile>
+# Usage: ruby patch-dockerfile.rb <trivy-results.json> <grype-results.json> <Dockerfile>
 #
-# Reads Trivy JSON output and adds any packages Trivy flags as fixable to the
-# auto-managed RUN block in the Dockerfile's BASE stage. Removal is intentionally
-# manual — Trivy with --ignore-unfixed cannot distinguish "fix shipped in the
-# new base image" from "fix already applied by this auto-fix block", so
-# auto-removing risks reintroducing the CVE on the next build. Clear the block
-# manually when bumping the base Ruby image.
+# Reads Trivy and Grype JSON output and adds any packages either scanner flags
+# as fixable to the auto-managed RUN block in the Dockerfile's BASE stage. The
+# union is taken because Trivy and Grype use different vulnerability databases
+# and routinely disagree on which CVEs apply to a given package version.
+# Removal is intentionally manual — scanners run with --ignore-unfixed / only-fixed
+# cannot distinguish "fix shipped in the new base image" from "fix already
+# applied by this auto-fix block", so auto-removing risks reintroducing the CVE
+# on the next build. Clear the block manually when bumping the base Ruby image.
 #
 # Only manages blocks marked with the AUTOFIX_MARKER comment.
 # Never touches the manually-maintained "Upgrade packages in base image" block.
@@ -18,10 +20,10 @@
 require "json"
 require "set"
 
-AUTOFIX_MARKER    = "# Auto-fix: OS package vulnerabilities detected by Trivy"
+AUTOFIX_MARKER    = "# Auto-fix: OS package vulnerabilities detected by Trivy and Grype"
 INSERTION_ANCHOR  = "# Rails app lives here"
 
-def parse_trivy_results(trivy_path)
+def parse_trivy(trivy_path)
   data = JSON.parse(File.read(trivy_path))
   needed = Set.new
 
@@ -33,6 +35,22 @@ def parse_trivy_results(trivy_path)
 
       needed.add(vuln["PkgName"])
     end
+  end
+
+  needed
+end
+
+def parse_grype(grype_path)
+  data = JSON.parse(File.read(grype_path))
+  needed = Set.new
+
+  (data["matches"] || []).each do |match|
+    fix = match.dig("vulnerability", "fix") || {}
+    next unless fix["state"] == "fixed"
+    next if (fix["versions"] || []).empty?
+
+    name = match.dig("artifact", "name")
+    needed.add(name) if name
   end
 
   needed
@@ -100,9 +118,14 @@ def write_summary(added)
   File.write(summary_file, out)
 end
 
-def main(trivy_path, dockerfile_path)
-  needed = parse_trivy_results(trivy_path)
-  puts "Trivy flagged #{needed.size} package(s) with fixes available: #{needed.sort}"
+def main(trivy_path, grype_path, dockerfile_path)
+  from_trivy = parse_trivy(trivy_path)
+  from_grype = parse_grype(grype_path)
+  needed = from_trivy | from_grype
+
+  puts "Trivy flagged: #{from_trivy.sort}"
+  puts "Grype flagged: #{from_grype.sort}"
+  puts "Union (#{needed.size} package(s) with fixes available): #{needed.sort}"
 
   lines = File.readlines(dockerfile_path)
 
@@ -111,7 +134,7 @@ def main(trivy_path, dockerfile_path)
 
   to_add = needed - currently_patched
   stale  = currently_patched - needed
-  puts "Already-patched packages no longer flagged by Trivy (kept; manual cleanup at base image bump): #{stale.sort}" if stale.any?
+  puts "Already-patched packages no longer flagged (kept; manual cleanup at base image bump): #{stale.sort}" if stale.any?
 
   if to_add.empty?
     puts "No new packages to add."
@@ -142,9 +165,9 @@ def main(trivy_path, dockerfile_path)
   set_github_output("changes_made", "true")
 end
 
-if ARGV.size != 2
-  warn "Usage: #{$PROGRAM_NAME} <trivy-results.json> <Dockerfile>"
+if ARGV.size != 3
+  warn "Usage: #{$PROGRAM_NAME} <trivy-results.json> <grype-results.json> <Dockerfile>"
   exit 1
 end
 
-main(ARGV[0], ARGV[1])
+main(ARGV[0], ARGV[1], ARGV[2])

--- a/.github/scripts/patch-dockerfile_test.rb
+++ b/.github/scripts/patch-dockerfile_test.rb
@@ -1,0 +1,323 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/AbcSize,Metrics/ClassLength,Metrics/MethodLength,Style/Documentation
+
+require 'minitest/autorun'
+require 'json'
+require 'tmpdir'
+
+require_relative 'patch-dockerfile'
+
+class PatchDockerfileTest < Minitest::Test
+  EXISTING_MARKER_LINE = "#{AUTOFIX_MARKER} (managed automatically)\n".freeze
+  STALE_MARKER_LINE = "# Auto-fix: OS package vulnerabilities detected by Trivy (managed automatically)\n"
+  INSERTION_ANCHOR_LINE = "#{INSERTION_ANCHOR}\n".freeze
+
+  def setup
+    @tmpdir = Dir.mktmpdir
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  # --- helpers ---
+
+  def write_json(name, data)
+    path = File.join(@tmpdir, name)
+    File.write(path, JSON.generate(data))
+    path
+  end
+
+  def write_dockerfile(lines)
+    path = File.join(@tmpdir, 'Dockerfile')
+    File.write(path, lines.join)
+    path
+  end
+
+  def run_main(trivy:, grype:, dockerfile:)
+    out, = capture_io { main(trivy, grype, dockerfile) }
+    out
+  end
+
+  def dockerfile_with_existing_block(packages)
+    [
+      "FROM debian AS base\n",
+      EXISTING_MARKER_LINE,
+      "# hadolint ignore=DL3008\n",
+      "RUN apt-get update -qq && \\\n",
+      "    apt-get install -y --no-install-recommends \\\n",
+      *packages.map { |p| "      #{p} \\\n" },
+      "    && \\\n",
+      "    rm -rf /var/lib/apt/lists /var/cache/apt/archives\n",
+      "\n",
+      INSERTION_ANCHOR_LINE,
+      "WORKDIR /rails\n"
+    ]
+  end
+
+  def dockerfile_without_block
+    [
+      "FROM debian AS base\n",
+      "\n",
+      INSERTION_ANCHOR_LINE,
+      "WORKDIR /rails\n"
+    ]
+  end
+
+  def trivy_fixture(*pkg_names)
+    {
+      'Results' => [
+        {
+          'Class' => 'os-pkgs',
+          'Vulnerabilities' => pkg_names.map { |n| { 'PkgName' => n, 'FixedVersion' => '1.0' } }
+        }
+      ]
+    }
+  end
+
+  def grype_match(name:, type: 'deb', state: 'fixed', versions: ['1.0'])
+    {
+      'artifact' => { 'name' => name, 'type' => type },
+      'vulnerability' => { 'fix' => { 'state' => state, 'versions' => versions } }
+    }
+  end
+
+  def grype_fixture(*matches)
+    { 'matches' => matches }
+  end
+
+  # --- tests ---
+
+  def test_real_dockerfile_marker_matches_constant
+    # Regression: drift between AUTOFIX_MARKER and the actual marker in
+    # app/Dockerfile would cause the script to insert a duplicate block instead
+    # of editing the existing one. Catch the drift here at test time.
+    real_dockerfile = File.expand_path('../../app/Dockerfile', __dir__)
+    skip("app/Dockerfile not found at #{real_dockerfile}") unless File.exist?(real_dockerfile)
+
+    assert_includes File.read(real_dockerfile), AUTOFIX_MARKER,
+                    'app/Dockerfile must contain the current AUTOFIX_MARKER'
+  end
+
+  def test_recognizes_existing_block_with_current_marker
+    # Regression: if AUTOFIX_MARKER and the Dockerfile comment drift apart,
+    # parse_autofix_block fails to find the block and a duplicate gets inserted.
+    df = write_dockerfile(dockerfile_with_existing_block(%w[libcap2]))
+    trivy = write_json('t.json', trivy_fixture)
+    grype = write_json('g.json', grype_fixture(grype_match(name: 'libcap2')))
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_equal 1, content.scan(AUTOFIX_MARKER).size, 'exactly one autofix block expected'
+    refute_match(/libcap2.*libcap2/m, content)
+  end
+
+  def test_does_not_duplicate_block_when_marker_matches_and_nothing_changes
+    df = write_dockerfile(dockerfile_with_existing_block(%w[libcap2 libsystemd0]))
+    original = File.read(df)
+    trivy = write_json('t.json', trivy_fixture('libcap2'))
+    grype = write_json('g.json', grype_fixture(grype_match(name: 'libsystemd0')))
+
+    out = run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    assert_equal original, File.read(df), 'Dockerfile must not change when union ⊆ existing'
+    assert_match(/No new packages to add/, out)
+  end
+
+  def test_inserts_new_block_when_dockerfile_has_no_marker
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_fixture('libfoo'))
+    grype = write_json('g.json', grype_fixture)
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, AUTOFIX_MARKER
+    assert_includes content, "      libfoo \\\n"
+    assert_equal 1, content.scan(AUTOFIX_MARKER).size
+  end
+
+  def test_does_not_recognize_stale_marker_and_creates_new_block
+    # If someone forgets to bump the Dockerfile marker when bumping the constant,
+    # the script should at least NOT silently edit the old (stale) block.
+    # Documents the current behavior: stale marker is ignored, new block inserted.
+    lines = [
+      "FROM debian AS base\n",
+      STALE_MARKER_LINE,
+      "RUN apt-get update -qq && \\\n",
+      "    apt-get install -y --no-install-recommends \\\n",
+      "      oldpkg \\\n",
+      "    && \\\n",
+      "    rm -rf /var/lib/apt/lists /var/cache/apt/archives\n",
+      "\n",
+      INSERTION_ANCHOR_LINE
+    ]
+    df = write_dockerfile(lines)
+    trivy = write_json('t.json', trivy_fixture('newpkg'))
+    grype = write_json('g.json', grype_fixture)
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, 'oldpkg', 'stale block left untouched'
+    assert_includes content, 'newpkg', 'new block added'
+    assert_includes content, AUTOFIX_MARKER
+  end
+
+  def test_grype_filter_drops_non_os_artifact_types
+    matches = [
+      grype_match(name: 'libdeb1', type: 'deb'),
+      grype_match(name: 'nokogiri', type: 'gem'),
+      grype_match(name: 'lodash', type: 'npm'),
+      grype_match(name: 'requests', type: 'python'),
+      grype_match(name: 'log4j-core', type: 'java-archive'),
+      grype_match(name: 'alpine-pkg', type: 'apk'),
+      grype_match(name: 'rpm-pkg', type: 'rpm')
+    ]
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_fixture)
+    grype = write_json('g.json', grype_fixture(*matches))
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    %w[libdeb1 alpine-pkg rpm-pkg].each { |p| assert_includes content, "      #{p} \\\n" }
+    %w[nokogiri lodash requests log4j-core].each { |p| refute_includes content, p }
+  end
+
+  def test_grype_filter_drops_unfixed_state
+    matches = [
+      grype_match(name: 'libfixed', state: 'fixed'),
+      grype_match(name: 'libunfixed', state: 'not-fixed'),
+      grype_match(name: 'libwontfix', state: 'wont-fix')
+    ]
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_fixture)
+    grype = write_json('g.json', grype_fixture(*matches))
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, 'libfixed'
+    refute_includes content, 'libunfixed'
+    refute_includes content, 'libwontfix'
+  end
+
+  def test_grype_filter_drops_empty_versions
+    matches = [
+      grype_match(name: 'libgood', versions: ['1.0']),
+      grype_match(name: 'libempty', versions: [])
+    ]
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_fixture)
+    grype = write_json('g.json', grype_fixture(*matches))
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, 'libgood'
+    refute_includes content, 'libempty'
+  end
+
+  def test_trivy_filter_only_includes_os_pkgs_class
+    trivy_data = {
+      'Results' => [
+        { 'Class' => 'os-pkgs', 'Vulnerabilities' => [{ 'PkgName' => 'libos', 'FixedVersion' => '1.0' }] },
+        { 'Class' => 'lang-pkgs', 'Vulnerabilities' => [{ 'PkgName' => 'somelibrary', 'FixedVersion' => '2.0' }] }
+      ]
+    }
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_data)
+    grype = write_json('g.json', grype_fixture)
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, 'libos'
+    refute_includes content, 'somelibrary'
+  end
+
+  def test_trivy_filter_drops_empty_fixed_version
+    trivy_data = {
+      'Results' => [
+        { 'Class' => 'os-pkgs', 'Vulnerabilities' => [
+          { 'PkgName' => 'libfixed', 'FixedVersion' => '1.0' },
+          { 'PkgName' => 'libunfixed', 'FixedVersion' => '' }
+        ] }
+      ]
+    }
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_data)
+    grype = write_json('g.json', grype_fixture)
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, 'libfixed'
+    refute_includes content, 'libunfixed'
+  end
+
+  def test_union_dedups_packages_flagged_by_both_scanners
+    df = write_dockerfile(dockerfile_without_block)
+    trivy = write_json('t.json', trivy_fixture('libshared'))
+    grype = write_json('g.json', grype_fixture(grype_match(name: 'libshared')))
+
+    run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_equal 1, content.scan(/^      libshared/).size
+  end
+
+  def test_stale_packages_kept_in_block
+    df = write_dockerfile(dockerfile_with_existing_block(%w[libold libstill-flagged]))
+    trivy = write_json('t.json', trivy_fixture('libstill-flagged'))
+    grype = write_json('g.json', grype_fixture(grype_match(name: 'libnew')))
+
+    out = run_main(trivy: trivy, grype: grype, dockerfile: df)
+
+    content = File.read(df)
+    assert_includes content, "      libold \\\n", 'stale package retained'
+    assert_includes content, "      libstill-flagged \\\n", 'still-flagged package retained'
+    assert_includes content, "      libnew \\\n", 'new package added'
+    assert_match(/Already-patched packages no longer flagged.*libold/, out)
+  end
+
+  def test_emits_no_changes_when_union_subset_of_existing
+    df = write_dockerfile(dockerfile_with_existing_block(%w[libcap2]))
+    original = File.read(df)
+    trivy = write_json('t.json', trivy_fixture('libcap2'))
+    grype = write_json('g.json', grype_fixture)
+
+    Tempfile.create('gh_output') do |f|
+      ENV['GITHUB_OUTPUT'] = f.path
+      run_main(trivy: trivy, grype: grype, dockerfile: df)
+      assert_match(/changes_made=false/, File.read(f.path))
+    end
+    assert_equal original, File.read(df)
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+  end
+
+  def test_emits_changes_made_true_and_writes_summary_when_adding
+    df = write_dockerfile(dockerfile_with_existing_block(%w[libcap2]))
+    trivy = write_json('t.json', trivy_fixture('libcap2'))
+    grype = write_json('g.json', grype_fixture(grype_match(name: 'libnew')))
+
+    Tempfile.create('gh_output') do |gh_out|
+      Tempfile.create('summary') do |summary|
+        ENV['GITHUB_OUTPUT'] = gh_out.path
+        ENV['PATCH_SUMMARY_FILE'] = summary.path
+        run_main(trivy: trivy, grype: grype, dockerfile: df)
+        assert_match(/changes_made=true/, File.read(gh_out.path))
+        assert_match(/^- `libnew`/, File.read(summary.path))
+      end
+    end
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+    ENV.delete('PATCH_SUMMARY_FILE')
+  end
+end
+# rubocop:enable Metrics/AbcSize,Metrics/ClassLength,Metrics/MethodLength,Style/Documentation

--- a/.github/workflows/auto-fix-vulnerabilities.yml
+++ b/.github/workflows/auto-fix-vulnerabilities.yml
@@ -80,11 +80,21 @@ jobs:
           vuln-type: os
           scanners: vuln
 
+      - name: Run Grype scan (JSON output)
+        uses: anchore/scan-action@v7
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          output-format: json
+          output-file: grype-results.json
+          severity-cutoff: high
+          fail-build: false
+          only-fixed: true
+
       - name: Patch Dockerfile with fixable OS packages
         id: patch
         env:
           PATCH_SUMMARY_FILE: patch-summary.md
-        run: ruby .github/scripts/patch-dockerfile.rb trivy-results.json app/Dockerfile
+        run: ruby .github/scripts/patch-dockerfile.rb trivy-results.json grype-results.json app/Dockerfile
 
       - name: Generate PR body
         if: steps.patch.outputs.changes_made == 'true'
@@ -108,7 +118,7 @@ jobs:
               echo "**Triggered by:** manual \`${EVENT_NAME}\`"
             fi
             echo ""
-            echo "Trivy identified OS packages with available CVE fixes. The auto-managed"
+            echo "Trivy and Grype identified OS packages with available CVE fixes. The auto-managed"
             echo "\`RUN apt-get install\` block in the Dockerfile BASE stage has been updated:"
             echo ""
             cat patch-summary.md
@@ -124,10 +134,11 @@ jobs:
             echo "Once CI passes and confirms Trivy/Anchore are green, this PR is safe to merge."
             echo ""
             echo "_The auto-fix block in the Dockerfile is temporary and add-only. This workflow_"
-            echo "_will not auto-remove packages — Trivy with \`--ignore-unfixed\` cannot tell a_"
-            echo "_base-image fix apart from one already applied by this block, so removing_"
-            echo "_would risk reintroducing the CVE. Clear the block manually when the base_"
-            echo "_Ruby image is bumped (see upgrade instructions at the top of the Dockerfile)._"
+            echo "_will not auto-remove packages — Trivy (\`--ignore-unfixed\`) and Grype_"
+            echo "_(\`only-fixed\`) cannot tell a base-image fix apart from one already applied_"
+            echo "_by this block, so removing would risk reintroducing the CVE. Clear the block_"
+            echo "_manually when the base Ruby image is bumped (see upgrade instructions at the_"
+            echo "_top of the Dockerfile)._"
           } > pr-body.md
 
       - name: Check for existing open fix PR

--- a/.github/workflows/auto-fix-vulnerabilities.yml
+++ b/.github/workflows/auto-fix-vulnerabilities.yml
@@ -108,12 +108,12 @@ jobs:
             echo "## Automated Dockerfile OS Vulnerability Fix"
             echo ""
             if [ "$EVENT_NAME" = "workflow_run" ]; then
-              echo "| | |"
-              echo "|---|---|"
-              echo "| **Failed scan** | [${TRIGGER_RUN_TITLE}](${TRIGGER_RUN_URL}) |"
+              echo "<table>"
+              echo "<tr><td><b>Failed scan</b></td><td><a href=\"${TRIGGER_RUN_URL}\">${TRIGGER_RUN_TITLE}</a></td></tr>"
               if [ -n "$TRIGGER_PR_NUMBER" ] && [ "$TRIGGER_PR_NUMBER" != "null" ]; then
-                echo "| **Source PR** | #${TRIGGER_PR_NUMBER} |"
+                echo "<tr><td><b>Source PR</b></td><td>#${TRIGGER_PR_NUMBER}</td></tr>"
               fi
+              echo "</table>"
             else
               echo "**Triggered by:** manual \`${EVENT_NAME}\`"
             fi

--- a/.github/workflows/pr-reviewer-lottery.yml
+++ b/.github/workflows/pr-reviewer-lottery.yml
@@ -5,7 +5,13 @@ on:
 
 jobs:
   reviewer-lottery:
-    if: github.actor != 'dependabot[bot]'
+    # Skip when the PR already has a requested reviewer — preserves any reviewer
+    # set at PR creation (e.g. by the auto-fix-vulnerabilities workflow) across
+    # the close/reopen dance that the autofix PR body instructs maintainers to
+    # perform to force CI.
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      toJSON(github.event.pull_request.requested_reviewers) == '[]'
     name: Add random reviewer via Reviewer Lottery
     runs-on: ubuntu-latest
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,13 @@ repos:
     language: system
     files: '.*/Dockerfile'
 
+  - id: patch-dockerfile-test
+    name: patch-dockerfile.rb test
+    entry: ruby .github/scripts/patch-dockerfile_test.rb
+    language: system
+    files: '^(\.github/scripts/patch-dockerfile.*\.rb|app/Dockerfile)$'
+    pass_filenames: false
+
   - id: actionlint
     name: ActionLint
     entry: actionlint

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update -qq && \
     && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Auto-fix: OS package vulnerabilities detected by Trivy (managed automatically)
+# Auto-fix: OS package vulnerabilities detected by Trivy and Grype (managed automatically)
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Changes
- Extend Dockerfile autofix script to include the union of Grype (Anchore) and Trivy results.
- Skip reviewer lottery when PR already has a requested reviewer, so autofix PR reviewers survive the close/reopen CI dance.
- Change formatting of table to use html so we don't see a blank header like in #1722. 
- Added tests! They run in our precommit hook. when patch-dockerfile.rb changes 

## Context for reviewers
- Trivy and Grype use different vulnerability DBs and disagree often; union avoids missing fixes either scanner catches alone. You can see this in #1722 where all but the `anchore-scan` passed successfully.

## Acceptance testing
- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)