### PR TITLE
FFS-4227: Order education and employment cards chronologically

### DIFF
--- a/app/app/helpers/activities_helper.rb
+++ b/app/app/helpers/activities_helper.rb
@@ -41,7 +41,6 @@ module ActivitiesHelper
       account_months = monthly_summaries[account.aggregator_account_id] || {}
       months = account_months
         .sort_by { |month_key, _| month_key }
-        .reverse
         .filter_map do |month_key, month_data|
         next unless active_employment_month?(month_data)
 

--- a/app/app/services/education_activity_card_builder.rb
+++ b/app/app/services/education_activity_card_builder.rb
@@ -21,7 +21,7 @@ class EducationActivityCardBuilder
 
   def fully_self_attested_cards
     months_by_date = @activity.education_activity_months.index_by(&:month)
-    months = @reporting_months.reverse.filter_map do |month_start|
+    months = @reporting_months.filter_map do |month_start|
       activity_month = months_by_date[month_start.beginning_of_month]
       next unless activity_month
       next unless education_credit_hours(activity_month).positive?
@@ -49,7 +49,7 @@ class EducationActivityCardBuilder
   def validated_card(terms)
     school_name = terms.first.school_name&.titlecase || I18n.t("activities.education.title")
     resolver = reporting_month_resolver(terms)
-    months = @reporting_months.reverse.filter_map do |month_start|
+    months = @reporting_months.filter_map do |month_start|
       effective_term = resolver.result_for(month_start).effective_term
       next unless effective_term
 
@@ -99,7 +99,7 @@ class EducationActivityCardBuilder
 
   def partially_self_attested_months_for_school(school_terms)
     resolver = reporting_month_resolver(school_terms)
-    @reporting_months.reverse.filter_map do |month_start|
+    @reporting_months.filter_map do |month_start|
       effective_term = resolver.result_for(month_start).effective_term
       next unless effective_term
       next if effective_term.less_than_half_time? && @activity.review_term_credit_hours(effective_term).zero?

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: first_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.full_time")
@@ -339,7 +339,7 @@ RSpec.describe ActivitiesHelper do
           month: second_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.full_time")
         }
-      )
+      ])
     end
 
     it "does not include months without overlapping terms" do
@@ -430,7 +430,7 @@ RSpec.describe ActivitiesHelper do
       expect(result.first[:edit_path]).to eq(
         helper.review_activities_flow_education_path(id: activity.id, from_edit: 1)
       )
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: first_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
@@ -439,7 +439,7 @@ RSpec.describe ActivitiesHelper do
           month: second_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         }
-      )
+      ])
     end
 
     it "shows enrollment status only for partially self-attested months" do
@@ -456,7 +456,7 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: first_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
@@ -465,7 +465,7 @@ RSpec.describe ActivitiesHelper do
           month: second_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.less_than_half_time")
         }
-      )
+      ])
     end
 
     it "only includes overlapping months for partially self-attested terms" do
@@ -536,7 +536,7 @@ RSpec.describe ActivitiesHelper do
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: first_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.enrolled")
@@ -545,7 +545,7 @@ RSpec.describe ActivitiesHelper do
           month: second_month,
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.enrolled")
         }
-      )
+      ])
     end
 
     it "builds a fully self-attested card from activity months" do
@@ -611,7 +611,7 @@ RSpec.describe ActivitiesHelper do
       result = helper.education_cards([ activity.reload ], summer_months)
 
       expect(result.length).to eq(1)
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: Date.new(2025, 7, 1),
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
@@ -620,7 +620,7 @@ RSpec.describe ActivitiesHelper do
           month: Date.new(2025, 8, 1),
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
         }
-      )
+      ])
     end
 
     it "shows the spring enrollment status on the summer card when no summer term exists" do
