### PR TITLE
No ticket: add AI disclosure to PR template, delete top comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
-<!-- ---------------------------------------------------------------------------
-Some examples of good, understandable PR titles:
-
-FFS-1111: Fix missing translation on /entry page
-FFS-2222: Implement invitation reminder emails
-
-(The title of the pull request will be used in the eventual deploy log - so it's helpful to format the title to be understandable by other disciplines if possible.)
---------------------------------------------------------------------------- -->
 ## [FFS-XXXX](https://jiraent.cms.gov/browse/FFS-XXXX)
 
 ## Changes
@@ -28,6 +20,14 @@ Tag product and design in Slack for acceptance: @emmy-acceptance-testers
   * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
   * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
 
+## AI Usage
+- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
+- [ ] NO_AI: I did not use AI.
+
+Optional — for learning, not audited:
+- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
+- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
+
 ## Infrastructure Changes
 <!-- If this PR includes Terraform changes, please provide relevant info. -->
   - [ ] Plan reviewed
@@ -35,5 +35,5 @@ Tag product and design in Slack for acceptance: @emmy-acceptance-testers
   - [ ] Applied in demo after merge
   - [ ] Applied in prod after merge (note any exceptions or special coordination below)
 
-**Risk / Downtime:**
+## **Risk / Downtime:**
 <!-- Note exceptions, potential downtime, or required coordination -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Tag product and design in Slack for acceptance: @emmy-acceptance-testers
   * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
 
 ## AI Usage
-- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
+- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
 - [ ] NO_AI: I did not use AI.
 
 Optional — for learning, not audited:

--- a/.github/workflows/ai-disclosure-check.yml
+++ b/.github/workflows/ai-disclosure-check.yml
@@ -1,0 +1,39 @@
+name: AI Disclosure Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  ai-disclosure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify AI disclosure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const lines = body.split(/\r?\n/);
+
+            const isChecked = (label) => {
+              const line = lines.find(l => l.includes(label + ":"));
+              return !!line && /^\s*-\s*\[x\]/i.test(line);
+            };
+
+            const usedAI = isChecked("USED_AI");
+            const noAI   = isChecked("NO_AI");
+
+            if (!usedAI && !noAI) {
+              core.setFailed(
+                "AI disclosure required: check either USED_AI or NO_AI in the " +
+                "AI Usage section of the PR description."
+              );
+              return;
+            }
+
+            if (usedAI && noAI) {
+              core.setFailed(
+                "Both USED_AI and NO_AI are checked — please check only one."
+              );
+              return;
+            }

--- a/.github/workflows/ai-disclosure-check.yml
+++ b/.github/workflows/ai-disclosure-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   ai-disclosure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## No ticket

## Changes
* Add an AI disclosure to our PR template
* Removed the top comment, which I just delete without reading every time anyway (open to debate)

## Context for reviewers
As we experiment more with AI, I'd like us to document our AI usage in each PR.

## Testing instructions
* Use [this branch](https://github.com/DSACMS/iv-cbv-payroll/pull/1793) to play with whether the GHA works
* Try checking the AI disclosure, unchecking it, deleting it, etc.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)