### PR TITLE
FFS-4499: Use SHA image tags for UAT deploys

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,6 +34,9 @@ The CD workflow uses these reusable workflows:
 - [`deploy`](./deploy.yml): deploys an application
 - [`database-migrations`](./database-migrations.yml): runs database migrations for an application
 - [`build-and-publish`](./build-and-publish.yml): builds a container image for an application and publishes it to an image repository
+- [`deploy-cms`](./deploy-cms.yml): builds and publishes a SHA-tagged CMS image, then deploys that same image tag to CMS
+- [`deploy-ecs`](./deploy-ecs.yml): updates a CMS ECS service to use an existing image tag
+- [`build-and-publish-to-cms`](./build-and-publish-to-cms.yml): builds and publishes a SHA-tagged image to the CMS image repository
 
 ```mermaid
 graph TD
@@ -44,6 +47,10 @@ graph TD
 
   cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|build-and-publish
 ```
+
+CMS deploys use `deploy-cms` when the image should be built and deployed from
+one workflow dispatch. It resolves the requested ref to a commit SHA, publishes
+that SHA-tagged image if needed, and then deploys the same SHA tag.
 
 ## ⛑️ Helper workflows
 

--- a/.github/workflows/build-and-publish-to-cms.yml
+++ b/.github/workflows/build-and-publish-to-cms.yml
@@ -64,20 +64,30 @@ jobs:
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
+      - name: Check if image is already published
+        id: check-image-published
+        run: |
+          is_image_published=$(./bin/is-ecr-image-published "${{ env.EMMY_IMAGE_REPO }}" "${{ needs.get-commit-hash.outputs.commit_hash }}")
+          echo "Is image published: $is_image_published"
+          echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.check-image-published.outputs.is_image_published == 'false'
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to Amazon ECR
+        if: steps.check-image-published.outputs.is_image_published == 'false'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and publish release
+        if: steps.check-image-published.outputs.is_image_published == 'false'
         shell: bash
         run: |
           make APP_NAME=${{ inputs.app_name }} \

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -1,13 +1,9 @@
 name: Deploy to CMS
-run-name: Deploy ${{ inputs.ref }} to CMS ${{ inputs.app_name }} (${{ inputs.environment }})
+run-name: Deploy ${{ inputs.ref }} to CMS app (${{ inputs.environment }})
 
 on:
   workflow_call:
     inputs:
-      app_name:
-        description: "name of application folder under infra directory"
-        required: true
-        type: string
       environment:
         description: "the name of the application environment (e.g. uat)"
         required: true
@@ -18,11 +14,6 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      app_name:
-        description: "name of application folder under infra directory"
-        required: true
-        default: "app"
-        type: string
       environment:
         description: "the name of the application environment (e.g. uat)"
         required: true
@@ -33,7 +24,7 @@ on:
         required: true
         type: string
 
-concurrency: deploy-cms-${{ inputs.app_name }}-${{ inputs.environment }}
+concurrency: deploy-cms-app-${{ inputs.environment }}
 
 jobs:
   get-commit-hash:
@@ -63,7 +54,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      app_name: ${{ inputs.app_name }}
+      app_name: app
       ref: ${{ needs.get-commit-hash.outputs.commit_hash }}
     secrets: inherit
 
@@ -75,7 +66,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      app_name: ${{ inputs.app_name }}
+      app_name: app
       environment: ${{ inputs.environment }}
       image_tag: ${{ needs.get-commit-hash.outputs.commit_hash }}
     secrets: inherit

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -1,0 +1,81 @@
+name: Deploy to CMS
+run-name: Deploy ${{ inputs.ref }} to CMS ${{ inputs.app_name }} (${{ inputs.environment }})
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. uat)"
+        required: true
+        type: string
+      ref:
+        description: "the branch, tag, or SHA to deploy"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "name of application folder under infra directory"
+        required: true
+        default: "app"
+        type: string
+      environment:
+        description: "the name of the application environment (e.g. uat)"
+        required: true
+        default: "uat"
+        type: string
+      ref:
+        description: "the branch, tag, or SHA to deploy"
+        required: true
+        type: string
+
+concurrency: deploy-cms-${{ inputs.app_name }}-${{ inputs.environment }}
+
+jobs:
+  get-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Get commit hash
+        id: get-commit-hash
+        run: |
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "Commit hash: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+
+  build-and-publish:
+    name: Build and publish to CMS
+    needs: get-commit-hash
+    uses: ./.github/workflows/build-and-publish-to-cms.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      app_name: ${{ inputs.app_name }}
+      ref: ${{ needs.get-commit-hash.outputs.commit_hash }}
+    secrets: inherit
+
+  deploy:
+    name: Deploy to ECS
+    needs: [get-commit-hash, build-and-publish]
+    uses: ./.github/workflows/deploy-ecs.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      app_name: ${{ inputs.app_name }}
+      environment: ${{ inputs.environment }}
+      image_tag: ${{ needs.get-commit-hash.outputs.commit_hash }}
+    secrets: inherit