@@ -639,7 +639,7 @@ RSpec.describe ActivitiesHelper do
       result = helper.education_cards([ activity.reload ], summer_months)
 
       expect(result.length).to eq(1)
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         {
           month: Date.new(2025, 7, 1),
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
@@ -648,7 +648,7 @@ RSpec.describe ActivitiesHelper do
           month: Date.new(2025, 8, 1),
           enrollment_status: I18n.t("components.enrollment_term_table_component.status.half_time")
         }
-      )
+      ])
     end
 
     it "shows spring carryover on partially self-attested cards in a long reporting window" do
@@ -819,8 +819,8 @@ RSpec.describe ActivitiesHelper do
       result = helper.employment_cards([ payroll_account ], mock_report, reporting_range)
 
       expect(result.first[:months]).to eq([
-        { month: second_month, gross_earnings: 0, hours: 85.45 },
-        { month: first_month, gross_earnings: 2500_00, hours: 42.24 }
+        { month: first_month, gross_earnings: 2500_00, hours: 42.24 },
+        { month: second_month, gross_earnings: 0, hours: 85.45 }
       ])
     end
 
@@ -865,10 +865,10 @@ RSpec.describe ActivitiesHelper do
       expect(result.first[:edit_path]).to eq(
         helper.review_activities_flow_income_employment_path(id: activity.id, from_edit: 1)
       )
-      expect(result.first[:months]).to contain_exactly(
+      expect(result.first[:months]).to eq([
         { month: first_month, gross_earnings: 50000, hours: 40 },
         { month: second_month, gross_earnings: 30000, hours: 20 }
-      )
+      ])
     end
 
     it "filters out months with no income or hours" do

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -376,14 +376,14 @@ RSpec.describe ActivitiesHelper do
       expect(result.map { |card| card[:name] }).to eq([ "Summer U" ])
     end
 
-    it "returns months in reverse chronological order" do
+    it "returns months in chronological order" do
       activity = create(:education_activity, activity_flow: flow)
       create(:nsc_enrollment_term, education_activity: activity, school_name: "Test U", term_begin: first_month, term_end: second_month.end_of_month)
 
       result = helper.education_cards([ activity.reload ], reporting_months)
 
       months = result.first[:months].map { |m| m[:month] }
-      expect(months).to eq(months.sort.reverse)
+      expect(months).to eq(months.sort)
     end
 
     it "includes edit path to education review with from_edit for validated education" do
@@ -564,8 +564,8 @@ RSpec.describe ActivitiesHelper do
         {
           name: "Updated University of Illinois",
           months: [
-            { month: second_month, credit_hours: 6, community_engagement_hours: 24 },
-            { month: first_month, credit_hours: 4, community_engagement_hours: 16 }
+            { month: first_month, credit_hours: 4, community_engagement_hours: 16 },
+            { month: second_month, credit_hours: 6, community_engagement_hours: 24 }
           ],
           edit_path: helper.review_activities_flow_education_path(id: activity.id, from_edit: 1)
         }


### PR DESCRIPTION
## [FFS-4227](https://jiraent.cms.gov/browse/FFS-4227)

## Changes
**Chronological cards**
- Removed `.reverse` from the three month-building loops in `EducationActivityCardBuilder` (`fully_self_attested_cards`, `validated_card`, `partially_self_attested_months_for_school`) so education activity cards list months in chronological (ascending) order.
- Updated `activities_helper_spec` expectations to assert chronological month ordering.
- Removed `.reverse` from `employment_cards` in `activities_helper` so payroll employment cards also list months chronologically, matching the education and community-service cards.
- Switched month-array spec assertions from `contain_exactly` to `eq([...])` so the suite detects month-ordering regressions, not just membership.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
`@reporting_months` is already in chronological order, so dropping `.reverse` yields ascending months. Change affects all three education card variants (fully self-attested, validated, partially self-attested) for consistent ordering.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1771.navapbc.cloud/launcher/advanced
- Deployed commit: 17774f525c951d7659d0bb44d26bf1149247f6ec
<!-- end PR environment info -->