### PR TITLE
FFS-4072: Fix single-month reporting period display

### DIFF
--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -113,13 +113,13 @@ class ActivityFlow < Flow
     range = reporting_window_range
     end_display = I18n.l(range.end, format: :month_year)
 
+    return end_display if reporting_window_months == 1
+
     if range.begin.year == range.end.year
       start_display = I18n.l(range.begin, format: :month)
     else
       start_display = I18n.l(range.begin, format: :month_year)
     end
-
-    return end_display if start_display == end_display
 
     "#{start_display} - #{end_display}"
   end

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -5,14 +5,10 @@
 <% variant = @flow.renewal_reporting_window? ? :renewal : :application %>
 <% title_key = activity_hub_title_key(state) %>
 <% description_key = activity_hub_description_key(state) %>
-<% single_month_reporting_window = @flow.reporting_months.one? %>
-<% reporting_window_display = single_month_reporting_window ? l(@flow.reporting_window_range.begin, format: :month_year) : @flow.reporting_window_display %>
-<% empty_state_description_key = single_month_reporting_window ? "activities.hub.empty_state_description_single_month" : "activities.hub.empty_state_description" %>
+<% reporting_window_display = @flow.reporting_window_display %>
 <%# i18n-tasks-use t("activities.hub.empty_state_title") %>
 <%# i18n-tasks-use t("activities.hub.completed_state_title") %>
 <%# i18n-tasks-use t("activities.hub.in_progress_state_title") %>
-<%# i18n-tasks-use t("activities.hub.empty_state_description") %>
-<%# i18n-tasks-use t("activities.hub.empty_state_description_single_month") %>
 <%# i18n-tasks-use t("activities.hub.completed_state_description", agency_name: "Test Agency") %>
 <%# i18n-tasks-use t("activities.hub.in_progress_state_description", agency_name: "Test Agency") %>
 <%# i18n-tasks-use t("activities.hub.empty_state_months_required_any", required_month_count: 3) %>
@@ -41,7 +37,11 @@
       <% end %>
 
       <p class="activity-hub-subheading">
-        <%= t(empty_state_description_key, reporting_window: reporting_window_display) %>
+        <% if @flow.reporting_window_months == 1 %>
+          <%= t("activities.hub.empty_state_description_single_month", reporting_window: reporting_window_display) %>
+        <% else %>
+          <%= t("activities.hub.empty_state_description", reporting_window: reporting_window_display) %>
+        <% end %>
       </p>
     <% else %>
       <p class="activity-hub-subheading margin-top-2">

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -215,6 +215,12 @@ RSpec.describe ActivityFlow, type: :model do
       expect(flow.reporting_window_display).to eq("January - February 2025")
     end
 
+    it "returns a single month for a one-month reporting window" do
+      flow = create(:activity_flow, reporting_window_months: 1)
+
+      expect(flow.reporting_window_display).to eq("February 2025")
+    end
+
     describe "#within_reporting_window?" do
       it "returns true when date range overlaps with reporting window" do
         expect(flow.within_reporting_window?(Date.new(2024, 12, 1), Date.new(2025, 1, 15))).to be true


### PR DESCRIPTION
## [FFS-4072](https://jiraent.cms.gov/browse/FFS-4072)

## Changes
- Display one-month activity reporting periods as a single month instead of a duplicated range.
- Use single-month activity hub empty-state copy that says activities were done in the month.
- Add regression coverage for the model display string and rendered hub copy.

## Context for reviewers
This fixes the one-month demo/application flow copy so the reporting period no longer renders awkwardly as the same month twice or says activities were done "between" a single month.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1736.navapbc.cloud/launcher/advanced
- Deployed commit: 3b9588ffc7486a4f162999ad785100df37290515
<!-- end PR environment info -->