### PR TITLE
Allow fallback transmission of redacted income reports

### DIFF
--- a/app/app/services/caseworker_mailer_fallback_service.rb
+++ b/app/app/services/caseworker_mailer_fallback_service.rb
@@ -13,6 +13,7 @@ class CaseworkerMailerFallbackService
   def deliver_all(filter_name: nil)
     sent = 0
     skipped = []
+    warnings = []
 
     failed_caseworker_executions(filter_name: filter_name).each do |failed_execution|
       entry = entry_for(failed_execution)
@@ -21,6 +22,7 @@ class CaseworkerMailerFallbackService
         next
       end
 
+      warnings << warning_message(entry) if entry[:warning].present?
       deliver(entry)
       entry[:cbv_flow].touch(:transmitted_at)
       failed_execution.destroy
@@ -28,7 +30,7 @@ class CaseworkerMailerFallbackService
       sent += 1
     end
 
-    { sent: sent, skipped: skipped }
+    { sent: sent, skipped: skipped, warnings: warnings }
   end
 
   private
@@ -66,13 +68,12 @@ class CaseworkerMailerFallbackService
       fallback_email: agency&.caseworker_fallback_email || FALLBACK_EMAIL_MISSING,
       case_number: cbv_flow.cbv_applicant.case_number,
       transmitted: transmitted_status(cbv_flow),
+      warning: warning_for(cbv_flow),
       error: failed_execution.error
     }
 
     if cbv_flow.transmitted_at?
       base_entry.merge(status: :skipped, reason: "already transmitted at #{cbv_flow.transmitted_at}")
-    elsif cbv_flow.cbv_applicant.redacted_at?
-      base_entry.merge(status: :skipped, reason: "applicant is redacted")
     elsif agency&.caseworker_fallback_email.blank?
       base_entry.merge(status: :skipped, reason: "no caseworker_fallback_email configured for agency #{agency&.id || 'unknown'}")
     else
@@ -116,6 +117,14 @@ class CaseworkerMailerFallbackService
     else
       "solid_queue_job_id=#{entry[:solid_queue_job_id]}: #{entry[:reason]}"
     end
+  end
+
+  def warning_for(cbv_flow)
+    "applicant is redacted" if cbv_flow.cbv_applicant.redacted_at?
+  end
+
+  def warning_message(entry)
+    "cbv_flow_id=#{entry[:cbv_flow_id]}: #{entry[:warning]}"
   end
 
   def deliver(entry)

--- a/app/lib/tasks/caseworker_mailer_fallback.rake
+++ b/app/lib/tasks/caseworker_mailer_fallback.rake
@@ -34,6 +34,7 @@ namespace :caseworker_mailer_fallback do
       else
         puts "  cbv_flow_id=#{entry[:cbv_flow_id]}  agency=#{entry[:agency_id]}  to=#{entry[:fallback_email]}  case=#{entry[:case_number]}  transmitted=#{entry[:transmitted]}"
         puts "  status: #{entry[:reason]}" if entry[:status] == :skipped
+        puts "  warning: #{entry[:warning]}" if entry[:warning].present?
         puts "  error: #{entry[:error].to_s.truncate(300)}"
       end
       puts
@@ -47,6 +48,7 @@ namespace :caseworker_mailer_fallback do
 
     result = CaseworkerMailerFallbackService.new.deliver_all(filter_name: mode)
 
+    result[:warnings].each { |warning| puts "  Warning: #{warning}" }
     result[:skipped].each { |reason| puts "  Skipped: #{reason}" }
     puts "\nSummary: #{result[:sent]} sent, #{result[:skipped].count} skipped"
   end

--- a/app/lib/tasks/caseworker_mailer_fallback.rake
+++ b/app/lib/tasks/caseworker_mailer_fallback.rake
@@ -50,6 +50,6 @@ namespace :caseworker_mailer_fallback do
 
     result[:warnings].each { |warning| puts "  Warning: #{warning}" }
     result[:skipped].each { |reason| puts "  Skipped: #{reason}" }
-    puts "\nSummary: #{result[:sent]} sent, #{result[:skipped].count} skipped"
+    puts "\nSummary: #{result[:sent]} sent, #{result[:skipped].count} skipped, #{result[:warnings].count} warning(s)"
   end
 end

--- a/app/spec/lib/caseworker_mailer_fallback_rake_spec.rb
+++ b/app/spec/lib/caseworker_mailer_fallback_rake_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe Rake::Task, "#execute" do
 
         expect($stdout).to have_received(:puts).with("  Warning: cbv_flow_id=123: applicant is redacted")
       end
+
+      it "includes the warning count in the summary" do
+        described_class["caseworker_mailer_fallback:deliver_all"].execute
+
+        expect($stdout).to have_received(:puts).with("\nSummary: 1 sent, 0 skipped, 1 warning(s)")
+      end
     end
   end
 end

