### PR TITLE
Remove body from exception message for HttpPdfTransmitter errors

### DIFF
--- a/app/app/services/transmitters/http_pdf_transmitter.rb
+++ b/app/app/services/transmitters/http_pdf_transmitter.rb
@@ -46,8 +46,9 @@ class Transmitters::HttpPdfTransmitter < Transmitters::BasePdfTransmitter
   private
 
   def raise_response_error!(response, default_error_class)
-    message = "Unexpected response from agency: code=#{response.code} message=#{response.message} body=#{response.body}"
+    message = "Unexpected response from agency: code=#{response.code} message=#{response.message}"
     Rails.logger.error message
+    Rails.logger.error "Error response body: #{response.body}"
 
     error_class = silence_errors_from_response_codes.include?(response.code.to_s) ?
       ApplicationJob::SilencedError :

--- a/app/spec/services/transmitters/http_pdf_transmitter_spec.rb
+++ b/app/spec/services/transmitters/http_pdf_transmitter_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Transmitters::HttpPdfTransmitter do
         expect { subject.deliver }
           .to raise_error(
             ApplicationJob::SilencedError,
-            /code=403 message=Forbidden body=Forbidden/
+            /code=403 message=Forbidden/
           )
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe Transmitters::HttpPdfTransmitter do
         expect { subject.deliver }
           .to raise_error(
             Transmitters::HttpPdfTransmitter::HttpPdfTransmitterError,
-            /code=500 message=Internal Server Error body=Internal Server Error/
+            /code=500 message=Internal Server Error/
           )
       end
     end

--- a/app/spec/services/transmitters/json_and_pdf_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_and_pdf_transmitter_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Transmitters::JsonAndPdfTransmitter do
           expect { subject.deliver }
             .to raise_error(
               ApplicationJob::SilencedError,
-              /code=502 message=Bad Gateway body=Bad Gateway/
+              /code=502 message=Bad Gateway/
             )
 
           expect(json_request).to have_been_made.once


### PR DESCRIPTION
## Hotfix to minimize on-call noise

## Changes
<!-- What was added, updated, or removed in this PR. -->
These errors from LA have timestamps that cause the errors to not
group properly in NewRelic. Let's convert it into a separate log line,
separate from the exception tracking, so that the noise in NewRelic is
minimized.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
