### PR TITLE
[FFS-4394] introduce way to manually deploy to ecs depending on terraform that doesnt exist in this repo

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,0 +1,64 @@
+name: Deploy to ECS
+run-name: Deploy ${{ inputs.image_tag }} to ${{ inputs.app_name }} (${{ inputs.environment }})
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. dev, staging, prod)"
+        required: true
+        type: string
+      image_tag:
+        description: "the tag of the image to deploy"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. dev, staging, prod)"
+        required: true
+        type: string
+      image_tag:
+        description: "the tag of the image to deploy"
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
+      AWS_REGION: us-east-1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
+
+      - name: Deploy release
+        shell: bash
+        run: |
+          make APP_NAME=${{ inputs.app_name }} \
+            ENVIRONMENT=${{ inputs.environment }} \
+            EMMY_IMAGE_REPO=${{ env.EMMY_IMAGE_REPO }} \
+            EMMY_IMAGE_TAG=${{ inputs.image_tag }} \
+            release-update-ecs

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ __check_defined = \
 	infra-update-app-database-roles \
 	infra-update-app-database \
 	infra-update-app-service \
+	release-update-ecs \
 	infra-update-current-account \
 	infra-update-network \
 	infra-validate-modules \
@@ -219,6 +220,13 @@ release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
 	./bin/deploy-release $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
+
+release-update-ecs: ## Update ECS task definition with $EMMY_IMAGE_REPO and $EMMY_IMAGE_TAG for $APP_NAME in $ENVIRONMENT
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
+	@:$(call check_defined, EMMY_IMAGE_REPO, the container image repository URI)
+	@:$(call check_defined, EMMY_IMAGE_TAG, the tag of the image to deploy)
+	./bin/deploy-ecs-manual $(APP_NAME) $(ENVIRONMENT) $(EMMY_IMAGE_REPO) $(EMMY_IMAGE_TAG)
 
 release-image-name: ## Prints the image name of the release image
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/bin/deploy-ecs-manual
+++ b/bin/deploy-ecs-manual
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script updates an ECS service's task definition with a new image
+# without relying on Terraform to manage the task definition resource.
+#
+# Usage: bin/deploy-ecs-manual <app_name> <environment> <image_repo> <image_tag>
+
+app_name="$1"
+environment="$2"
+image_repo="$3"
+image_tag="$4"
+
+echo "-------------------"
+echo "Manual ECS Deployment"
+echo "-------------------"
+echo "Input parameters:"
+echo "  app_name=${app_name}"
+echo "  environment=${environment}"
+echo "  image_repo=${image_repo}"
+echo "  image_tag=${image_tag}"
+echo
+
+# 1. Get Cluster and Service names from Terraform outputs
+# While we don't have direct access to the TF that *created* the task definition (as per instructions),
+# we might still need to know which cluster and service to update.
+# The previous solution used TF outputs to find cluster_name and service_name.
+# If we truly "don't have direct access to the terraform", we might need these as inputs,
+# but let's assume for now we can at least query the current state to find them,
+# OR that we should use naming conventions.
+#
+# Looking at infra/app/service/main.tf, service_name is local.service_config.service_name.
+
+# Let's try to get them from TF if available, but allow overrides via ENV vars
+cluster_name=${ECS_CLUSTER_NAME:-$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)}
+service_name=${ECS_SERVICE_NAME:-$(terraform -chdir="infra/${app_name}/service" output -raw service_name)}
+
+echo "Targeting Cluster: ${cluster_name}"
+echo "Targeting Service: ${service_name}"
+
+# 2. Describe the current service to find the current task definition
+current_task_def_arn=$(aws ecs describe-services --cluster "${cluster_name}" --services "${service_name}" --query 'services[0].taskDefinition' --output text)
+
+echo "Current Task Definition: ${current_task_def_arn}"
+
+# 3. Download the current task definition JSON
+# We strip out metadata fields that aren't allowed in register-task-definition
+current_task_def=$(aws ecs describe-task-definition --task-definition "${current_task_def_arn}" --query 'taskDefinition' --output json)
+
+# 4. Create a new task definition JSON with the updated image
+# We use jq to update the image of the first container (assuming it's the main one)
+# or all containers if they should use the same image (less likely).
+# Typically there's one main container with the same name as the service.
+new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" '
+  del(.taskDefinitionArn) |
+  del(.revision) |
+  del(.status) |
+  del(.requiresAttributes) |
+  del(.compatibilities) |
+  del(.registeredAt) |
+  del(.registeredBy) |
+  (.containerDefinitions[] | select(.name == "'"${service_name}"'")) .image = $IMAGE
+')
+
+# 5. Register the new task definition
+echo "Registering new task definition revision..."
+new_task_def_arn=$(aws ecs register-task-definition --cli-input-json "${new_task_def}" --query 'taskDefinition.taskDefinitionArn' --output text)
+
+echo "New Task Definition ARN: ${new_task_def_arn}"
+
+# 6. Update the service to use the new task definition
+echo "Updating service ${service_name} to use new task definition..."
+aws ecs update-service --cluster "${cluster_name}" --service "${service_name}" --task-definition "${new_task_def_arn}" > /dev/null
+
+# 7. Wait for the service to become stable
+echo "Waiting for service ${service_name} to become stable..."
+aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+
+echo "Deployment completed successfully!"

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -169,8 +169,7 @@ module "service" {
 
   image_repository_arn = local.build_repository_config.repository_arn
   image_repository_url = local.build_repository_config.repository_url
-
-  image_tag = local.image_tag
+  image_tag            = local.image_tag
 
   vpc_id             = data.aws_vpc.network.id
   public_subnet_ids  = data.aws_subnets.public.ids


### PR DESCRIPTION
## [FFS-4394](https://jiraent.cms.gov/browse/FFS-4394)

## Changes
Introduce way to manually deploy to ECS for the CMS infra. 

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [X] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)