### PR TITLE
Fix time related spec failures

### DIFF
--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ActivitiesHelper do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe "activity hub display helpers" do
     describe "#activity_hub_state" do
       let(:meeting_result) { instance_double(ActivityFlowProgressCalculator::MonthlyResult, meets_requirements: true) }
@@ -298,6 +300,8 @@ RSpec.describe ActivitiesHelper do
   end
 
   describe "#education_cards" do
+    around { |example| travel_to(Date.new(2025, 11, 15)) { example.run } }
+
     let(:flow) { create(:activity_flow, reporting_window_months: 2, volunteering_activities_count: 0, job_training_activities_count: 0, education_activities_count: 0) }
     let(:first_month) { flow.reporting_window_range.begin }
     let(:second_month) { first_month + 1.month }

--- a/app/spec/models/education_activity_spec.rb
+++ b/app/spec/models/education_activity_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe EducationActivity do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe "validations" do
     let(:activity_flow) { create(:activity_flow, reporting_window_months: 1, education_activities_count: 0) }
 
@@ -356,6 +358,8 @@ RSpec.describe EducationActivity do
   end
 
   describe "#progress_hours_for_month" do
+    around { |example| travel_to(Date.new(2025, 11, 15)) { example.run } }
+
     let(:flow) { create(:activity_flow, reporting_window_months: 1, education_activities_count: 0) }
     let(:education_activity) { create(:education_activity, activity_flow: flow, status: "succeeded") }
     let(:month_start) { flow.reporting_window_range.begin }

--- a/app/spec/services/activity_flow_progress_calculator_spec.rb
+++ b/app/spec/services/activity_flow_progress_calculator_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ActivityFlowProgressCalculator do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe "#overall_result" do
     subject(:result) { described_class.new(flow).overall_result }
 
@@ -795,6 +797,8 @@ RSpec.describe ActivityFlowProgressCalculator do
 
   describe "education progress" do
     subject(:progress) { described_class.new(flow).overall_result }
+
+    around { |example| travel_to(Date.new(2025, 11, 15)) { example.run } }
 
     let(:flow) { create(:activity_flow, reporting_window_months: 1, education_activities_count: 0) }
     let(:education_activity) { create(:education_activity, activity_flow: flow, status: "succeeded") }


### PR DESCRIPTION
Our entry into the summer months exposed some weird edge cases with our tests: May is the first summer month and the since the reporting window moved from March - April to May - June we incorrectly applied the spring term carryover. Now the reporting-window math is deterministic and will avoid this in the future.

## Changes
- Added `include ActiveSupport::Testing::TimeHelpers` to `activities_helper_spec`, `education_activity_spec`, and `activity_flow_progress_calculator_spec`.
- Wrapped the `#education_cards`, `#progress_hours_for_month`, and education progress example groups in `travel_to(Date.new(2025, 11, 15))` so they run against a fixed date.

## Acceptance testing
- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
