### PR TITLE
No ticket: Allow partially redacted reports to be sent

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -30,8 +30,9 @@ class CaseWorkerTransmitterJob < ApplicationJob
 
     with_flow_tags(@cbv_flow) do
       if @cbv_flow.cbv_applicant&.redacted_at.present?
-        raise RedactedApplicantError,
-          "Refusing to transmit cbv_flow #{cbv_flow_id}: applicant #{@cbv_flow.cbv_applicant_id} has been redacted"
+        NewRelic::Agent.notice_error(
+          RedactedApplicantError.new("Transmitting cbv_flow #{cbv_flow_id} with redacted applicant #{@cbv_flow.cbv_applicant_id}")
+        )
       end
 
       aggregator_report = AggregatorReportFetcher.new(@cbv_flow).report

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -104,20 +104,22 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
     context "when the applicant has been redacted" do
       let(:transmission_method) { "shared_email" }
+      let(:transmission_method_configuration) { { "email" => "caseworker@example.com" } }
 
       before do
         cbv_flow.cbv_applicant.redact!
+        allow(NewRelic::Agent).to receive(:notice_error)
       end
 
-      it "raises RedactedApplicantError" do
-        expect { described_class.new.perform(cbv_flow.id) }
-          .to raise_error(CaseWorkerTransmitterJob::RedactedApplicantError)
+      it "reports a RedactedApplicantError to New Relic" do
+        described_class.new.perform(cbv_flow.id)
+        expect(NewRelic::Agent).to have_received(:notice_error)
+          .with(instance_of(CaseWorkerTransmitterJob::RedactedApplicantError))
       end
 
-      it "does not update transmitted_at" do
+      it "still transmits the report" do
         expect { described_class.new.perform(cbv_flow.id) }
-          .to raise_error(CaseWorkerTransmitterJob::RedactedApplicantError)
-        expect(cbv_flow.reload.transmitted_at).to be_nil
+          .to change { cbv_flow.reload.transmitted_at }.from(nil)
       end
     end
 


### PR DESCRIPTION
## No ticket

## Changes
Previously, we prevented sending any partially-redacted reports (as fixed in eb53a9b240297fdd8cd7fb34f72425894c6a3a80).
Now, we still flag that one is being sent in NewRelic, but we allow the report to be sent.

## Context for reviewers
In eb53a9b240297fdd8cd7fb34f72425894c6a3a80 we fixed an issue where an Applicant is inappropriately redacted before an associated Invitation is expired. However, we also prevented any reports from being sent to a state when this happens. Long term, this is what we want, but in these few weeks after implementing the fix we should still send these reports. We expect that instances of this problem will stop after all Invitations sent prior to the fix being deployed are expired.

## Testing instructions
Use the below script to set up this situation and confirm the changes are working (or to make your own variations!):

```
# rails c (development)

# ── Create the problem state ──────────────────────────────────────────────────
applicant = CbvApplicant::Sandbox.create!(
  first_name: "Jane",
  middle_name: "Sue",
  last_name: "Doe",
  date_of_birth: Date.new(1992, 3, 19),
  snap_application_date: Date.current,
  case_number: "REDACT_TEST_#{Time.now.to_i}"
)
flow = CbvFlow.create!(
  cbv_applicant: applicant,
  device_id: SecureRandom.uuid,
  consented_to_authorized_use_at: Time.now,
  confirmation_code: "SANDBOX_TEST_001"
)

# Simulate the pre-fix bug: applicant redacted while invitation is still live
applicant.redact!
puts "Precondition — applicant redacted_at: #{applicant.reload.redacted_at}"
puts "Precondition — transmitted_at before:  #{flow.reload.transmitted_at.inspect}"

# ── Stubs ─────────────────────────────────────────────────────────────────────
fake_report = Struct.new(:paystubs).new([])
AggregatorReportFetcher.define_singleton_method(:new) { |_| Struct.new(:report).new(fake_report) }

deliveries = []
Transmitters::SharedEmailTransmitter.define_method(:deliver) { deliveries << true }

noticed_errors = []
NewRelic::Agent.define_singleton_method(:notice_error) { |err| noticed_errors << err }

# ── Run ───────────────────────────────────────────────────────────────────────
puts "\nRunning CaseWorkerTransmitterJob..."
begin
  CaseWorkerTransmitterJob.new.perform(flow.id)
  puts "Job completed without raising ✓"
rescue => e
  puts "UNEXPECTED RAISE: #{e.class}: #{e.message}"
end

# ── Verify ────────────────────────────────────────────────────────────────────
flow.reload
puts "\n--- Results ---"
puts "transmitted_at set:           #{flow.transmitted_at.present?}  (expected: true)"
puts "deliver called:               #{deliveries.count == 1}          (expected: true)"
puts "NewRelic.notice_error called: #{noticed_errors.count == 1}      (expected: true)"
noticed_errors.each { |e| puts "  ↳ #{e.class}: #{e.message}" }
```

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
