### PR TITLE
FFS-4383: Remove cbv_applicant cookie/clearout logic

### DIFF
--- a/app/app/controllers/flow_controller.rb
+++ b/app/app/controllers/flow_controller.rb
@@ -9,13 +9,13 @@ class FlowController < ApplicationController
       return
     end
 
-    @flow, is_new_session = find_or_create_flow
+    @flow = create_flow_with_new_applicant
     @cbv_flow = @flow # Maintain for compatibility until all controllers are converted
 
     set_flow_session(@flow.id, flow_param)
     apply_demo_overrides
 
-    track_generic_link_clicked_event(@flow, is_new_session)
+    track_generic_link_clicked_event(@flow)
   end
 
   def next_path
@@ -42,33 +42,13 @@ class FlowController < ApplicationController
 
   private
 
-  def find_or_create_flow
-    existing_applicant = find_existing_applicant_from_cookie
-    if existing_applicant && existing_applicant.client_agency_id == current_agency&.id
-      create_flow_with_existing_applicant(existing_applicant)
-    else
-      create_flow_with_new_applicant
-    end
-  end
-
-  def create_flow_with_existing_applicant(applicant)
-    applicant.reset_applicant_attributes
-    flow = flow_class(flow_param).create(
-      cbv_applicant: applicant,
-      device_id: cookies.permanent.signed[:device_id],
-      **flow_attributes_from_params
-    )
-    [ flow, false ]
-  end
-
   def create_flow_with_new_applicant
     applicant = CbvApplicant.create!(client_agency_id: current_agency.id)
-    flow = flow_class(flow_param).create(
+    flow_class(flow_param).create(
       cbv_applicant: applicant,
       device_id: cookies.permanent.signed[:device_id],
       **flow_attributes_from_params
     )
-    [ flow, true ]
   end
 
   def set_flow
@@ -108,15 +88,7 @@ class FlowController < ApplicationController
     end
   end
 
-  def find_existing_applicant_from_cookie
-    device_id = cookies.permanent.signed[:device_id]
-    return nil unless device_id.present?
-
-    recent_flow = flow_class(flow_param).where(device_id: device_id).order(created_at: :desc).first
-    recent_flow&.cbv_applicant
-  end
-
-  def track_generic_link_clicked_event(flow, is_new_session)
+  def track_generic_link_clicked_event(flow)
     # Skip tracking this event for a specific user agent, since we tend
     # to get a ton of traffic from it during LA SMS sends
     return if request.user_agent&.match?(/go-http-client/i)
@@ -126,8 +98,7 @@ class FlowController < ApplicationController
       cbv_applicant_id: flow.cbv_applicant_id,
       cbv_flow_id: flow.id, # TODO: Genericize/migrate key, it could be activity or cbv
       client_agency_id: flow.cbv_applicant.client_agency_id,
-      origin: params[:origin],
-      is_new_session: is_new_session
+      origin: params[:origin]
     })
   end
 

--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -99,13 +99,6 @@ class CbvApplicant < ApplicationRecord
     @required_applicant_attributes = get_required_applicant_attributes
   end
 
-  # Reset the applicant attributes to nil by removing any non-symbol keys i.e. { date_of_birth: [ :day, :month, :year ] }
-  # and then setting the attributes to nil.
-  def reset_applicant_attributes
-    clear_attributes = applicant_attributes.reject { |key| !key.is_a?(Symbol) }.index_with(nil)
-    update!(clear_attributes)
-  end
-
   def is_applicant_attribute_required?(attribute)
     get_required_applicant_attributes
     .include?(attribute)

--- a/app/spec/controllers/activities/entries_controller_spec.rb
+++ b/app/spec/controllers/activities/entries_controller_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Activities::EntriesController do
           create(:activity_flow, cbv_applicant: flow.cbv_applicant, device_id: "test-device-id")
         end
 
-        it "reuses the existing applicant" do
+        it "creates a new applicant" do
           expect {
             get :show, params: { client_agency_id: 'sandbox' }
-          }.not_to change(CbvApplicant, :count)
+          }.to change(CbvApplicant, :count).by(1)
 
           expect(session[:flow_type]).to eq(:activity)
           expect(session[:flow_id]).to be_truthy

--- a/app/spec/controllers/cbv/generic_links_controller_spec.rb
+++ b/app/spec/controllers/cbv/generic_links_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cbv::GenericLinksController do
         end
       end
 
-      context 'when no existing CBV applicant cookie exists' do
+      context 'when starting from a generic link' do
         let(:headers) { {} }
 
         before do
@@ -42,15 +42,14 @@ RSpec.describe Cbv::GenericLinksController do
           expect(assigns(:cbv_flow).cbv_applicant.client_agency_id).to eq("sandbox")
         end
 
