### PR TITLE
FFS-4433, FFS-4434: Fix Rick Banas education records not found when launched via the advanced launcher, Fix pre-populated activities not appearing on activity hub after advanced launcher selection

### DIFF
--- a/app/app/controllers/demo_launcher_controller.rb
+++ b/app/app/controllers/demo_launcher_controller.rb
@@ -174,9 +174,10 @@ class DemoLauncherController < ApplicationController
   end
 
   def reporting_window_months_for_activities(client_agency_id)
-    # Uses the agency's default application window regardless of the launcher's reporting_window
-    # setting, because ActivityFlowInvitation validates months against the same default range.
-    range = ActivityFlow.expected_reporting_window_range(client_agency_id)
+    range = ActivityFlow.expected_reporting_window_range(
+      client_agency_id,
+      **pre_populated_reporting_window_options(client_agency_id)
+    )
     months = []
     current = range.begin.beginning_of_month
     while current <= range.end
@@ -184,6 +185,38 @@ class DemoLauncherController < ApplicationController
       current = current.next_month
     end
     months
+  end
+
+  def pre_populated_reporting_window_options(client_agency_id)
+    reporting_window_type = launcher_params[:reporting_window] == "renewal" ? "renewal" : "application"
+    month_count = pre_populated_reporting_window_month_count(client_agency_id)
+    reference_date = Date.current
+
+    if launcher_params[:reporting_window_start].present?
+      start_date = Date.parse(normalize_date_param(launcher_params[:reporting_window_start])).beginning_of_month
+      reference_date = start_date + month_count.months
+    end
+
+    {
+      reporting_window_type: reporting_window_type,
+      reference_date: reference_date,
+      months_override: month_count
+    }
+  end
+
+  def pre_populated_reporting_window_month_count(client_agency_id)
+    return launcher_params[:reporting_window_months].to_i if launcher_params[:reporting_window_months].present?
+    return ActivityFlow::DEFAULT_RENEWAL_REPORTING_WINDOW_MONTHS if launcher_params[:reporting_window] == "renewal"
+
+    Rails.application.config.client_agencies[client_agency_id]&.application_reporting_months ||
+      ActivityFlow::DEFAULT_APPLICATION_REPORTING_WINDOW_MONTHS
+  end
+
+  def create_launcher_activity_flow_invitation!(attributes)
+    invitation = ActivityFlowInvitation.create!(attributes)
+    pre_populated = build_pre_populated_activities
+    invitation.update_columns(pre_populated_activities: pre_populated) if pre_populated.present?
+    invitation
   end
 
   def launch_overrides(flow_type)
@@ -279,11 +312,9 @@ class DemoLauncherController < ApplicationController
   end
 
   def build_tokenized_url(client_agency_id, overrides)
