### PR TITLE
FFS-4446: Fix invitations being redacted before their expiration date

### DIFF
--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -25,7 +25,7 @@ class DataRetentionService
         next unless Time.current.after?(cbv_flow_invitation.expires_at + REDACT_UNUSED_INVITATIONS_AFTER)
 
         cbv_flow_invitation.redact!
-        cbv_flow_invitation.cbv_applicant&.redact! if cbv_flow_invitation.cbv_flows.none?
+        redact_applicant_if_no_active_invitations_or_cbv_flows(cbv_flow_invitation.cbv_applicant) if cbv_flow_invitation.cbv_flows.none?
       end
   end
 
@@ -33,7 +33,7 @@ class DataRetentionService
     CbvFlow
       .incomplete
       .unredacted
-      .includes(:cbv_flow_invitation, :payroll_accounts)
+      .includes(:cbv_applicant, :cbv_flow_invitation, :payroll_accounts)
       .find_each do |cbv_flow|
         if cbv_flow.cbv_flow_invitation.present?
           # Redact CbvFlow records (together with their invitations) some period
@@ -43,7 +43,7 @@ class DataRetentionService
 
           cbv_flow.redact!
           cbv_flow.cbv_flow_invitation.redact!
-          cbv_flow.cbv_applicant&.redact!
+          redact_applicant_if_no_active_invitations_or_cbv_flows(cbv_flow.cbv_applicant)
           cbv_flow.payroll_accounts.each(&:redact!)
         else
           # Redact standalone CbvFlow records some period after their last
@@ -56,7 +56,7 @@ class DataRetentionService
           next unless Time.now.after?(flow_redact_at)
 
           cbv_flow.redact!
-          cbv_flow.cbv_applicant&.redact!
+          redact_applicant_if_no_active_invitations_or_cbv_flows(cbv_flow.cbv_applicant)
           cbv_flow.payroll_accounts.each(&:redact!)
         end
       end
@@ -66,13 +66,10 @@ class DataRetentionService
     CbvFlow
       .unredacted
       .where("transmitted_at < ?", REDACT_TRANSMITTED_CBV_FLOWS_AFTER.ago)
-      .includes(:payroll_accounts, cbv_applicant: :cbv_flow_invitations)
+      .includes(:cbv_applicant, :payroll_accounts)
       .find_each do |cbv_flow|
         cbv_flow.redact!
-        applicant = cbv_flow.cbv_applicant
-        # `all?` returns true on an empty collection: applicants with no invitations
-        # can't receive new flows, so they're safe to redact.
-        applicant.redact! if applicant && applicant.cbv_flow_invitations.all?(&:expired?)
+        redact_applicant_if_no_active_invitations_or_cbv_flows(cbv_flow.cbv_applicant)
         cbv_flow.payroll_accounts.each(&:redact!)
       end
   end
@@ -120,5 +117,16 @@ class DataRetentionService
       applicant.redact!({ case_number: :string })
     end
     Rails.logger.info "Redacted #{applicants.length} applicants"
+  end
+
+  private
+
+  def redact_applicant_if_no_active_invitations_or_cbv_flows(applicant)
+    return unless applicant
+
+    return if applicant.cbv_flow_invitations.where(redacted_at: nil).where("expires_at >= ?", Time.current).exists?
+    return if applicant.cbv_flows.unredacted.exists?
+
+    applicant.redact!
   end
 end

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -124,7 +124,7 @@ class DataRetentionService
   def redact_applicant_if_no_active_invitations_or_cbv_flows(applicant)
     return unless applicant
 
-    return if applicant.cbv_flow_invitations.where(redacted_at: nil).where("expires_at >= ?", Time.current).exists?
+    return if applicant.cbv_flow_invitations.unredacted.where("expires_at >= ?", Time.current).exists?
     return if applicant.cbv_flows.unredacted.exists?
 
     applicant.redact!

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -116,6 +116,61 @@ RSpec.describe Cbv::SubmitsController do
         end
 
         context "with sandbox client agency" do