-        it "tracks ApplicantClickedGenericLink event with is_new_session: true" do
+        it "tracks ApplicantClickedGenericLink event metadata" do
           expect(EventTrackingJob).to have_received(:perform_later).with(
             "ApplicantClickedGenericLink",
             anything,
             hash_including(
               cbv_applicant_id: assigns(:cbv_flow).cbv_applicant_id,
               cbv_flow_id: assigns(:cbv_flow).id,
-              client_agency_id: "sandbox",
-              is_new_session: true
+              client_agency_id: "sandbox"
             )
           )
         end
@@ -75,31 +74,53 @@ RSpec.describe Cbv::GenericLinksController do
       end
 
       context 'when a previous flow exists for the same device' do
-        let!(:existing_applicant) { create(:cbv_applicant, :sandbox, case_number: "12345", first_name: "John") }
+        let!(:invitation) do
+          create(
+            :cbv_flow_invitation,
+            :sandbox,
+            cbv_applicant_attributes: {
+              case_number: "12345",
+              first_name: "John"
+            }
+          )
+        end
+        let(:existing_applicant) { invitation.cbv_applicant }
 
         before do
-          create(:cbv_flow, cbv_applicant: existing_applicant, device_id: "test-device-id")
+          create(
+            :cbv_flow,
+            cbv_flow_invitation: invitation,
+            cbv_applicant: existing_applicant,
+            device_id: "test-device-id"
+          )
           cookies.permanent.signed[:device_id] = "test-device-id"
+        end
+
+        it "starts a CBV flow with a new applicant" do
+          expect do
+            get :show, params: { client_agency_id: "sandbox" }
+          end.to change(CbvApplicant, :count).by(1)
+
+          expect(assigns(:cbv_flow).cbv_applicant.client_agency_id).to eq("sandbox")
+        end
+
+        it "preserves applicant information fields on the previous applicant" do
           get :show, params: { client_agency_id: "sandbox" }
+
+          expect(existing_applicant.reload).to have_attributes(
+            case_number: "12345",
+            first_name: "John"
+          )
         end
 
-        it "reuses existing applicant" do
-          expect(assigns(:cbv_flow).cbv_applicant_id).to eq(existing_applicant.id)
-        end
+        it "tracks ApplicantClickedGenericLink event with the new applicant" do
+          get :show, params: { client_agency_id: "sandbox" }
 
-        it "clears applicant information fields" do
-          existing_applicant.reload
-          expect(existing_applicant.case_number).to be_nil
-          expect(existing_applicant.first_name).to be_nil
-        end
-
-        it "tracks ApplicantClickedGenericLink event with is_new_session: false" do
           expect(EventTrackingJob).to have_received(:perform_later).with(
             "ApplicantClickedGenericLink",
             anything,
             hash_including(
-              cbv_applicant_id: existing_applicant.id,
-              is_new_session: false
+              cbv_applicant_id: assigns(:cbv_flow).cbv_applicant_id
             )
           )
         end
@@ -114,11 +135,11 @@ RSpec.describe Cbv::GenericLinksController do
           expect(assigns(:cbv_flow).cbv_applicant).to be_persisted
         end
 
-        it "tracks event with is_new_session: true" do
+        it "tracks the ApplicantClickedGenericLink event" do
           expect(EventTrackingJob).to have_received(:perform_later).with(
             "ApplicantClickedGenericLink",
             anything,
-            hash_including(is_new_session: true)
+            anything
           )
         end
       end

--- a/app/spec/e2e/timeout_spec.rb
+++ b/app/spec/e2e/timeout_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "timeout test", :js, type: :feature do
   include E2e::TestHelpers
-  let(:cbv_flow_invitation) { create(:cbv_flow_invitation) }
+  let(:cbv_flow_invitation) do
+    create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "ABC1234" })
+  end
 
   it 'times out the user and directs them to start again' do
     visit URI(root_url).request_uri
@@ -24,5 +26,6 @@ RSpec.describe "timeout test", :js, type: :feature do
     click_link "click here"
     expect(page).to have_content(I18n.t("cbv.entries.show.header"))
     expect(page).not_to have_content(I18n.t("cbv.error_missing_token_html"))
+    expect(cbv_flow_invitation.cbv_applicant.reload.case_number).to eq("ABC1234")
   end
 end


### PR DESCRIPTION
## [FFS-4383](https://jiraent.cms.gov/browse/FFS-4383)

## Changes
- Generic links always create a fresh `CbvApplicant` instead of reusing one from the same device
- Tokenized links still use the applicant tied to the invitation
- Removed the old applicant field clearout logic and the stale `is_new_session` metric field

## Context for reviewers
There was no `session[:cbv_applicant_id]` that I saw to remove. Generic links may create more mostly blank applicant rows now. 

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.