-    pre_populated = build_pre_populated_activities
-    invitation = ActivityFlowInvitation.create!(
+    invitation = create_launcher_activity_flow_invitation!(
       client_agency_id: client_agency_id,
-      reference_id: "demo-#{SecureRandom.hex(4)}",
-      pre_populated_activities: pre_populated
+      reference_id: "demo-#{SecureRandom.hex(4)}"
     )
     invitation.to_url(
       **launcher_url_options,
@@ -311,7 +342,7 @@ class DemoLauncherController < ApplicationController
       client_agency_id: client_agency_id
     )
 
-    invitation = ActivityFlowInvitation.create!(
+    invitation = create_launcher_activity_flow_invitation!(
       cbv_applicant: cbv_applicant,
       client_agency_id: client_agency_id,
       reference_id: "demo-#{scenario_key}"
@@ -334,7 +365,7 @@ class DemoLauncherController < ApplicationController
       client_agency_id: client_agency_id
     )
 
-    invitation = ActivityFlowInvitation.create!(
+    invitation = create_launcher_activity_flow_invitation!(
       cbv_applicant: cbv_applicant,
       client_agency_id: client_agency_id,
       reference_id: "demo-#{scenario_key}"

--- a/app/app/services/demo_launcher/nsc_forward_dating_service.rb
+++ b/app/app/services/demo_launcher/nsc_forward_dating_service.rb
@@ -1,7 +1,18 @@
 class DemoLauncher::NscForwardDatingService
+  DEMO_SCENARIO_KEYS = %w[lynette rick dominique linda].freeze
+  # These dates match each persona's latest term end so NSC reports them as currently enrolled before forward-dating.
+  DEMO_AS_OF_DATES = {
+    "lynette" => Date.new(2024, 11, 19),
+    "rick" => Date.new(2024, 11, 29)
+  }.freeze
+
   def self.applicable?(education_activity)
-    scenario_key = education_activity.activity_flow.activity_flow_invitation&.reference_id&.delete_prefix("demo-")
-    scenario_key.present? && DemoLauncherController::TEST_SCENARIOS.key?(scenario_key)
+    scenario_key = scenario_key_for(education_activity)
+    scenario_key.present? && DEMO_SCENARIO_KEYS.include?(scenario_key)
+  end
+
+  def self.scenario_key_for(education_activity)
+    education_activity.activity_flow.activity_flow_invitation&.reference_id&.delete_prefix("demo-")
   end
 
   def initialize(education_activity:, logger: Rails.logger, environment: ENV.fetch("NSC_ENVIRONMENT", "sandbox"))
@@ -10,7 +21,8 @@ class DemoLauncher::NscForwardDatingService
       education_activity: education_activity,
       logger: logger,
       environment: environment,
-      response_transformer: method(:forward_dated_response)
+      response_transformer: method(:forward_dated_response),
+      as_of_date: demo_as_of_date
     )
   end
 
@@ -19,6 +31,10 @@ class DemoLauncher::NscForwardDatingService
   end
 
   private
+
+  def demo_as_of_date
+    DEMO_AS_OF_DATES[self.class.scenario_key_for(@education_activity)]
+  end
 
   def forward_dated_response(response)
     latest_term_end = Array(response["enrollmentDetails"])

--- a/app/app/services/nsc_data_fetcher_service.rb
+++ b/app/app/services/nsc_data_fetcher_service.rb
@@ -15,12 +15,14 @@ class NscDataFetcherService
     education_activity:,
     logger: Rails.logger,
     environment: ENV.fetch("NSC_ENVIRONMENT", "sandbox"),
-    response_transformer: nil
+    response_transformer: nil,
+    as_of_date: nil
   )
     @education_activity = education_activity
     @logger = logger
     @service = Aggregators::Sdk::NscService.new(environment: environment, logger: logger)
     @response_transformer = response_transformer
+    @as_of_date = as_of_date
   end
 
   # Main entry pont to submit an enrollment request to NSC
@@ -30,7 +32,7 @@ class NscDataFetcherService
       first_name: identity.first_name,
       last_name: identity.last_name,
       date_of_birth: identity.date_of_birth,
-      as_of_date: @education_activity.activity_flow.reporting_window_range.max
+      as_of_date: @as_of_date || @education_activity.activity_flow.reporting_window_range.max
     )
     response = transform_response(response)
     update_education_activity(@education_activity, response)

--- a/app/spec/controllers/demo_launcher_controller_spec.rb
+++ b/app/spec/controllers/demo_launcher_controller_spec.rb
@@ -436,6 +436,27 @@ RSpec.describe DemoLauncherController, type: :controller do
         expect(location).to include("demo_timeout=20")
       end
 
+      it "preserves pre-populated activities for Rick" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          test_scenario: "rick",
+          reporting_window: "application",
+          education_enabled: "1",
+          education_school_name: "Springfield Community College",
+          education_hours_per_month: "6"
+        }
+
+        invitation = ActivityFlowInvitation.last
+        activity = invitation.pre_populated_activities.first
+
+        expect(invitation.reference_id).to eq("demo-rick")
+        expect(activity).to include(
+          "type" => "education",
+          "school_name" => "Springfield Community College"
+        )
+        expect(activity["months"]).to all(include("hours" => 6))
+      end
+
       it "raises an error for an unknown test scenario" do
         expect {
           post :create, params: {
@@ -592,6 +613,26 @@ RSpec.describe DemoLauncherController, type: :controller do
         expect(response).to redirect_to(%r{/activities/start/#{invitation.auth_token}})
         expect(response.location).to include("reporting_window_start=2025-06-01")
       end
+
+      it "preserves pre-populated activities for a fake test user" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          test_scenario: "partial_enrollment_sam",
+          volunteering_enabled: "1",
+          volunteering_organization_name: "Food Bank",
+          volunteering_hours_per_month: "8"
+        }
+
+        invitation = ActivityFlowInvitation.last
+        activity = invitation.pre_populated_activities.first
+
+        expect(invitation.reference_id).to eq("demo-partial_enrollment_sam")
+        expect(activity).to include(
+          "type" => "volunteering",
+          "organization_name" => "Food Bank"
+        )
+        expect(activity["months"]).to all(include("hours" => 8))
+      end
     end
 
     context "with pre-populated activities" do
@@ -675,6 +716,43 @@ RSpec.describe DemoLauncherController, type: :controller do
         expect(activities[0]["program_name"]).to eq("Career Prep")
         expect(activities[0]["organization_name"]).to eq("Goodwill")
         expect(activities[0]["months"]).to all(include("hours" => 10))
+      end
+
+      it "uses the selected reporting window for pre-populated work program months" do
+        Timecop.freeze(Date.new(2026, 6, 13)) do
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "tokenized",
+            reporting_window: "application",
+            reporting_window_months: "6",
+            job_training_enabled: "1",
+            job_training_program_name: "Career Prep",
+            job_training_organization_name: "Goodwill",
+            job_training_hours_per_month: "10"
+          }
+
+          activities = ActivityFlowInvitation.last.pre_populated_activities
+          months = activities.first["months"].map { |month| month["month"] }
+          expect(months).to eq(%w[2025-12-01 2026-01-01 2026-02-01 2026-03-01 2026-04-01 2026-05-01])
+        end
+      end
+
+      it "uses the selected reporting window start for pre-populated work program months" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "tokenized",
+          reporting_window: "application",
+          reporting_window_months: "3",
+          reporting_window_start: "07/01/2025",
+          job_training_enabled: "1",
+          job_training_program_name: "Career Prep",
+          job_training_organization_name: "Goodwill",
+          job_training_hours_per_month: "10"
+        }
+
+        activities = ActivityFlowInvitation.last.pre_populated_activities
+        months = activities.first["months"].map { |month| month["month"] }
+        expect(months).to eq(%w[2025-07-01 2025-08-01 2025-09-01])
       end
 
       it "creates an invitation with all activity types when all are enabled" do

--- a/app/spec/factories/identity.rb
+++ b/app/spec/factories/identity.rb
@@ -28,5 +28,11 @@ FactoryBot.define do
       last_name { "Banas" }
       date_of_birth { "1979-08-18" }
     end
+
+    trait :nsc_dominique do
+      first_name { "Dominique" }
+      last_name { "Ricardo" }
+      date_of_birth { "1978-01-12" }
+    end
   end
 end

--- a/app/spec/services/demo_launcher/nsc_forward_dating_service_spec.rb
+++ b/app/spec/services/demo_launcher/nsc_forward_dating_service_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe DemoLauncher::NscForwardDatingService do
   subject(:service) { described_class.new(education_activity: education_activity, environment: :test, logger: logger) }
 
   let(:logger) { Logger.new(StringIO.new) }
-  let(:identity) do
-    create(
-      :identity,
-      first_name: first_name,
-      last_name: last_name,
-      date_of_birth: date_of_birth
-    )
-  end
   let(:invitation) { create(:activity_flow_invitation, reference_id: "demo-#{scenario_key}") }
   let(:activity_flow) do
     create(
@@ -42,9 +34,7 @@ RSpec.describe DemoLauncher::NscForwardDatingService do
   describe "#fetch" do
     context "for Lynette" do
       let(:scenario_key) { "lynette" }
-      let(:first_name) { "Lynette" }
-      let(:last_name) { "Oyola" }
-      let(:date_of_birth) { Date.parse("1988-10-24") }
+      let(:identity) { create(:identity, :nsc_lynette) }
 
       before do
         nsc_stub_request_education_search_response("lynette")
@@ -59,13 +49,19 @@ RSpec.describe DemoLauncher::NscForwardDatingService do
         expect(term.term_end).to eq(activity_flow.reporting_window_range.max)
         expect(activity_flow.within_reporting_window?(term.term_begin, term.term_end)).to be(true)
       end
+
+      it "queries NSC with Lynette's stable demo as-of date" do
+        service.fetch
+
+        expect(WebMock)
+          .to have_requested(:post, %r{#{Aggregators::Sdk::NscService::ENROLLMENT_ENDPOINT}})
+          .with(body: hash_including("asOfDate" => "2024-11-19"))
+      end
     end
 
     context "for Rick" do
       let(:scenario_key) { "rick" }
-      let(:first_name) { "Rick" }
-      let(:last_name) { "Banas" }
-      let(:date_of_birth) { Date.parse("1979-08-18") }
+      let(:identity) { create(:identity, :nsc_rick) }
 
       before do
         nsc_stub_request_education_search_response("rick_banas")
@@ -83,19 +79,42 @@ RSpec.describe DemoLauncher::NscForwardDatingService do
         expect((terms.last.term_begin - terms.first.term_begin).to_i).to eq(19)
         expect(terms).to all(satisfy { |term| activity_flow.within_reporting_window?(term.term_begin, term.term_end) })
       end
+
+      it "queries NSC with Rick's stable demo as-of date" do
+        service.fetch
+
+        expect(WebMock)
+          .to have_requested(:post, %r{#{Aggregators::Sdk::NscService::ENROLLMENT_ENDPOINT}})
+          .with(body: hash_including("asOfDate" => "2024-11-29"))
+      end
     end
 
     context "for a demo user with no current enrollments" do
       let(:scenario_key) { "linda" }
-      let(:first_name) { "Linda" }
-      let(:last_name) { "Cooper" }
-      let(:date_of_birth) { Date.parse("1999-01-01") }
+      let(:identity) { create(:identity, :nsc_linda) }
 
       before do
         nsc_stub_request_education_search_response("linda")
       end
 
       it "preserves the no-enrollments result" do
+        expect { service.fetch }
+          .to change { education_activity.reload.status }
+          .from("unknown").to("no_enrollments")
+
+        expect(education_activity.nsc_enrollment_terms).to be_empty
+      end
+    end
+
+    context "for Dominique" do
+      let(:scenario_key) { "dominique" }
+      let(:identity) { create(:identity, :nsc_dominique) }
+
+      before do
+        nsc_stub_request_education_search_response("dominique_ricardo")
+      end
+
+      it "preserves the no-enrollments result for CN enrollments" do
         expect { service.fetch }
           .to change { education_activity.reload.status }
           .from("unknown").to("no_enrollments")

--- a/app/spec/services/nsc_data_fetcher_service_spec.rb
+++ b/app/spec/services/nsc_data_fetcher_service_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe NscDataFetcherService do
 
         expect(education_activity.reload.data_source).to eq("partially_self_attested")
       end
+
+      it "queries NSC with the reporting window end date" do
+        service.fetch
+
+        expect(WebMock)
+          .to have_requested(:post, %r{#{Aggregators::Sdk::NscService::ENROLLMENT_ENDPOINT}})
+          .with(body: hash_including("asOfDate" => activity_flow.reporting_window_range.max.strftime("%Y-%m-%d")))
+      end
     end
 
     context "when there are multiple enrollments (Rick)" do


### PR DESCRIPTION
## [FFS-4433](https://jiraent.cms.gov/browse/FFS-4433)
## [FFS-4434](https://jiraent.cms.gov/browse/FFS-4434)

## Changes
- Rick Bananas and other NSC test users function again
- Pre-populated skeleton activities now work in coordination with any test user
- Pre-populated skeleton activity months now have a configurable reporting window in the launcher

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1790.navapbc.cloud/launcher/advanced
- Deployed commit: fa67433697bc0bdcef13cedcee33b41d797ba50c
<!-- end PR environment info -->