### PR TITLE
Update will-deploy script to output new link

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -150,7 +150,7 @@ tags = tags_for_changes(both_changes, income_changes, ce_changes)
 
 output = +""
 output << "🚀 Will deploy `#{current_sha[0, 7]}` to production: 🚀 (cc #{tags})\n"
-output << "🧪 *[Launch the demo →](https://la-verify-demo.navapbc.cloud/demo)*\n\n"
+output << "🧪 *[Open the launcher →](https://verify-demo.navapbc.cloud/launcher)*\n\n"
 append_changes(output, "👥 *User facing changes to Emmy Income + Emmy CE*", both_changes)
 append_changes(
   output,


### PR DESCRIPTION
Fixes FFS-4421

## [FFS-4421](https://jiraent.cms.gov/browse/FFS-4421)

## Changes
- Updated the `bin/will-deploy` script so the Slack message link reads "Open the launcher" instead of "Launch the demo".
- Updated the hyperlink URL from `https://la-verify-demo.navapbc.cloud/demo` to `https://verify-demo.navapbc.cloud/launcher`.

## Testing instructions
1. From `app/`, run `bin/will-deploy` (or inspect the script at `app/bin/will-deploy:153`).
2. Confirm the generated Slack output contains `*[Open the launcher →](https://verify-demo.navapbc.cloud/launcher)*` instead of the previous "Launch the demo" link.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production.

## AI Agent Notes
### Assumptions Made
1. The only place that needed updating was `app/bin/will-deploy:153` — no other files in the repo referenced "Launch the demo" or the `la-verify-demo.navapbc.cloud/demo` URL.
2. The new launcher URL host should not include the `la-` prefix (matches the ticket's stated URL exactly).
3. The arrow character (`→`) and surrounding markdown formatting in the Slack message should be preserved as-is.

### Open questions
1. None.