+          context "when a household member reuses an active invitation after retention runs" do
+            let(:cbv_applicant) do
+              create(
+                :cbv_applicant,
+                created_at: current_time,
+                first_name: "Taylor",
+                last_name: "Household",
+                case_number: "ABC1234"
+              )
+            end
+            let(:cbv_flow_invitation) do
+              create(
+                :cbv_flow_invitation,
+                cbv_applicant: cbv_applicant,
+                expires_at: 1.day.from_now
+              )
+            end
+            let!(:previous_family_member_flow) do
+              CbvFlow.create_from_invitation(cbv_flow_invitation, "previous_family_member_device")
+            end
+            let(:cbv_flow) do
+              create(:cbv_flow,
+                     :with_pinwheel_account,
+                     :completed,
+                     with_errored_jobs: errored_jobs,
+                     created_at: current_time,
+                     supported_jobs: supported_jobs,
+                     cbv_applicant: cbv_applicant,
+                     cbv_flow_invitation: cbv_flow_invitation
+              )
+            end
+
+            before do
+              stale_flow = create(:cbv_flow, cbv_applicant: cbv_applicant, cbv_flow_invitation: nil)
+              stale_flow.update_columns(created_at: 8.days.ago, updated_at: 8.days.ago)
+
+              DataRetentionService.new.redact_incomplete_cbv_flows
+            end
+
+            it "includes non-redacted applicant information in the submitted report" do
+              expect(previous_family_member_flow.cbv_flow_invitation).to eq(cbv_flow_invitation)
+
+              get :show, format: :pdf, params: {
+                is_caseworker: "true"
+              }
+
+              expect(response).to be_successful
+
+              pdf_text = extract_pdf_text(response)
+
+              expect(pdf_text).to include("Taylor")
+              expect(pdf_text).to include("Household")
+            end
+          end
+
           context "when rendering for a caseworker" do
             it "shows the right client information fields" do
               get :show, format: :pdf, params: {

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -42,6 +42,53 @@ RSpec.describe DataRetentionService do
           )
         end
 
+        context "when the applicant has another active invitation" do
+          before do
+            create(
+              :cbv_flow_invitation,
+              cbv_applicant: cbv_flow_invitation.cbv_applicant,
+              expires_at: now + 1.day
+            )
+          end
+
+          it "keeps the applicant information available" do
+            service.redact_invitations
+
+            expect(cbv_flow_invitation.reload).to have_attributes(
+              email_address: "REDACTED@example.com",
+              redacted_at: within(1.second).of(now)
+            )
+            expect(cbv_flow_invitation.cbv_applicant.reload).to have_attributes(
+              first_name: "Jane",
+              redacted_at: nil
+            )
+          end
+        end
+
+        context "when the applicant has an active standalone flow" do
+          let!(:active_flow) do
+            create(
+              :cbv_flow,
+              cbv_applicant: cbv_flow_invitation.cbv_applicant,
+              cbv_flow_invitation: nil
+            )
+          end
+
+          it "keeps the applicant information available" do
+            service.redact_invitations
+
+            expect(cbv_flow_invitation.reload).to have_attributes(
+              email_address: "REDACTED@example.com",
+              redacted_at: within(1.second).of(now)
+            )
+            expect(active_flow.reload.redacted_at).to be_nil
+            expect(cbv_flow_invitation.cbv_applicant.reload).to have_attributes(
+              first_name: "Jane",
+              redacted_at: nil
+            )
+          end
+        end
+
         it "skips the invitation if it has already been redacted" do
           cbv_flow_invitation.redact!
 
@@ -143,6 +190,32 @@ RSpec.describe DataRetentionService do
         )
       end
 
+      context "when the applicant has another active invitation" do
+        before do
+          create(
+            :cbv_flow_invitation,
+            cbv_applicant: cbv_flow.cbv_applicant,
+            expires_at: now + 1.day
+          )
+        end
+
+        it "keeps the applicant information available" do
+          service.redact_incomplete_cbv_flows
+
+          expect(cbv_flow.reload).to have_attributes(
+            end_user_id: "00000000-0000-0000-0000-000000000000",
+            redacted_at: within(1.second).of(now)
+          )
+          expect(cbv_flow_invitation.reload).to have_attributes(
+            redacted_at: within(1.second).of(now)
+          )
+          expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+            first_name: "Jane",
+            redacted_at: nil
+          )
+        end
+      end
+
       it "redacts an associated PayrollAccount" do
         payroll_account = create(:payroll_account, flow: cbv_flow)
         service.redact_incomplete_cbv_flows
@@ -203,12 +276,42 @@ RSpec.describe DataRetentionService do
           )
         end
 
+        it "redacts the associated CbvApplicant" do
+          service.redact_incomplete_cbv_flows
+          expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+            first_name: "REDACTED"
+          )
+        end
+
         it "redacts an associated PayrollAccount" do
           payroll_account = create(:payroll_account, flow: cbv_flow)
           service.redact_incomplete_cbv_flows
           expect(payroll_account.reload).to have_attributes(
             redacted_at: within(1.second).of(now)
           )
+        end
+
+        context "when the applicant has an active invitation" do
+          before do
+            create(
+              :cbv_flow_invitation,
+              cbv_applicant: cbv_flow.cbv_applicant,
+              expires_at: now + 1.day
+            )
+          end
+
+          it "keeps the applicant information available" do
+            service.redact_incomplete_cbv_flows
+
+            expect(cbv_flow.reload).to have_attributes(
+              end_user_id: "00000000-0000-0000-0000-000000000000",
+              redacted_at: within(1.second).of(now)
+            )
+            expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+              first_name: "Jane",
+              redacted_at: nil
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
## [FFS-4446](https://jiraent.cms.gov/browse/FFS-4446)

## Changes
- The retention job doesn't redact an applicant while an active invitation or unredacted flow still depends on that applicant
- Expired invitation and flow redaction should work the same as before

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.