### PR TITLE
No ticket: set up ai test classifier

### DIFF
--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -16,5 +16,5 @@ jobs:
     secrets:
       # Needed when tool: claude
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # Needed when tool: codex
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+# Needed when tool: codex (uncomment if switching tools)
+# OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -2,6 +2,10 @@ name: AI test classifier
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
 jobs:
   classify:
     uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -5,7 +5,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 jobs:
   classify:
     uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot

--- a/.github/workflows/ai-test-classifier.yml
+++ b/.github/workflows/ai-test-classifier.yml
@@ -1,0 +1,16 @@
+name: AI test classifier
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  classify:
+    uses: navapbc/ai-transformation-delivery-systems/.github/workflows/test-classifier.yml@pilot
+    with:
+      # Which AI CLI runs the classifier: claude | codex.
+      # Set the matching API-key secret below for whichever you pick.
+      tool: claude
+    secrets:
+      # Needed when tool: claude
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Needed when tool: codex
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## No ticket

## Changes
- Adds `.github/workflows/ai-test-classifier.yml` — fetched verbatim from `navapbc/ai-transformation-delivery-systems@pilot`
- On each PR, classifies failing tests as `APPLICATION_BUG` / `TEST_BUG` / `FLAKY_FAILURE` / `ENVIRONMENT_ISSUE` and posts one comment
- Non-blocking; does not gate merges

## Testing instructions
See it working on [this PR](https://github.com/DSACMS/iv-cbv-payroll/pull/1803) -- it correctly files a comment about the failed rspec test.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)