### PR TITLE
FFS-4425: Enable specific agencies to run in an iframe

### DIFF
--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
   helper :view
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
-  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :configure_iframe_embedding, :set_device_id_cookie
-  after_action :apply_iframe_embedding_headers
+  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :set_device_id_cookie
+  after_action :apply_iframe_embedding
 
   rescue_from ActionController::InvalidAuthenticityToken do
     redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
@@ -49,24 +49,28 @@ class ApplicationController < ActionController::Base
     { same_site: :none, secure: true }
   end
 
-  # Relax the session cookie's SameSite attribute for embedding agencies so the
-  # session persists when the app is loaded inside a cross-origin iframe.
-  def configure_iframe_embedding
-    return unless iframe_embedding_allowed?
-
-    iframe_cookie_options.each { |key, value| request.session_options[key] = value }
-  end
-
-  # Widen CSP `frame-ancestors` and drop the default `X-Frame-Options:
-  # SAMEORIGIN` for embedding agencies so the configured parents can frame us.
-  # Done in an after_action because the agency may only be resolvable once the controller
-  # has loaded the flow
-  def apply_iframe_embedding_headers
+  # Relax framing policy and cookies for embedding agencies. Done in an
+  # after_action because the agency may only be resolvable once the controller
+  # has loaded the flow (e.g. the tokenized `/start/:token` entry, where
+  # `current_agency` is still nil during the before_actions). The session and
+  # device-id cookies are committed by middleware *after* this runs, so setting
+  # `session_options` and re-issuing the device-id cookie here still takes
+  # effect on the emitted `Set-Cookie` headers.
+  def apply_iframe_embedding
     return if current_agency&.allowed_iframe_ancestors.blank?
+
+    # Reissue the session and device-id cookies as `SameSite=None; Secure` so
+    # they survive inside a cross-origin iframe (no-op off SSL).
+    if (cookie_options = iframe_cookie_options).present?
+      cookie_options.each { |key, value| request.session_options[key] = value }
+      if (device_id = cookies.permanent.signed[:device_id]).present?
+        cookies.permanent.signed[:device_id] = { value: device_id, httponly: true, **cookie_options }
+      end
+    end
 
     if (policy = request.content_security_policy)
       request.content_security_policy = policy.clone.tap do |cloned|
-        cloned.frame_ancestors(:self, *current_agency&.allowed_iframe_ancestors)
+        cloned.frame_ancestors(:self, *current_agency.allowed_iframe_ancestors)
       end
     end
     response.headers.delete("X-Frame-Options")

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -3,12 +3,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
   before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :configure_iframe_embedding, :set_device_id_cookie
-  after_action :relax_frame_options_for_iframe
-
-  content_security_policy do |policy|
-    ancestors = current_agency&.allowed_iframe_ancestors
-    policy.frame_ancestors(:self, *ancestors) if ancestors.present?
-  end
+  after_action :apply_iframe_embedding_headers
 
   rescue_from ActionController::InvalidAuthenticityToken do
     redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
@@ -62,9 +57,18 @@ class ApplicationController < ActionController::Base
     iframe_cookie_options.each { |key, value| request.session_options[key] = value }
   end
 
-  def relax_frame_options_for_iframe
-    return unless iframe_embedding_allowed?
+  # Widen CSP `frame-ancestors` and drop the default `X-Frame-Options:
+  # SAMEORIGIN` for embedding agencies so the configured parents can frame us.
+  # Done in an after_action because the agency may only be resolvable once the controller
+  # has loaded the flow
+  def apply_iframe_embedding_headers
+    return if current_agency&.allowed_iframe_ancestors.blank?
 
+    if (policy = request.content_security_policy)
+      request.content_security_policy = policy.clone.tap do |cloned|
+        cloned.frame_ancestors(:self, *current_agency&.allowed_iframe_ancestors)
+      end
+    end
     response.headers.delete("X-Frame-Options")
   end
 

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -45,9 +45,11 @@ class ApplicationController < ActionController::Base
 
   # Cross-origin iframes only send cookies marked `SameSite=None; Secure`.
   # Scope this relaxation to agencies that opt in to embedding so other
