### PR TITLE
Skip publishing to the CMS regsitry when deploying PR envs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,7 @@ on:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
         required: true
         type: string
-      publish_to_artifactory:
+      publish_to_cms:
         description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
         required: false
         type: boolean
@@ -27,7 +27,7 @@ on:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
         required: true
         type: string
-      publish_to_artifactory:
+      publish_to_cms:
         description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
         required: false
         type: boolean

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,6 +12,11 @@ on:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
         required: true
         type: string
+      publish_to_artifactory:
+        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       app_name:
@@ -22,6 +27,11 @@ on:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
         required: true
         type: string
+      publish_to_artifactory:
+        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   get-commit-hash:
@@ -90,6 +100,7 @@ jobs:
 
   build-and-publish-to-artifactory:
     name: Build and publish to Artifactory
+    if: ${{ inputs.publish_to_artifactory }}
     uses: ./.github/workflows/build-and-publish-to-artifactory.yml
     permissions:
       contents: read

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       app_name: ${{ inputs.app_name }}
       ref: ${{ inputs.commit_hash }}
-      publish_to_artifactory: false # PR environments deploy from the shared ECR, not the CMS registry
+      publish_to_cms: false # PR environments deploy from the shared ECR, not the CMS registry
     secrets: inherit
 
   update:

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       app_name: ${{ inputs.app_name }}
       ref: ${{ inputs.commit_hash }}
+      publish_to_artifactory: false # PR environments deploy from the shared ECR, not the CMS registry
     secrets: inherit
 
   update:


### PR DESCRIPTION
## Context for reviewers
Pushing 8b5e765ca465559e5d597c9cf7d130de6cbca8d3 unintentionally broke the ability for PRs created before the push to create PR envs. Rebasing fixes it but this will ensure it's just bypassed entirely in these cases. 

If a PR env can be deployed at all and that step is skipped it can be accepted. 

## Acceptance testing
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
  

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1830.navapbc.cloud/launcher/advanced
- Deployed commit: bd99a2ac1130c86bee041395e609fcbbe20d0497
<!-- end PR environment info -->