### PR TITLE
Update will-deploy script to output new link

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -150,7 +150,7 @@ tags = tags_for_changes(both_changes, income_changes, ce_changes)
 
 output = +""
 output << "🚀 Will deploy `#{current_sha[0, 7]}` to production: 🚀 (cc #{tags})\n"
-output << "🧪 *[Launch the demo →](https://la-verify-demo.navapbc.cloud/demo)*\n\n"
+output << "🧪 *[Open the launcher →](https://verify-demo.navapbc.cloud/launcher)*\n\n"
 append_changes(output, "👥 *User facing changes to Emmy Income + Emmy CE*", both_changes)
 append_changes(
   output,


### PR DESCRIPTION
Fixes FFS-4421

## [FFS-4421](https://jiraent.cms.gov/browse/FFS-4421)

## Changes
- Updated the `bin/will-deploy` Slack output: the link text changed from "Launch the demo" to "Open the launcher", and the URL changed from `https://la-verify-demo.navapbc.cloud/demo` to `https://verify-demo.navapbc.cloud/launcher`.

## Testing instructions
1. From `app/`, run `bin/will-deploy` (or inspect the line in `app/bin/will-deploy` near the `output << "🧪 *[...]"` assignment).
2. Confirm the generated Slack message contains `🧪 *[Open the launcher →](https://verify-demo.navapbc.cloud/launcher)*` instead of the old "Launch the demo" link.
3. Optionally paste the output into Slack to verify the rendered hyperlink text and URL.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production.

## AI Agent Notes
### Assumptions Made
1. The only place to update is the Slack output string in `app/bin/will-deploy` (line 153). A repo-wide grep for the old text/URL confirmed there were no other references.
2. The new URL `https://verify-demo.navapbc.cloud/launcher` is reachable; the script does not validate the URL, so no further code change is needed.
3. The trailing arrow (`→`) styling was preserved to match the existing format.

### Open questions
1. None — the ticket specified the exact new link text and URL.