-  # agencies keep the stricter `SameSite=Lax` default.
+  # agencies keep the stricter `SameSite=Lax` default. `Secure` requires HTTPS,
+  # so only relax over SSL; otherwise the browser drops the cookie and the
+  # session is lost (e.g. E2E/dev served over plain HTTP).
   def iframe_cookie_options
-    return {} unless iframe_embedding_allowed?
+    return {} unless iframe_embedding_allowed? && request.ssl?
 
     { same_site: :none, secure: true }
   end
@@ -90,11 +92,15 @@ class ApplicationController < ActionController::Base
       return @current_agency
     end
 
+    # Don't memoize the domain fallback: it may be resolved during an early
+    # before_action (e.g. iframe/device-id setup) before @cbv_flow is set, and
+    # memoizing here would prevent current_agency from later resolving to the
+    # flow's agency.
     if client_agency_from_domain.present?
-      @current_agency = agency_config[client_agency_from_domain]
+      return agency_config[client_agency_from_domain]
     end
 
-    @current_agency
+    nil
   end
 
   def session_timeout_enabled?

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -126,12 +126,14 @@ class ApplicationController < ActionController::Base
   end
 
   def client_agency_from_domain
-    return nil unless request.host.present?
+    return @client_agency_from_domain if defined?(@client_agency_from_domain)
 
-    agency_config.client_agency_ids.find do |agency_id|
-      agency = agency_config[agency_id]
-      agency.agency_domain == request.host
-    end
+    @client_agency_from_domain =
+      if request.host.present?
+        agency_config.client_agency_ids.find do |agency_id|
+          agency_config[agency_id].agency_domain == request.host
+        end
+      end
   end
 
   def pilot_ended?

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
   before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :configure_iframe_embedding, :set_device_id_cookie
+  after_action :relax_frame_options_for_iframe
 
   content_security_policy do |policy|
     ancestors = current_agency&.allowed_iframe_ancestors
@@ -57,6 +58,12 @@ class ApplicationController < ActionController::Base
     return unless iframe_embedding_allowed?
 
     iframe_cookie_options.each { |key, value| request.session_options[key] = value }
+  end
+
+  def relax_frame_options_for_iframe
+    return unless iframe_embedding_allowed?
+
+    response.headers.delete("X-Frame-Options")
   end
 
   def show_menu?

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -2,7 +2,12 @@ class ApplicationController < ActionController::Base
   helper :view
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
-  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :set_device_id_cookie
+  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :configure_iframe_embedding, :set_device_id_cookie
+
+  content_security_policy do |policy|
+    ancestors = current_agency&.allowed_iframe_ancestors
+    policy.frame_ancestors(:self, *ancestors) if ancestors.present?
+  end
 
   rescue_from ActionController::InvalidAuthenticityToken do
     redirect_to root_url, flash: { slim_alert: { type: "info", message_html: t("cbv.error_missing_token_html") } }
@@ -27,8 +32,31 @@ class ApplicationController < ActionController::Base
   def set_device_id_cookie
     cookies.permanent.signed[:device_id] ||= {
       value: SecureRandom.uuid,
-      httponly: true
+      httponly: true,
+      **iframe_cookie_options
     }
+  end
+
+  # True when the current agency is configured to permit iframe embedding.
+  def iframe_embedding_allowed?
+    current_agency&.allowed_iframe_ancestors.present?
+  end
+
+  # Cross-origin iframes only send cookies marked `SameSite=None; Secure`.
+  # Scope this relaxation to agencies that opt in to embedding so other
+  # agencies keep the stricter `SameSite=Lax` default.
+  def iframe_cookie_options
+    return {} unless iframe_embedding_allowed?
+
+    { same_site: :none, secure: true }
+  end
+
+  # Relax the session cookie's SameSite attribute for embedding agencies so the
+  # session persists when the app is loaded inside a cross-origin iframe.
+  def configure_iframe_embedding
+    return unless iframe_embedding_allowed?
+
+    iframe_cookie_options.each { |key, value| request.session_options[key] = value }
   end
 
   def show_menu?

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -140,6 +140,9 @@
     work_programs: true
     employment: true
   prefilled_activities_enabled: true
+  allowed_iframe_ancestors:
+    - http://localhost:8000
+    - https://dsacms.github.io
 
 - id: research
   agency_name: Example State Department of Health

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -141,8 +141,10 @@
     employment: true
   prefilled_activities_enabled: true
   allowed_iframe_ancestors:
-    - http://localhost:8000
     - https://dsacms.github.io
+# Uncomment for local testing:
+#    - http://localhost:8000
+#    - https://*.ngrok-free.app
 
 - id: research
   agency_name: Example State Department of Health

--- a/app/config/environments/development.rb
+++ b/app/config/environments/development.rb
@@ -77,6 +77,11 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  # Allow Action Cable from any origin only when iframe embedding is enabled for
+  # some agency. Embedded/ngrok pages connect from a non-localhost origin, which
+  # the default dev allowed_request_origins (localhost only) would reject.
+  iframe_embedding_enabled = config.client_agencies.client_agency_ids.any? do |agency_id|
+    config.client_agencies[agency_id].allowed_iframe_ancestors.present?
+  end
+  config.action_cable.disable_request_forgery_protection = true if iframe_embedding_enabled
 end

--- a/app/config/initializers/ngrok_development.rb
+++ b/app/config/initializers/ngrok_development.rb
@@ -9,6 +9,14 @@ Rails.application.config.to_prepare do
       tunnel_url = tunnels.first["public_url"]
       Rails.logger.info "Found ngrok tunnel at #{tunnel_url}!"
 
+      # Point the sandbox agency at this machine's current ngrok host so it
+      # resolves the agency by domain when accessed or embedded over ngrok
+      sandbox_agency = Rails.application.config.client_agencies["sandbox"]
+      if sandbox_agency
+        sandbox_agency.instance_variable_set(:@agency_domain, URI(tunnel_url).host)
+        Rails.logger.info "Set sandbox agency_domain to #{sandbox_agency.agency_domain} for ngrok"
+      end
+
       subscription_name = ENV["USER"]
       raise "USER environment variable not specified" unless subscription_name.present?
 

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -64,6 +64,7 @@ class ClientAgencyConfig
       generic_links_disabled
       activity_types
       prefilled_activities_enabled
+      allowed_iframe_ancestors
     ])
 
     def initialize(yaml)
@@ -96,8 +97,10 @@ class ClientAgencyConfig
       @activity_types = yaml["activity_types"]&.symbolize_keys || {}
       @prefilled_activities_enabled = yaml["prefilled_activities_enabled"] || false
       @caseworker_fallback_email = yaml["caseworker_fallback_email"]
+      @allowed_iframe_ancestors = yaml["allowed_iframe_ancestors"] || []
 
       raise ArgumentError.new("Client Agency missing id") if @id.blank?
+      raise ArgumentError.new("Client Agency #{@id} `allowed_iframe_ancestors` must be a list") unless @allowed_iframe_ancestors.is_a?(Array)
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `agency_name`") if @agency_name.blank?
       raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.w2") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:w2])
       raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.gig") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:gig])

--- a/app/spec/lib/client_agency_config_spec.rb
+++ b/app/spec/lib/client_agency_config_spec.rb
@@ -55,6 +55,72 @@ RSpec.describe ClientAgencyConfig do
         config = described_class.new(sample_config_path)
         expect(config["foo"].renewal_required_months).to eq(2)
       end
+
+      it "defaults allowed_iframe_ancestors to an empty array" do
+        config = described_class.new(sample_config_path)
+        expect(config["foo"].allowed_iframe_ancestors).to eq([])
+      end
+    end
+  end
+
+  context "allowed_iframe_ancestors configuration" do
+    describe "#allowed_iframe_ancestors" do
+      context "when given a YAML list" do
+        let(:sample_config) { <<~YAML }
+          - id: foo
+            agency_name: Foo Agency Name
+            pinwheel:
+              environment: foo
+            argyle:
+              environment: foo
+            transmission_method: foo
+            allowed_iframe_ancestors:
+              - https://example-portal.com
+              - https://partner.gov
+        YAML
+
+        it "returns the list of origins" do
+          config = described_class.new(sample_config_path)
+          expect(config["foo"].allowed_iframe_ancestors)
+            .to eq([ "https://example-portal.com", "https://partner.gov" ])
+        end
+      end
+
+      context "when not a list (e.g. a string)" do
+        let(:sample_config) { <<~YAML }
+          - id: foo
+            agency_name: Foo Agency Name
+            pinwheel:
+              environment: foo
+            argyle:
+              environment: foo
+            transmission_method: foo
+            allowed_iframe_ancestors: "https://example-portal.com"
+        YAML
+
+        it "raises an error" do
+          expect do
+            described_class.new(sample_config_path)
+          end.to raise_error(ArgumentError, "Client Agency foo `allowed_iframe_ancestors` must be a list")
+        end
+      end
+
+      context "when omitted" do
+        let(:sample_config) { <<~YAML }
+          - id: foo
+            agency_name: Foo Agency Name
+            pinwheel:
+              environment: foo
+            argyle:
+              environment: foo
+            transmission_method: foo
+        YAML
+
+        it "returns an empty array" do
+          config = described_class.new(sample_config_path)
+          expect(config["foo"].allowed_iframe_ancestors).to eq([])
+        end
+      end
     end
   end
 

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe "Iframe embedding", type: :request do
         expect(response.headers["Content-Security-Policy"])
           .to include("frame-ancestors 'self' https://portal.example.com")
       end
