### PR TITLE
FFS-4074: Show street address line 2 and zipcode in address on activity review page

### DIFF
--- a/app/app/components/contact_info_review_table_component.rb
+++ b/app/app/components/contact_info_review_table_component.rb
@@ -5,10 +5,6 @@ class ContactInfoReviewTableComponent < ViewComponent::Base
     @value_header = value_header
   end
 
-  def self.formatted_address(activity)
-    [ activity.street_address, activity.city, activity.state ].select(&:present?).join(", ").presence
-  end
-
   def display_value(value)
     value.presence || I18n.t("shared.not_applicable")
   end

--- a/app/app/models/education_activity.rb
+++ b/app/app/models/education_activity.rb
@@ -34,7 +34,9 @@ class EducationActivity < Activity
   end
 
   def formatted_address
-    [ street_address, city, state ].compact_blank.join(", ").presence
+    locality = [ city, state ].compact_blank.join(", ")
+    locality_zip = [ locality, zip_code ].compact_blank.join(" ")
+    [ street_address, street_address_line_2, locality_zip ].compact_blank.join(", ").presence
   end
 
   def community_engagement_hours(credit_hours)

--- a/app/app/views/activities/volunteering/review.html.erb
+++ b/app/app/views/activities/volunteering/review.html.erb
@@ -23,7 +23,7 @@
 </div>
 <%= render(ContactInfoReviewTableComponent.new(field_header: t("shared.table_headers.community_service_information"), value_header: t("shared.table_headers.your_details"), rows: [
   { label: t("activities.community_service.review.name"), value: @volunteering_activity.organization_name },
-  { label: t("activities.community_service.review.address"), value: ContactInfoReviewTableComponent.formatted_address(@volunteering_activity) },
+  { label: t("activities.community_service.review.address"), value: @volunteering_activity.formatted_address },
   { label: t("activities.community_service.review.coordinator_name"), value: @volunteering_activity.coordinator_name },
   { label: t("activities.community_service.review.coordinator_email"), value: @volunteering_activity.coordinator_email },
   { label: t("activities.community_service.review.coordinator_phone"), value: @volunteering_activity.coordinator_phone_number }

--- a/app/spec/models/education_activity_spec.rb
+++ b/app/spec/models/education_activity_spec.rb
@@ -134,19 +134,33 @@ RSpec.describe EducationActivity do
   end
 
   describe "#formatted_address" do
-    it "returns a formatted street, city, and state string when present" do
+    it "joins street, city, state, and zip into a single line" do
       activity = build(
         :education_activity,
         street_address: "601 E John St",
         city: "Champaign",
-        state: "IL"
+        state: "IL",
+        zip_code: "61820"
       )
 
-      expect(activity.formatted_address).to eq("601 E John St, Champaign, IL")
+      expect(activity.formatted_address).to eq("601 E John St, Champaign, IL 61820")
+    end
+
+    it "includes street_address_line_2 when present" do
+      activity = build(
+        :education_activity,
+        street_address: "601 E John St",
+        street_address_line_2: "Suite 200",
+        city: "Champaign",
+        state: "IL",
+        zip_code: "61820"
+      )
+
+      expect(activity.formatted_address).to eq("601 E John St, Suite 200, Champaign, IL 61820")
     end
 
     it "returns nil when no address fields are present" do
-      activity = build(:education_activity, street_address: nil, city: nil, state: nil)
+      activity = build(:education_activity, street_address: nil, street_address_line_2: nil, city: nil, state: nil, zip_code: nil)
 
       expect(activity.formatted_address).to be_nil
     end


### PR DESCRIPTION
## [FFS-4074](https://jiraent.cms.gov/browse/FFS-4074)

## Changes
- Include `street_address_line_2` in formatted address output on `EducationActivity` and `ContactInfoReviewTableComponent`
- Append `zip_code` after city/state in the same formatters

## Context for reviewers
Address now renders as `street, line_2, city, state zip`. `zip_code` joins to `city, state` with a space (not comma); everything else comma-separated. `compact_blank` keeps output clean when any field is missing.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1760.navapbc.cloud/launcher/advanced
- Deployed commit: 96569c633fab6d82583811296d5b52e3960f5f6d
<!-- end PR environment info -->