### PR TITLE
Add confirmation_code to ApplicantSharedIncomeSummary event

### DIFF
--- a/app/app/jobs/case_worker_transmitter_job.rb
+++ b/app/app/jobs/case_worker_transmitter_job.rb
@@ -69,6 +69,7 @@ class CaseWorkerTransmitterJob < ApplicationJob
       client_agency_id: cbv_flow.cbv_applicant.client_agency_id,
       cbv_applicant_id: cbv_flow.cbv_applicant_id,
       cbv_flow_id: cbv_flow.id,
+      confirmation_code: cbv_flow.confirmation_code,
       device_id: cbv_flow.device_id,
       invitation_id: cbv_flow.cbv_flow_invitation_id,
       account_count: cbv_flow.fully_synced_payroll_accounts.count,

--- a/app/spec/jobs/case_worker_transmitter_job_spec.rb
+++ b/app/spec/jobs/case_worker_transmitter_job_spec.rb
@@ -56,11 +56,14 @@ RSpec.describe CaseWorkerTransmitterJob, type: :job do
 
   shared_examples "tracks an ApplicantSharedIncomeSummary event" do
     it "tracks an ApplicantSharedIncomeSummary event" do
+      cbv_flow.update!(confirmation_code: "SANDBOX123")
+
       described_class.new.perform(cbv_flow.id)
 
       expect(fake_event_logger).to have_received(:track)
         .with("ApplicantSharedIncomeSummary", anything, include(
           cbv_flow_id: cbv_flow.id,
+          confirmation_code: cbv_flow.confirmation_code,
           flow_started_seconds_ago: 10.minutes.to_i,
           account_count: cbv_flow.fully_synced_payroll_accounts.count
         ))


### PR DESCRIPTION
## No ticket

## Changes
Include cbv_flow confirmation_code on the ApplicantSharedIncomeSummary
event. Update the shared transmitter job spec to assert the confirmation
code is forwarded.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

I decided this would be nice rather than having to take the Cbv Flow ID through
an AWS database query.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: Codex CLI
- Prompt artifacts: N/A