+
+      it "removes the X-Frame-Options header that would otherwise block framing" do
+        get path
+
+        expect(response.headers).not_to include("X-Frame-Options")
+      end
     end
 
     context "when the agency does not permit iframe embedding" do
@@ -30,6 +36,39 @@ RSpec.describe "Iframe embedding", type: :request do
         csp = response.headers["Content-Security-Policy"]
         expect(csp).to include("frame-ancestors 'self'")
         expect(csp).not_to include("portal.example.com")
+      end
+
+      it "keeps the X-Frame-Options header" do
+        get path
+
+        expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
+      end
+    end
+  end
+
+  describe "session cookie SameSite" do
+    context "when the agency permits iframe embedding" do
+      before do
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ "https://portal.example.com" ])
+      end
+
+      it "issues the session cookie as SameSite=None; Secure so it survives a cross-site iframe" do
+        get path
+
+        expect(request.session_options[:same_site]).to eq(:none)
+        expect(request.session_options[:secure]).to be(true)
+      end
+    end
+
+    context "when the agency does not permit iframe embedding" do
+      before do
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [])
+      end
+
+      it "does not relax the session cookie SameSite" do
+        get path
+
+        expect(request.session_options[:same_site]).not_to eq(:none)
       end
     end
   end

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe "Iframe embedding", type: :request do
   let(:path) { "/help?client_agency_id=sandbox" }
   let(:allowed_iframe_ancestor) { "https://portal.example.com" }
 
+  def cookie_named(name)
+    set_cookie = response.headers["Set-Cookie"]
+    cookies = set_cookie.is_a?(Array) ? set_cookie : set_cookie.to_s.split("\n")
+    cookies.find { |c| c.start_with?(name) }.to_s
+  end
+
+  def session_cookie
+    cookie_named("_iv_cbv_payroll_session")
+  end
+
   describe "entering via the tokenized link" do
     let(:invitation) { create(:cbv_flow_invitation, :sandbox) }
 
@@ -21,6 +31,15 @@ RSpec.describe "Iframe embedding", type: :request do
           .to include("frame-ancestors 'self' #{allowed_iframe_ancestor}")
         expect(response.headers).not_to include("X-Frame-Options")
       end
+
+      it "relaxes the session and device-id cookies to SameSite=None; Secure on the token path" do
+        get "/start/#{invitation.auth_token}", env: { "HTTPS" => "on" }
+
+        expect(session_cookie).to match(/samesite=none/i)
+        expect(session_cookie).to match(/;\s*secure/i)
+        expect(cookie_named("device_id")).to match(/samesite=none/i)
+        expect(cookie_named("device_id")).to match(/;\s*secure/i)
+      end
     end
 
     context "when the agency does not permit iframe embedding" do
@@ -34,16 +53,16 @@ RSpec.describe "Iframe embedding", type: :request do
         expect(response.headers["Content-Security-Policy"]).to include("frame-ancestors 'self'")
         expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
       end
+
+      it "keeps the session cookie at the stricter SameSite default on the token path" do
+        get "/start/#{invitation.auth_token}", env: { "HTTPS" => "on" }
+
+        expect(session_cookie).not_to match(/samesite=none/i)
+      end
     end
   end
 
   describe "session cookie SameSite" do
