### PR TITLE
FFS-4444: updated timeout page content for NH pilot

### DIFF
--- a/app/app/views/cbv/sessions/timeout.html.erb
+++ b/app/app/views/cbv/sessions/timeout.html.erb
@@ -12,7 +12,7 @@
       </svg>
     </div>
     <div class="grid-col-fill">
-      <%= t("session_timeout.page.info_box", agency_full_name: agency_translation("shared.agency_full_name")) %>
+      <%= agency_translation("session_timeout.page.info_box", agency_full_name: agency_translation("shared.agency_full_name")) %>
     </div>
   </div>
 </div>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -1154,7 +1154,9 @@ en:
       heading: Do you need more time?
     page:
       description: Sessions end after 30 minutes of being away from the page. This helps keep your information safe.
-      info_box: To report your income, start again. Use the link %{agency_full_name} sent you in a text message.
+      info_box:
+        default: To report your income, start again. Use the link %{agency_full_name} sent you in a text message.
+        nh_dhhs: You were sent a unique link or QR code to use this income verification tool. Use the link or QR code originally sent to you to start over.
       start_over_html: If you can't find your link, <a href='%{link}' data-action='%{action}'>click here</a> to start over.
       title: Your session has timed out
   shared:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -615,7 +615,8 @@ es:
       heading: "¿Necesita más tiempo en la sesión?"
     page:
       description: Las sesiones terminan después de 30 minutos de inactividad. Esto ayuda a que su información esté segura.
-      info_box: Para reportar su ingreso, comience de nuevo. Use el enlace que %{agency_full_name} le envió en un mensaje de texto.
+      info_box:
+        default: Para reportar su ingreso, comience de nuevo. Use el enlace que %{agency_full_name} le envió en un mensaje de texto.
       start_over_html: Si no puede encontrar su enlace, <a href='%{link}' data-action='%{action}'>visite</a> para comenzar nuevamente.
       title: Su sesión ha terminado.
   shared:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -617,6 +617,7 @@ es:
       description: Las sesiones terminan después de 30 minutos de inactividad. Esto ayuda a que su información esté segura.
       info_box:
         default: Para reportar su ingreso, comience de nuevo. Use el enlace que %{agency_full_name} le envió en un mensaje de texto.
+        nh_dhhs: Se le envió un enlace único o un código QR para usar la herramienta de verificación de ingresos. Use ese enlace o el código QR que se le envió para comenzar de nuevo.
       start_over_html: Si no puede encontrar su enlace, <a href='%{link}' data-action='%{action}'>visite</a> para comenzar nuevamente.
       title: Su sesión ha terminado.
   shared:


### PR DESCRIPTION
## [FFS-4444](https://jiraent.cms.gov/browse/FFS-4444)

## Changes
New copy for NH in Emmy Income timeout flow (use the timeout setting on /launcher/advanced!)

## Testing instructions
Observe the change
Test in Spanish

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1789.navapbc.cloud/launcher/advanced
- Deployed commit: 4b29a2ea1fb3d355d331a9fa13140a89deff0708
<!-- end PR environment info -->

## Screenshot
<img width="631" height="419" alt="image" src="https://github.com/user-attachments/assets/a4e18ac8-c119-421d-9334-41f9b7b323a9" />