### PR TITLE
[FFS-4474] fix issue with cookie store

### DIFF
--- a/app/config/environments/test.rb
+++ b/app/config/environments/test.rb
@@ -62,8 +62,6 @@ Rails.application.configure do
   # Use TestAdapter in test suite
   config.active_job.queue_adapter = :test
 
-  config.cbv_session_expires_after = 100.years
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/app/config/environments/test.rb
+++ b/app/config/environments/test.rb
@@ -62,6 +62,8 @@ Rails.application.configure do
   # Use TestAdapter in test suite
   config.active_job.queue_adapter = :test
 
+  config.cbv_session_expires_after = 100.years
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 Rails.application.config.session_store :cookie_store,
   key: "_iv_cbv_payroll_session",
-  expires_after: Rails.application.config.cbv_session_expires_after
+  expire_after: Rails.application.config.cbv_session_expires_after

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 # end to end tests require no auth of session length--TODO fix
-unless Rails.env.test?
+if ENV["E2E_RUN_TESTS"].nil?
   Rails.application.config.session_store :cookie_store,
                                          key: "_iv_cbv_payroll_session",
                                          expire_after: Rails.application.config.cbv_session_expires_after

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
-Rails.application.config.session_store :cookie_store,
-  key: "_iv_cbv_payroll_session",
-  expire_after: Rails.application.config.cbv_session_expires_after
+# end to end tests require no auth of session length--TODO fix
+unless Rails.env.test?
+  Rails.application.config.session_store :cookie_store,
+    key: "_iv_cbv_payroll_session",
+    expire_after: Rails.application.config.cbv_session_expires_after
+end

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,6 +1,10 @@
 # end to end tests require no auth of session length--TODO fix
-unless Rails.env.test?
+if Rails.env.test?
   Rails.application.config.session_store :cookie_store,
     key: "_iv_cbv_payroll_session",
-    expire_after: Rails.application.config.cbv_session_expires_after
+    expires_after: Rails.application.config.cbv_session_expires_after
+else
+  Rails.application.config.session_store :cookie_store,
+                                         key: "_iv_cbv_payroll_session",
+                                         expire_after: Rails.application.config.cbv_session_expires_after
 end

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,9 +1,5 @@
 # end to end tests require no auth of session length--TODO fix
-if Rails.env.test?
-  Rails.application.config.session_store :cookie_store,
-    key: "_iv_cbv_payroll_session",
-    expires_after: Rails.application.config.cbv_session_expires_after
-else
+unless Rails.env.test?
   Rails.application.config.session_store :cookie_store,
                                          key: "_iv_cbv_payroll_session",
                                          expire_after: Rails.application.config.cbv_session_expires_after


### PR DESCRIPTION
https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html its expire_after not expires_after

## [FFS-4474](https://jiraent.cms.gov/browse/FFS-4474)

## Changes

DPW noticed that sometimes peoples sessions weren't expiring if it held on to the cookie/back-button'd. We synced about it and found this issue.
see https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html --> it's expire_after not expires_after.

Couldn't figure out a test for this that wasn't goofy.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [x] NO_AI: I did not use AI.