-    def session_cookie
-      set_cookie = response.headers["Set-Cookie"]
-      cookies = set_cookie.is_a?(Array) ? set_cookie : set_cookie.to_s.split("\n")
-      cookies.find { |c| c.start_with?("_iv_cbv_payroll_session") }.to_s
-    end
-
     context "when the agency permits iframe embedding" do
       before do
         stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ allowed_iframe_ancestor ])

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe "Iframe embedding", type: :request do
   end
 
   describe "session cookie SameSite" do
+    # Assert on the emitted Set-Cookie header (what the browser actually
+    # enforces), not just request.session_options.
+    def session_cookie
+      Array(response.headers["Set-Cookie"]).find { |c| c.start_with?("_iv_cbv_payroll_session") }.to_s
+    end
+
     context "when the agency permits iframe embedding" do
       before do
         stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ allowed_iframe_ancestor ])
@@ -46,14 +52,14 @@ RSpec.describe "Iframe embedding", type: :request do
       it "issues the session cookie as SameSite=None; Secure so it survives a cross-site iframe" do
         get path, env: { "HTTPS" => "on" }
 
-        expect(request.session_options[:same_site]).to eq(:none)
-        expect(request.session_options[:secure]).to be(true)
+        expect(session_cookie).to match(/samesite=none/i)
+        expect(session_cookie).to match(/;\s*secure/i)
       end
 
       it "does not set Secure cookies over plain HTTP, which the browser would drop" do
         get path
 
-        expect(request.session_options[:same_site]).not_to eq(:none)
+        expect(session_cookie).not_to match(/samesite=none/i)
       end
     end
 
@@ -65,7 +71,7 @@ RSpec.describe "Iframe embedding", type: :request do
       it "does not relax the session cookie SameSite" do
         get path, env: { "HTTPS" => "on" }
 
-        expect(request.session_options[:same_site]).not_to eq(:none)
+        expect(session_cookie).not_to match(/samesite=none/i)
       end
     end
   end

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -4,23 +4,21 @@ RSpec.describe "Iframe embedding", type: :request do
   # Use a lightweight, agency-scoped page that resolves `current_agency` from
   # the `client_agency_id` query param and renders without creating a flow.
   let(:path) { "/help?client_agency_id=sandbox" }
+  let(:allowed_iframe_ancestor) { "https://portal.example.com" }
 
-  describe "Content-Security-Policy frame-ancestors" do
+  describe "entering via the tokenized link" do
+    let(:invitation) { create(:cbv_flow_invitation, :sandbox) }
+
     context "when the agency permits iframe embedding" do
       before do
-        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ "https://portal.example.com" ])
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ allowed_iframe_ancestor ])
       end
 
-      it "allows the configured parent origins" do
-        get path
+      it "applies the embedding headers on the token-resolved page" do
+        get "/start/#{invitation.auth_token}"
 
         expect(response.headers["Content-Security-Policy"])
-          .to include("frame-ancestors 'self' https://portal.example.com")
-      end
-
-      it "removes the X-Frame-Options header that would otherwise block framing" do
-        get path
-
+          .to include("frame-ancestors 'self' #{allowed_iframe_ancestor}")
         expect(response.headers).not_to include("X-Frame-Options")
       end
     end
@@ -30,17 +28,10 @@ RSpec.describe "Iframe embedding", type: :request do
         stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [])
       end
 
-      it "restricts framing to the same origin" do
-        get path
+      it "keeps framing locked down" do
+        get "/start/#{invitation.auth_token}"
 
-        csp = response.headers["Content-Security-Policy"]
-        expect(csp).to include("frame-ancestors 'self'")
-        expect(csp).not_to include("portal.example.com")
-      end
-
-      it "keeps the X-Frame-Options header" do
-        get path
-
+        expect(response.headers["Content-Security-Policy"]).to include("frame-ancestors 'self'")
         expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
       end
     end
@@ -49,7 +40,7 @@ RSpec.describe "Iframe embedding", type: :request do
   describe "session cookie SameSite" do
     context "when the agency permits iframe embedding" do
       before do
