### PR TITLE
[FFS-4399] get database migrations up and running as a github action for CMS

### DIFF
--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -1,0 +1,55 @@
+name: Database migrations
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. dev, staging, prod)"
+        required: true
+        type: string
+      image_tag:
+        description: "the tag of the image to deploy"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. dev, staging, prod)"
+        required: true
+        type: string
+      image_tag:
+        description: "the tag of the image to deploy"
+        required: true
+        type: string
+
+concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }}
+
+jobs:
+  run-migrations:
+    name: Run migrations
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
+
+      - name: Run migrations
+        run: |
+          make release-run-database-migrations-cms ENVIRONMENT=${{ inputs.environment }} EMMY_IMAGE_TAG=${{ inputs.image_tag }}

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ __check_defined = \
 	release-publish \
 	release-publish-artifactory \
 	release-run-database-migrations \
+	release-run-database-migrations-cms \
 	e2e-setup \
 	e2e-test
 
@@ -217,6 +218,11 @@ release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVI
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
 	./bin/run-database-migrations $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
+
+release-run-database-migrations-cms: ## Update ECS task definition emmy-{ENVIRONMENT}-migrate and run migrations for CMS
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
+	@:$(call check_defined, EMMY_IMAGE_TAG, the tag of the image to deploy)
+	./bin/run-database-migrations-cms $(ENVIRONMENT) $(EMMY_IMAGE_TAG)
 
 release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/bin/run-database-migrations-cms
+++ b/bin/run-database-migrations-cms
@@ -32,7 +32,7 @@ echo "Step 1. Update task definition ${task_def_family}"
 current_task_def=$(aws ecs describe-task-definition --task-definition "${task_def_family}" --query 'taskDefinition' --output json)
 
 # Create a new task definition revision with the updated image
-# We assume the container name is "emmy-app" based on existing scripts, 
+# We assume the container name is "emmy-app-migrate" or "app" based on existing scripts, 
 # or we can update all container images if there are multiple.
 # Given the instructions, we just need to update the image to EMMY_IMAGE_TAG.
 # We'll need the repository URI. We can try to extract it from the current image.
@@ -65,9 +65,32 @@ echo "Step 2. Run migration task"
 service_name="emmy-${environment}-app"
 network_config=$(aws ecs describe-services --cluster "${cluster_name}" --services "${service_name}" --query "services[0].networkConfiguration" --output json)
 
-aws ecs run-task \
+task_arn=$(aws ecs run-task \
   --cluster "${cluster_name}" \
   --task-definition "${new_task_def_arn}" \
   --network-configuration "${network_config}" \
   --launch-type FARGATE \
-  --started-by "migration-script"
+  --started-by "migration-script" \
+  --query 'tasks[0].taskArn' \
+  --output text)
+
+echo "Task started: ${task_arn}"
+
+echo "Waiting for task to complete..."
+aws ecs wait tasks-stopped --cluster "${cluster_name}" --tasks "${task_arn}"
+
+echo "Checking task exit code..."
+# We try to match "emmy-app-migrate" or "app" as per the task definition update logic
+container_name=$(echo "${new_task_def}" | jq -r '.containerDefinitions[] | select(.name == "emmy-app-migrate" or .name == "app") | .name' | head -n 1)
+
+task_details=$(aws ecs describe-tasks --cluster "${cluster_name}" --tasks "${task_arn}" --query "tasks[0]" --output json)
+exit_code=$(echo "${task_details}" | jq -r ".containers[] | select(.name == \"${container_name}\") | .exitCode")
+
+if [ "${exit_code}" != "0" ]; then
+  echo "Error: Migration task failed with exit code ${exit_code}"
+  echo "Task details:"
+  echo "${task_details}" | jq '.'
+  exit 1
+fi
+
+echo "Migration task completed successfully."

--- a/bin/run-database-migrations-cms
+++ b/bin/run-database-migrations-cms
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Run database migrations for CMS
+# 1. Update the task definition emmy-{ENVIRONMENT}-migrate with the new image
+# 2. Run the task
+#
+# Positional parameters:
+#   environment (required) – the name of the application environment (e.g. dev,
+#     staging, prod)
+#   image_tag (required) – the tag of the latest build
+# -----------------------------------------------------------------------------
+
+environment="$1"
+image_tag="$2"
+
+echo "======================"
+echo "Running CMS migrations"
+echo "======================"
+echo "Input parameters"
+echo "  environment=${environment}"
+echo "  image_tag=${image_tag}"
+echo
+
+cluster_name="emmy-${environment}"
+task_def_family="emmy-${environment}-migrate"
+
+echo "Step 1. Update task definition ${task_def_family}"
+
+# Get the latest task definition
+current_task_def=$(aws ecs describe-task-definition --task-definition "${task_def_family}" --query 'taskDefinition' --output json)
+
+# Create a new task definition revision with the updated image
+# We assume the container name is "emmy-app" based on existing scripts, 
+# or we can update all container images if there are multiple.
+# Given the instructions, we just need to update the image to EMMY_IMAGE_TAG.
+# We'll need the repository URI. We can try to extract it from the current image.
+
+current_image=$(echo "${current_task_def}" | jq -r '.containerDefinitions[0].image')
+image_repo=$(echo "${current_image}" | cut -d':' -f1)
+
+echo "Updating image to ${image_repo}:${image_tag}"
+
+new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" '
+  del(.taskDefinitionArn) |
+  del(.revision) |
+  del(.status) |
+  del(.requiresAttributes) |
+  del(.compatibilities) |
+  del(.registeredAt) |
+  del(.registeredBy) |
+  (.containerDefinitions[] | select(.name == "emmy-app-migrate" or .name == "app")) .image = $IMAGE
+')
+
+new_task_def_arn=$(aws ecs register-task-definition --cli-input-json "${new_task_def}" --query 'taskDefinition.taskDefinitionArn' --output text)
+echo "Registered new task definition: ${new_task_def_arn}"
+
+echo
+echo "Step 2. Run migration task"
+
+# Get network configuration from the cluster or a service in the cluster
+# Since we don't have a service name for migrate task (it's just a task definition), 
+# we can try to find the "app" service to get the network config, similar to run-command.
+service_name="emmy-${environment}-app"
+network_config=$(aws ecs describe-services --cluster "${cluster_name}" --services "${service_name}" --query "services[0].networkConfiguration" --output json)
+
+aws ecs run-task \
+  --cluster "${cluster_name}" \
+  --task-definition "${new_task_def_arn}" \
+  --network-configuration "${network_config}" \
+  --launch-type FARGATE \
+  --started-by "migration-script"


### PR DESCRIPTION

## [FFS-4399](https://jiraent.cms.gov/browse/FFS-4399)

## Changes
Adds a new migration deploy action that doesnt rely on the terraform but can spin up a new migration task ad hoc.

- [ X ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)


Proof of testing:
Running CMS migrations
======================
Input parameters
  environment=dev
  image_tag=79794af67798cf8da2cebef31ed6bb7c97f51c9f

Step 1. Update task definition emmy-dev-migrate
Updating image to 162263641551.dkr.ecr.us-east-1.amazonaws.com/emmy-prod-app:79794af67798cf8da2cebef31ed6bb7c97f51c9f
Registered new task definition: arn:aws:ecs:us-east-1:554269192106:task-definition/emmy-dev-migrate:17

Step 2. Run migration task
Task started: arn:aws:ecs:us-east-1:554269192106:task/emmy-dev/d9dbb82ee94c4167a289699c7779915a
Waiting for task to complete...
Checking task exit code...
Migration task completed successfully.