--- a/app/spec/lib/caseworker_mailer_fallback_rake_spec.rb
+++ b/app/spec/lib/caseworker_mailer_fallback_rake_spec.rb
@@ -33,10 +33,40 @@ RSpec.describe Rake::Task, "#execute" do
 
       expect(service).to have_received(:preview).with(filter_name: "la_ldh_schema_error")
     end
+
+    context "when the preview result includes a warning" do
+      let(:service) do
+        instance_double(
+          CaseworkerMailerFallbackService,
+          preview: {
+            count: 1,
+            entries: [
+              {
+                status: :sendable,
+                cbv_flow: instance_double(CbvFlow),
+                cbv_flow_id: 123,
+                agency_id: "la_ldh",
+                fallback_email: "fallback@example.gov",
+                case_number: "ABC123",
+                transmitted: "not yet sent",
+                warning: "applicant is redacted",
+                error: "Some error"
+              }
+            ]
+          }
+        )
+      end
+
+      it "prints the warning" do
+        described_class["caseworker_mailer_fallback:preview"].execute
+
+        expect($stdout).to have_received(:puts).with("  warning: applicant is redacted")
+      end
+    end
   end
 
   describe "caseworker_mailer_fallback:deliver_all" do
-    let(:service) { instance_double(CaseworkerMailerFallbackService, deliver_all: { sent: 0, skipped: [] }) }
+    let(:service) { instance_double(CaseworkerMailerFallbackService, deliver_all: { sent: 0, skipped: [], warnings: [] }) }
 
     before do
       allow(CaseworkerMailerFallbackService).to receive(:new).and_return(service)
@@ -53,6 +83,21 @@ RSpec.describe Rake::Task, "#execute" do
       described_class["caseworker_mailer_fallback:deliver_all"].execute(mode: "la_ldh_schema_error")
 
       expect(service).to have_received(:deliver_all).with(filter_name: "la_ldh_schema_error")
+    end
+
+    context "when the deliver result includes a warning" do
+      let(:service) do
+        instance_double(
+          CaseworkerMailerFallbackService,
+          deliver_all: { sent: 1, skipped: [], warnings: [ "cbv_flow_id=123: applicant is redacted" ] }
+        )
+      end
+
+      it "prints the warning" do
+        described_class["caseworker_mailer_fallback:deliver_all"].execute
+
+        expect($stdout).to have_received(:puts).with("  Warning: cbv_flow_id=123: applicant is redacted")
+      end
     end
   end
 end

--- a/app/spec/services/caseworker_mailer_fallback_service_spec.rb
+++ b/app/spec/services/caseworker_mailer_fallback_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CaseworkerMailerFallbackService do
     context "when there are no failed CaseWorkerTransmitterJob executions" do
       it "returns sent: 0 and empty skipped list" do
         result = service.deliver_all
-        expect(result).to eq({ sent: 0, skipped: [] })
+        expect(result).to eq({ sent: 0, skipped: [], warnings: [] })
       end
     end
 
@@ -66,10 +66,12 @@ RSpec.describe CaseworkerMailerFallbackService do
         create_failed_execution(cbv_flow)
       end
 
-      it "skips and reports the applicant as redacted" do
+      it "sends the email and returns a warning" do
         result = service.deliver_all
-        expect(result[:sent]).to eq(0)
-        expect(result[:skipped].first).to include("applicant is redacted")
+        expect(result[:sent]).to eq(1)
+        expect(result[:skipped]).to eq([])
+        expect(result[:warnings].first).to include("applicant is redacted")
+        expect(mock_mail).to have_received(:deliver_now)
       end
     end
 
@@ -110,7 +112,7 @@ RSpec.describe CaseworkerMailerFallbackService do
 
       it "returns sent: 1, skipped: []" do
         result = service.deliver_all
-        expect(result).to eq({ sent: 1, skipped: [] })
+        expect(result).to eq({ sent: 1, skipped: [], warnings: [] })
       end
     end
 
@@ -158,6 +160,23 @@ RSpec.describe CaseworkerMailerFallbackService do
           case_number: cbv_flow.cbv_applicant.case_number,
           transmitted: "not yet sent",
           error: error
+        )
+      end
+    end
+
+    context "when a failed execution references a redacted applicant" do
+      before do
+        cbv_flow.cbv_applicant.redact!
+        create_failed_execution(cbv_flow)
+      end
+
+      it "returns a sendable entry with a warning" do
+        result = service.preview
+
+        expect(result[:entries].first).to include(
+          cbv_flow_id: cbv_flow.id,
+          status: :sendable,
+          warning: "applicant is redacted"
         )
       end
     end


### PR DESCRIPTION
## [FFS-4452](https://jiraent.cms.gov/browse/FFS-4452)

## Changes
<!-- What was added, updated, or removed in this PR. -->

This converts the strict blocking of redacted reports into a warning, so
these reports will still be transmitted.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: OpenAI Codex