-        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ "https://portal.example.com" ])
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ allowed_iframe_ancestor ])
       end
 
       it "issues the session cookie as SameSite=None; Secure so it survives a cross-site iframe" do

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe "Iframe embedding", type: :request do
   end
 
   describe "session cookie SameSite" do
-    # Assert on the emitted Set-Cookie header (what the browser actually
-    # enforces), not just request.session_options.
     def session_cookie
-      Array(response.headers["Set-Cookie"]).find { |c| c.start_with?("_iv_cbv_payroll_session") }.to_s
+      set_cookie = response.headers["Set-Cookie"]
+      cookies = set_cookie.is_a?(Array) ? set_cookie : set_cookie.to_s.split("\n")
+      cookies.find { |c| c.start_with?("_iv_cbv_payroll_session") }.to_s
     end
 
     context "when the agency permits iframe embedding" do

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -53,10 +53,16 @@ RSpec.describe "Iframe embedding", type: :request do
       end
 
       it "issues the session cookie as SameSite=None; Secure so it survives a cross-site iframe" do
-        get path
+        get path, env: { "HTTPS" => "on" }
 
         expect(request.session_options[:same_site]).to eq(:none)
         expect(request.session_options[:secure]).to be(true)
+      end
+
+      it "does not set Secure cookies over plain HTTP, which the browser would drop" do
+        get path
+
+        expect(request.session_options[:same_site]).not_to eq(:none)
       end
     end
 
@@ -66,7 +72,7 @@ RSpec.describe "Iframe embedding", type: :request do
       end
 
       it "does not relax the session cookie SameSite" do
-        get path
+        get path, env: { "HTTPS" => "on" }
 
         expect(request.session_options[:same_site]).not_to eq(:none)
       end

--- a/app/spec/requests/iframe_embedding_spec.rb
+++ b/app/spec/requests/iframe_embedding_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Iframe embedding", type: :request do
+  # Use a lightweight, agency-scoped page that resolves `current_agency` from
+  # the `client_agency_id` query param and renders without creating a flow.
+  let(:path) { "/help?client_agency_id=sandbox" }
+
+  describe "Content-Security-Policy frame-ancestors" do
+    context "when the agency permits iframe embedding" do
+      before do
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [ "https://portal.example.com" ])
+      end
+
+      it "allows the configured parent origins" do
+        get path
+
+        expect(response.headers["Content-Security-Policy"])
+          .to include("frame-ancestors 'self' https://portal.example.com")
+      end
+    end
+
+    context "when the agency does not permit iframe embedding" do
+      before do
+        stub_client_agency_config_value("sandbox", "allowed_iframe_ancestors", [])
+      end
+
+      it "restricts framing to the same origin" do
+        get path
+
+        csp = response.headers["Content-Security-Policy"]
+        expect(csp).to include("frame-ancestors 'self'")
+        expect(csp).not_to include("portal.example.com")
+      end
+    end
+  end
+end

