### PR TITLE
[FFS-4505] add hawaii to sandbox access to allow hawaii to test things out

### DIFF
--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -142,6 +142,8 @@
   prefilled_activities_enabled: true
   allowed_iframe_ancestors:
     - https://dsacms.github.io
+    - https://statehub.hawaii.gov
+    - https://*.statehub.hawaii.gov
 # Uncomment for local testing:
 #    - http://localhost:8000
 #    - https://*.ngrok-free.app


### PR DESCRIPTION
## [FFS-4505](https://jiraent.cms.gov/browse/FFS-4505)
probably need to also start a hawaii config once they become more serious, but considering they are playing with sandbox for now

## Changes
Adds hawaii to sandbox access to allow them to play with the iframes in demo. 

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
```
can frame ancestors include wildcards instead of just a specific hostname? specifically to the rails context of
if (policy = request.content_security_policy)
      request.content_security_policy = policy.clone.tap do |cloned|
        cloned.frame_ancestors(:self, *current_agency.allowed_iframe_ancestors)
      end
    end
```