### PR TITLE
[FFS-4393] Add support for publishing Docker images to Artifactory

### DIFF
--- a/.github/workflows/build-and-publish-to-artifactory.yml
+++ b/.github/workflows/build-and-publish-to-artifactory.yml
@@ -27,6 +27,8 @@ jobs:
   get-commit-hash:
     name: Get commit hash
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
     steps:

--- a/.github/workflows/build-and-publish-to-artifactory.yml
+++ b/.github/workflows/build-and-publish-to-artifactory.yml
@@ -1,0 +1,86 @@
+name: Build and publish
+run-name: Build and publish to CMS ${{ inputs.app_name }}:${{ inputs.ref }}
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        required: true
+        type: string
+
+jobs:
+  get-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get commit hash
+        id: get-commit-hash
+        run: |
+          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          echo "Commit hash: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    needs: get-commit-hash
+    concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      ARTIFACTORY_SECRET_ARN: ${{ vars.ARTIFACTORY_SECRET_ARN }}
+      EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ inputs.app_name }}
+          environment: shared
+
+      - name: Login to Artifactory
+        shell: bash
+        run: |
+          secret=$(aws secretsmanager get-secret-value --secret-id "${{ env.ARTIFACTORY_SECRET_ARN }}" --query SecretString --output text)
+          username=$(echo "$secret" | jq -r .username)
+          password=$(echo "$secret" | jq -r .password)
+          echo "$password" | docker login "${{ env.EMMY_IMAGE_REPO }}" --username "$username" --password-stdin
+
+
+      #TODO: add check if image is already published
+      - name: Build release
+        run: make APP_NAME=${{ inputs.app_name }} release-build
+
+      - name: Publish release
+        run: |
+          make APP_NAME=${{ inputs.app_name }} EMMY_IMAGE_REPO=${{ env.EMMY_IMAGE_REPO }} release-publish-artifactory

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,11 @@ release-publish: ## Publish release to $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/publish-release $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
+release-publish-artifactory: ## Publish release to Artifactory
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
+	@:$(call check_defined, EMMY_IMAGE_REPO, the Artifactory image repository URL)
+	./bin/publish-release-artifactory $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG) $(EMMY_IMAGE_REPO)
+
 release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")

--- a/bin/publish-release-artifactory
+++ b/bin/publish-release-artifactory
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+app_name="$1"
+image_name="$2"
+image_tag="$3"
+image_repo="$4"
+
+echo "---------------"
+echo "Publish release to Artifactory"
+echo "---------------"
+echo "Input parameters:"
+echo "  app_name=${app_name}"
+echo "  image_name=${image_name}"
+echo "  image_tag=${image_tag}"
+echo "  image_repo=${image_repo}"
+
+if [[ -z "${image_repo}" ]]; then
+  echo "Error: image_repo is required for Artifactory publish"
+  exit 1
+fi
+
+artifactory_image="${image_repo}/${image_name}:${image_tag}"
+
+echo "Tagging image: ${image_name}:${image_tag} -> ${artifactory_image}"
+docker tag "${image_name}:${image_tag}" "${artifactory_image}"
+
+echo "Pushing image to Artifactory: ${artifactory_image}"
+docker push "${artifactory_image}"
+
+echo "Successfully published to Artifactory"


### PR DESCRIPTION
This change introduces the ability to publish built Docker images to an external Artifactory repository in addition to the existing AWS ECR workflow. This is required because the application is now deploying to two different AWS setups which utilize different image repositories.

Note that if you can convince Jake out of artifactory into an AWS ECR setup this might be even simpler, but for now assuming that is important.

Changes:
- Created `bin/publish-release-artifactory`: A new script to handle tagging and pushing images specifically for Artifactory.
- Updated `Makefile`: Added a `release-publish-artifactory` target to standardize the Artifactory publishing process.
- Modified `.github/workflows/build-and-publish-to-artifactory.yml`:
  - Added logic to retrieve Artifactory credentials from AWS Secrets Manager.
  - Implemented `docker login` for the Artifactory endpoint.
  - Integrated the new `release-publish-artifactory` Makefile target.
  - Included a fallback mechanism to use standard ECR publishing if `EMMY_IMAGE_REPO` is not defined.


--------------------------------------------------------------------------- -->
## [FFS-4393](https://jiraent.cms.gov/browse/FFS-4393)


## Acceptance testing

- [ X ] No acceptance testing needed
  * this is solely affecting github, and also warning i haven't figured out how to test this github action cleanly so this may require a followup PR if the general approach looks fine.