--- a/docs/iframe-test-harness.html
+++ b/docs/iframe-test-harness.html
@@ -1,55 +1,102 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Emmy iframe embedding test harness</title>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 0; color: #1b1b1b; }
-    header { padding: 1rem; border-bottom: 1px solid #d6d7d9; background: #f0f0f0; }
-    h1 { font-size: 1.1rem; margin: 0 0 .5rem; }
-    form { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; }
-    input[type="url"] { flex: 1 1 30rem; padding: .4rem; font-size: 1rem; }
-    button { padding: .4rem .9rem; font-size: 1rem; cursor: pointer; }
-    p.note { margin: .5rem 0 0; font-size: .85rem; color: #565c65; }
-    #origin { font-family: monospace; }
-    iframe { width: 100%; height: calc(100vh - 9rem); border: 0; display: block; }
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      color: #1b1b1b;
+    }
+
+    header {
+      padding: 1rem;
+      border-bottom: 1px solid #d6d7d9;
+      background: #f0f0f0;
+    }
+
+    h1 {
+      font-size: 1.1rem;
+      margin: 0 0 .5rem;
+    }
+
+    form {
+      display: flex;
+      gap: .5rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    input[type="url"] {
+      flex: 1 1 30rem;
+      padding: .4rem;
+      font-size: 1rem;
+    }
+
+    button {
+      padding: .4rem .9rem;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+
+    p.note {
+      margin: .5rem 0 0;
+      font-size: .85rem;
+      color: #565c65;
+    }
+
+    #origin {
+      font-family: monospace;
+    }
+
+    iframe {
+      width: 100%;
+      height: calc(100vh - 9rem);
+      border: 0;
+      display: block;
+    }
   </style>
 </head>
 <body>
-  <header>
-    <h1>Emmy iframe embedding test harness</h1>
-    <form id="frame-form">
-      <input
-        type="url"
-        id="target-url"
-        placeholder="https://sandbox.example.org/help?client_agency_id=sandbox"
-        required
-      />
-      <button type="submit">Load in iframe</button>
-    </form>
-    <p class="note">
-      This page's origin (must be in the agency's
-      <code>allowed_iframe_ancestors</code>): <span id="origin"></span>
-    </p>
-    <p class="note">
-      If the agency does not allow this origin, the browser blocks the frame and
-      logs a <code>frame-ancestors</code> CSP violation in the dev console.
-    </p>
-  </header>
-  <iframe id="target-frame" title="Embedded Emmy app"></iframe>
+<header>
+  <h1>Emmy iframe embedding test harness</h1>
+  <form id="frame-form">
+    <input
+      type="url"
+      id="target-url"
+      placeholder="https://sandbox.example.org/help?client_agency_id=sandbox"
+      required
+    />
+    <button type="submit">Load in iframe</button>
+  </form>
+  <p class="note">
+    🖥️ Host and open the harness by running this from the project root: <code style="background-color: black; color: white">cd docs && python3 -m http.server 8000 &&
+    open http://localhost:8000/iframe-test-harness.html</code>
+  </p>
+  <p class="note">
+    ⚠️ This page's origin (must be in the agency's
+    <code>allowed_iframe_ancestors</code>): <span id="origin"></span>
+  </p>
+  <p class="note">
+    🚫 If the agency does not allow this origin, the browser blocks the frame and
+    logs a <code>frame-ancestors</code> CSP violation in the dev console.
+  </p>
+</header>
+<iframe id="target-frame" title="Embedded Emmy app"></iframe>
 
-  <script>
-    document.getElementById("origin").textContent =
-      window.location.origin === "null"
-        ? "null (file://) — CSP cannot allowlist this; serve from a real origin"
-        : window.location.origin;
+<script>
+  document.getElementById("origin").textContent =
+    window.location.origin === "null"
+      ? "null (file://) — 🚨🚨🚨 CSP cannot allowlist this; serve from a real origin"
+      : window.location.origin;
 
-    document.getElementById("frame-form").addEventListener("submit", function (event) {
-      event.preventDefault();
-      document.getElementById("target-frame").src =
-        document.getElementById("target-url").value;
-    });
-  </script>
+  document.getElementById("frame-form").addEventListener("submit", function(event) {
+    event.preventDefault();
+    document.getElementById("target-frame").src =
+      document.getElementById("target-url").value;
+  });
+</script>
 </body>
 </html>