--- a/bin/deploy-ecs-manual
+++ b/bin/deploy-ecs-manual
@@ -36,16 +36,27 @@ service_name=${ECS_SERVICE_NAME:-emmy-${environment}-app}
 echo "Targeting Cluster: ${cluster_name}"
 echo "Targeting Service: ${service_name}"
 
-# 2. Describe the current service to find the current task definition
+# 2. Confirm the requested image tag exists before updating ECS
+echo "Checking for image ${image_repo}:${image_tag}..."
+is_image_published=$(./bin/is-ecr-image-published "${image_repo}" "${image_tag}")
+if [ "${is_image_published}" != "true" ]; then
+  echo "Error: Image tag not found in ECR: ${image_repo}:${image_tag}" >&2
+  echo "Run Deploy to CMS, or build-and-publish with publish_to_cms=true, before deploying." >&2
+  exit 1
+fi
+
+echo "Image exists in ECR."
+
+# 3. Describe the current service to find the current task definition
 current_task_def_arn=$(aws ecs describe-services --cluster "${cluster_name}" --services "${service_name}" --query 'services[0].taskDefinition' --output text)
 
 echo "Current Task Definition: ${current_task_def_arn}"
 
-# 3. Download the current task definition JSON
+# 4. Download the current task definition JSON
 # We strip out metadata fields that aren't allowed in register-task-definition
 current_task_def=$(aws ecs describe-task-definition --task-definition "${current_task_def_arn}" --query 'taskDefinition' --output json)
 
-# 4. Create a new task definition JSON with the updated image
+# 5. Create a new task definition JSON with the updated image
 # We use jq to update the image of the first container (assuming it's the main one)
 # or all containers if they should use the same image (less likely).
 # Typically there's one main container with the same name as the service.
@@ -60,17 +71,17 @@ new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${imag
   (.containerDefinitions[] | select(.name == "'"emmy-app"'")) .image = $IMAGE
 ')
 
-# 5. Register the new task definition
+# 6. Register the new task definition
 echo "Registering new task definition revision..."
 new_task_def_arn=$(aws ecs register-task-definition --cli-input-json "${new_task_def}" --query 'taskDefinition.taskDefinitionArn' --output text)
 
 echo "New Task Definition ARN: ${new_task_def_arn}"
 
-# 6. Update the service to use the new task definition
+# 7. Update the service to use the new task definition
 echo "Updating service ${service_name} to use new task definition..."
 aws ecs update-service --cluster "${cluster_name}" --service "${service_name}" --task-definition "${new_task_def_arn}" > /dev/null
 
-# 7. Wait for the service to become stable
+# 8. Wait for the service to become stable
 echo "Waiting for service ${service_name} to become stable..."
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 

--- a/bin/is-ecr-image-published
+++ b/bin/is-ecr-image-published
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Checks if an image tag exists in an ECR repository URI.
+# Prints "true" if so, "false" otherwise.
+
+set -euo pipefail
+
+image_repo="$1"
+image_tag="$2"
+
+if [[ "${image_repo}" =~ ^([0-9]+)\.dkr\.ecr\.([a-z0-9-]+)\.amazonaws\.com/(.+)$ ]]; then
+  image_registry_id="${BASH_REMATCH[1]}"
+  image_region="${BASH_REMATCH[2]}"
+  image_repository_name="${BASH_REMATCH[3]}"
+else
+  echo "Error: image_repo must be an ECR repository URI, got: ${image_repo}" >&2
+  exit 1
+fi
+
+if describe_image_output=$(aws ecr describe-images \
+  --registry-id "${image_registry_id}" \
+  --repository-name "${image_repository_name}" \
+  --image-ids "imageTag=${image_tag}" \
+  --region "${image_region}" 2>&1); then
+  echo "true"
+elif echo "${describe_image_output}" | grep -q "ImageNotFoundException"; then
+  echo "false"
+else
+  echo "Error checking image in ECR: ${image_repo}:${image_tag}" >&2
+  echo "${describe_image_output}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## [FFS-4499](https://jiraent.cms.gov/browse/FFS-4499)

## Changes
<!-- What was added, updated, or removed in this PR. -->

- Added a new "Deploy to CMS" wrapper workflow to ease deploys with a single workflow dispatch until transition
- CMS build and publish workflow reruns don’t fail when the SHA image tag already exists
- There's an image check so we fail early if someone tries to deploy a tag that does not exist in ECR

I tested the individual pieces from this PR because the new wrapper workflow can’t be dispatched until it exists on main. I'll follow up with testing it after merge.

### Test runs
1. [First build & publish](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/28182998650)
2. [Second build & publish (testing already-published SHA)](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/28183325024)
3. [Deploy to ECS](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/28183363582)
4. [Deploy to CMS (post-merge)](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/28187224798)

**Note:** Verified the wrapper works after merging to main!

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.