### PR TITLE
FFS-4422: Create an agency for Accenture

### DIFF
--- a/app/app/models/cbv_applicant/accenture.rb
+++ b/app/app/models/cbv_applicant/accenture.rb
@@ -1,0 +1,9 @@
+class CbvApplicant::Accenture < CbvApplicant
+  VALID_ATTRIBUTES = %i[
+    case_number
+  ]
+
+  has_redactable_fields(
+    case_number: :string
+  )
+end

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -72,10 +72,10 @@ class CbvFlowInvitation < ApplicationRecord
   end
 
   def applicant_information
-    return if client_agency_id == "la_ldh"
+    required = cbv_applicant&.required_applicant_attributes || []
 
-    errors.add(:'cbv_applicant.first_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.first_name.blank")) if cbv_applicant.first_name.blank?
-    errors.add(:'cbv_applicant.last_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.last_name.blank")) if cbv_applicant.last_name.blank?
+    errors.add(:'cbv_applicant.first_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.first_name.blank")) if required.include?(:first_name) && cbv_applicant.first_name.blank?
+    errors.add(:'cbv_applicant.last_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.last_name.blank")) if required.include?(:last_name) && cbv_applicant.last_name.blank?
     errors.add(:'cbv_applicant.snap_application_date', I18n.t("activerecord.errors.models.cbv_applicant.attributes.snap_application_date.invalid_date")) if cbv_applicant.snap_application_date.blank?
   end
 

--- a/app/app/views/cbv/applicant_informations/_accenture.html.erb
+++ b/app/app/views/cbv/applicant_informations/_accenture.html.erb
@@ -1,0 +1,4 @@
+<% cbv_applicant = @cbv_flow.cbv_applicant %>
+<%= f.fields_for :cbv_applicant, cbv_applicant do |f2| %>
+  <%= f2.text_field :case_number, label: t(".fields.case_number.prompt") %>
+<% end %>

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -66,9 +66,9 @@
   pilot_ended: false
   generic_links_disabled: true
   sso:
-    client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
+    client_id: <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>
-    tenant_id:     <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
+    tenant_id: <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
     scope: "openid"
     name: "sandbox"
   pay_income_days:
@@ -111,9 +111,9 @@
   staff_portal_enabled: true
   pilot_ended: false
   sso:
-    client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
+    client_id: <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>
-    tenant_id:     <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
+    tenant_id: <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
     scope: "openid"
     name: "sandbox"
   pay_income_days:
@@ -162,9 +162,9 @@
   staff_portal_enabled: true
   pilot_ended: false
   sso:
-    client_id:     <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
+    client_id: <%= ENV["AZURE_SANDBOX_CLIENT_ID"] %>
     client_secret: <%= ENV["AZURE_SANDBOX_CLIENT_SECRET"] %>
-    tenant_id:     <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
+    tenant_id: <%= ENV["AZURE_SANDBOX_TENANT_ID"] %>
     scope: "openid"
     name: "sandbox"
   pay_income_days:
@@ -184,3 +184,30 @@
     community_service: true
     work_programs: true
     employment: true
+
+- id: accenture
+  agency_name: Accenture
+  agency_contact_website: https://www.example.com/contact
+  agency_missing_employers_website: https://www.example.com/contact
+  agency_domain: <%= ENV["ACCENTURE_DOMAIN_NAME"] %>
+  pinwheel:
+    environment: <%= ENV["SANDBOX_PINWHEEL_ENVIRONMENT"] %>
+  argyle:
+    environment: <%= ENV["SANDBOX_ARGYLE_ENVIRONMENT"] %>
+  transmission_method: json
+  transmission_method_configuration:
+    json_api_url: <%= ENV["ACCENTURE_INCOME_REPORT_URL"] %>
+  application_reporting_months: 2
+  invitation_valid_days: 14
+  applicant_attributes:
+    case_number:
+      required: true
+  activity_types:
+    education: true
+    community_service: true
+    work_programs: true
+    employment: true
+  allowed_iframe_ancestors:
+    - https://ac1752691868225.my.salesforce-sites.com
+    - https://ac1752691868225.my.salesforce.com
+    - https://ac1752691868225.my.site.com

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -647,6 +647,12 @@ en:
         radio_no: No, I don’t have another job to add with this tool
         radio_yes: Yes, I want to add another job with this tool
     applicant_informations:
+      accenture:
+        fields:
+          case_number:
+            blank: Enter your case number.
+            prompt: Case number
+            super_one_html: Case number<sup>1</sup>
       la_ldh:
         fields:
           case_number:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -92,6 +92,12 @@ es:
         radio_no: 'No'
         radio_yes: Sí
     applicant_informations:
+      accenture:
+        fields:
+          case_number:
+            blank: Escriba su número de caso.
+            prompt: Número de caso
+            super_one_html: Número de caso<sup>1</sup>
       la_ldh:
         fields:
           case_number:

--- a/app/spec/models/cbv_flow_invitation_spec.rb
+++ b/app/spec/models/cbv_flow_invitation_spec.rb
@@ -76,6 +76,37 @@ RSpec.describe CbvFlowInvitation, type: :model do
     end
   end
 
+  describe "#applicant_information" do
+    let(:invitation) do
+      build(:cbv_flow_invitation, :sandbox, cbv_applicant: build(:cbv_applicant, :sandbox, first_name: nil, last_name: nil))
+    end
+
+    let(:first_name_error) { I18n.t("activerecord.errors.models.cbv_applicant.attributes.first_name.blank") }
+    let(:last_name_error) { I18n.t("activerecord.errors.models.cbv_applicant.attributes.last_name.blank") }
+
+    context "when the agency's applicant requires first and last name (sandbox)" do
+      it "adds errors when they are blank" do
+        invitation.valid?
+
+        expect(invitation.errors[:'cbv_applicant.first_name']).to include(first_name_error)
+        expect(invitation.errors[:'cbv_applicant.last_name']).to include(last_name_error)
+      end
+    end
+
+    context "when the required attributes are stubbed" do
+      it "only enforces a field when the applicant's STI lists it as required" do
+        allow(invitation.cbv_applicant)
+          .to receive(:required_applicant_attributes)
+          .and_return(%i[first_name])
+
+        invitation.valid?
+
+        expect(invitation.errors[:'cbv_applicant.first_name']).to include(first_name_error)
+        expect(invitation.errors[:'cbv_applicant.last_name']).to be_empty
+      end
+    end
+  end
+
   describe "#expired?" do
     subject { invitation.expired? }
 

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -91,6 +91,10 @@ locals {
 
 
     # Transmission Configuration:
+    ACCENTURE_INCOME_REPORT_URL = {
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/accenture-income-report-url"
+    },
     LA_LDH_INCOME_REPORT_URL = {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/la-ldh-income-report-url"
@@ -230,6 +234,10 @@ locals {
     LA_LDH_CASEWORKER_FALLBACK_EMAIL = {
       manage_method     = "manual"
       secret_store_name = "/service/${var.app_name}-${var.environment}/la-ldh-caseworker-fallback-email"
+    },
+    ACCENTURE_DOMAIN_NAME = {
+      manage_method     = "manual"
+      secret_store_name = "/service/${var.app_name}-${var.environment}/accenture-domain-name"
     },
     LA_LDH_DOMAIN_NAME = {
       manage_method     = "manual"


### PR DESCRIPTION
## [FFS-4422](https://jiraent.cms.gov/browse/FFS-4422)
Add `accenture` client agency with some sensible defaults (JSON transmission, sandbox Pinwheel/Argyle, 2-month reporting window, 14-day invitation validity) alond with their requested iframe ancestors.

## Context for reviewers
- Requested iframe ancestors are behind a login so I think having them on the open internet is fine and less cumbersome than adding 3 additional env vars per site. 

## Remaining steps
- [x] 1. Add the following env vars with the values listed in the ticket:
  - `/service/<env>/accenture-income-report-url`
  - `/service/<env>/accenture-domain-name`
- [ ] 2. Generate an API key in demo for them to use (after next deploy)
   ```
   ./bin/run-command app demo '["bundle", "exec", "rails", "users:create_api_token[accenture]"]'
   ```


## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.

## Infrastructure Changes
  - [x] Plan reviewed

## Preview environment
- Link to launcher: https://p-1811.navapbc.cloud/launcher/advanced
- Deployed commit: f8cb94700eb666f7866c11e89a24997a6da31639

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1811.navapbc.cloud/launcher/advanced
- Deployed commit: 6eaa3bce3ef9e1c3b65407496d494d7634b9dec5
<!-- end PR environment info -->