--- a/docs/iframe-test-harness.html
+++ b/docs/iframe-test-harness.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Emmy iframe embedding test harness</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; color: #1b1b1b; }
+    header { padding: 1rem; border-bottom: 1px solid #d6d7d9; background: #f0f0f0; }
+    h1 { font-size: 1.1rem; margin: 0 0 .5rem; }
+    form { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; }
+    input[type="url"] { flex: 1 1 30rem; padding: .4rem; font-size: 1rem; }
+    button { padding: .4rem .9rem; font-size: 1rem; cursor: pointer; }
+    p.note { margin: .5rem 0 0; font-size: .85rem; color: #565c65; }
+    #origin { font-family: monospace; }
+    iframe { width: 100%; height: calc(100vh - 9rem); border: 0; display: block; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Emmy iframe embedding test harness</h1>
+    <form id="frame-form">
+      <input
+        type="url"
+        id="target-url"
+        placeholder="https://sandbox.example.org/help?client_agency_id=sandbox"
+        required
+      />
+      <button type="submit">Load in iframe</button>
+    </form>
+    <p class="note">
+      This page's origin (must be in the agency's
+      <code>allowed_iframe_ancestors</code>): <span id="origin"></span>
+    </p>
+    <p class="note">
+      If the agency does not allow this origin, the browser blocks the frame and
+      logs a <code>frame-ancestors</code> CSP violation in the dev console.
+    </p>
+  </header>
+  <iframe id="target-frame" title="Embedded Emmy app"></iframe>
+
+  <script>
+    document.getElementById("origin").textContent =
+      window.location.origin === "null"
+        ? "null (file://) — CSP cannot allowlist this; serve from a real origin"
+        : window.location.origin;
+
+    document.getElementById("frame-form").addEventListener("submit", function (event) {
+      event.preventDefault();
+      document.getElementById("target-frame").src =
+        document.getElementById("target-url").value;
+    });
+  </script>
+</body>
+</html>

--- a/docs/iframe-test-harness.html
+++ b/docs/iframe-test-harness.html
@@ -94,8 +94,19 @@
 
   document.getElementById("frame-form").addEventListener("submit", function(event) {
     event.preventDefault();
-    document.getElementById("target-frame").src =
-      document.getElementById("target-url").value;
+    var rawUrl = document.getElementById("target-url").value;
+
+    try {
+      var parsedUrl = new URL(rawUrl, window.location.href);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        alert("Please enter a valid http(s) URL.");
+        return;
+      }
+
+      document.getElementById("target-frame").src = parsedUrl.href;
+    } catch (e) {
+      alert("Please enter a valid URL.");
+    }
   });
 </script>
 </body>


### PR DESCRIPTION
## [FFS-4425](https://jiraent.cms.gov/browse/FFS-4425)
<img width="1216" height="1037" alt="Screenshot 2026-06-08 at 4 22 01 PM" src="https://github.com/user-attachments/assets/b067ebf9-5c64-4955-8c14-9346ceb3e124" />

## Changes
- Add per-agency `allowed_iframe_ancestors` config (validated as a list) that sets a CSP `frame-ancestors` allowlist so opted-in agencies can be embedded in cross-origin iframes; `dsacms.github.io` allowed for sandbox.
- Remove the Rails default `X-Frame-Options: SAMEORIGIN` header for embedding agencies so CSP `frame-ancestors` is the single source of truth.
- Issue session and device-id cookies as `SameSite=None; Secure` for embedding agencies so the session survives inside a cross-origin iframe; other agencies keep the stricter `SameSite=Lax` default.
- Enable Action Cable cross-origin requests in development only when an agency has iframe embedding configured.
- ngrok dev: point the sandbox agency's `agency_domain` at the active tunnel host so it resolves by domain when embedded over ngrok.
- Add `docs/iframe-test-harness.html` for manually testing iframe embedding from a real origin. 
- Add request specs for CSP/X-Frame-Options/cookie behavior and config specs for `allowed_iframe_ancestors`.

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR. 

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
- The embedding relaxations (CSP allowlist, dropped `X-Frame-Options`, `SameSite=None; Secure` cookies, dev Action Cable forgery protection) are all gated on `current_agency.allowed_iframe_ancestors` being present, so non-embedding agencies are unaffected.
- `X-Frame-Options` and CSP `frame-ancestors` interact: a browser blocks framing if *either* disallows it, so `X-Frame-Options` must be removed for the allowlist to take effect.
- `allowed_iframe_ancestors` must be a YAML list — a string raises an `ArgumentError` at config load.
- Local testing: uncomment the `localhost:8000` / `*.ngrok-free.app` entries in `client-agency-config.yml`, then serve the harness via `cd docs && python3 -m http.server 8000`. Cookies need `Secure`, so a cross-origin iframe requires HTTPS (ngrok).

## Acceptance testing
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester

### Local: 
1. Run and open the harness html from the project root like so: 
```
cd ../docs && python3 -m http.server 8000
```
2. Open http://localhost:8000/iframe-test-harness.html
3. Use the ngrok link generated in `bin/dev` as the url to load in the iframe. We can't use the site running in localhost because it's not served over HTTPS. 

### On Dev After Merge
1. [Setup github pages](https://github.com/DSACMS/iv-cbv-payroll/settings/pages) on root to host iframe-test-harness
2. Open the harness and confirm it reports origin https://dsacms.github.io.
3. Generate a flow on the demo launcher then paste its start link into the harness
4. Verify end-to-end inside the frame, sync a job and an education, generate and download a report.