### PR TITLE
FFS-4511: Add CODEOWNERS for CM-01a

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything not matched by a more specific rule below.
-* @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom
+* @DSACMS/income-verification-cbv-payroll-committers
 
 # Rails application
-/app/ @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom
+/app/ @DSACMS/income-verification-cbv-payroll-committers
 
 # Infrastructure
-/infra/ @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom
+/infra/ @DSACMS/income-verification-cbv-payroll-committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners are automatically requested for review when someone opens a
+# pull request that modifies code they own.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything not matched by a more specific rule below.
+* @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom
+
+# Rails application
+/app/ @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom
+
+# Infrastructure
+/infra/ @tdooner @daphnegold @millerti @bencalegari @j-shilling @imhben @dx-gov @serverless-mom

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything not matched by a more specific rule below.
-* @DSACMS/income-verification-cbv-payroll-committers
+* @DSACMS/emmy-app-committers
 
 # Rails application
-/app/ @DSACMS/income-verification-cbv-payroll-committers
+/app/ @DSACMS/emmy-app-committers
 
 # Infrastructure
-/infra/ @DSACMS/income-verification-cbv-payroll-committers
+/infra/ @DSACMS/emmy-app-committers

--- a/.github/ISSUE_TEMPLATE/contributor_ladder.md
+++ b/.github/ISSUE_TEMPLATE/contributor_ladder.md
@@ -59,7 +59,7 @@ This issue is used to request role changes within the iv-cbv-payroll repository 
 - [ ] Reviewing a minimum of 4 PRs per 3 month cycle
 - [ ] Contributing at least 2 PRs per 3 month cycle
 - [ ] Exercising judgment for the good of the project, independent of their employer, friends, or team, in line with project GOVERNANCE.
-- [ ] Taking responsibility for a key project management area as indicated in CODEOWNERS.md
+- [ ] Taking responsibility for a key project management area as indicated in [CODEOWNERS](../CODEOWNERS)
 - [ ] Writing and refactoring submitted PRs
 - [ ] Participating in Emmy maintainer activities
 - [ ] Proposing contributions to strategy and policy of the project

--- a/.github/ISSUE_TEMPLATE/contributor_ladder.md
+++ b/.github/ISSUE_TEMPLATE/contributor_ladder.md
@@ -59,7 +59,7 @@ This issue is used to request role changes within the iv-cbv-payroll repository 
 - [ ] Reviewing a minimum of 4 PRs per 3 month cycle
 - [ ] Contributing at least 2 PRs per 3 month cycle
 - [ ] Exercising judgment for the good of the project, independent of their employer, friends, or team, in line with project GOVERNANCE.
-- [ ] Taking responsibility for a key project management area as indicated in [CODEOWNERS](../CODEOWNERS)
+- [ ] Taking responsibility for a key project management area as indicated in [CODEOWNERS](/.github/CODEOWNERS)
 - [ ] Writing and refactoring submitted PRs
 - [ ] Participating in Emmy maintainer activities
 - [ ] Proposing contributions to strategy and policy of the project

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,9 +1,0 @@
-# Code Owners
-* @tdooner (Tom Dooner)
-* @daphnegold (Daphne Gold)
-* @millerti (Tim Miller)
-* @bencalegari (Ben Calegari)
-* @j-shilling (Jake Shilling)
-* @imhben (Imhotep Benjamin)
-* @dx-gov (Jan)
-* @serverless-mom (Nočnica Mellifera)

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -150,7 +150,7 @@ A Maintainer must meet the responsibilities and requirements of a contributor, p
 - Other privileges defined by the community in the future.
 
 #### Process of becoming a Maintainer
-1. Any current contributor may become a new Maintainer, by meeting the requirements, and opening a PR against the root of the iv-cbv-payroll adding the themselves as a maintainer in the COMMUNITY.md file and corresponding team in the[CODEOWNERS](.github/CODEOWNERS) file.
+1. Any current contributor may become a new Maintainer, by meeting the requirements, and opening a PR against the root of the iv-cbv-payroll adding the themselves as a maintainer in the COMMUNITY.md file and corresponding team in the [CODEOWNERS](.github/CODEOWNERS) file.
 2. At least 2 current Maintainers from the Core Team must then approve the PR.
 
 ## Core Team

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -22,7 +22,7 @@ IV CBV Payroll is supported by a dedicated team of individuals fulfilling variou
 | Software Engineer | Ben Calegari | Nava |
 | Open Source Lead/Community Manager | Nočnica Mellifera | Nava |
 
-See [CODEOWNERS.md](.github/CODEOWNERS.md) for a list of those responsible for the code and documentation in this repository.
+See [CODEOWNERS](.github/CODEOWNERS) for a list of those responsible for the code and documentation in this repository.
 
 See [Community Guidelines](#iv-cbv-payroll-open-source-community-guidelines) on principles and guidelines for participating in this open source project.
 
@@ -133,7 +133,7 @@ A Maintainer must meet the responsibilities and requirements of a contributor, p
 - Participating in, and leading, community discussions.
 - Mentoring other Maintainers.
 - Exercising judgment for the good of the project, independent of their employer, friends, or team, in line with project GOVERNANCE.
-- Become responsible for a key project management area as indicated in CODEOWNERS.md.
+- Become responsible for a key project management area as indicated in [CODEOWNERS](.github/CODEOWNERS).
 
 #### Requirements:
 - Must be actively contributing for at least 3 months to at least one project area:
@@ -150,7 +150,7 @@ A Maintainer must meet the responsibilities and requirements of a contributor, p
 - Other privileges defined by the community in the future.
 
 #### Process of becoming a Maintainer
-1. Any current contributor may become a new Maintainer, by meeting the requirements, and opening a PR against the root of the iv-cbv-payroll adding the themselves as a maintainer in the COMMUNITY.md file and corresponding team in the CODEOWNERS.md file.
+1. Any current contributor may become a new Maintainer, by meeting the requirements, and opening a PR against the root of the iv-cbv-payroll adding the themselves as a maintainer in the COMMUNITY.md file and corresponding team in the[CODEOWNERS](.github/CODEOWNERS) file.
 2. At least 2 current Maintainers from the Core Team must then approve the PR.
 
 ## Core Team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 3.  Create a feature branch
 4.  Write code and tests for your change
 5.  From your branch, make a pull request against main
-6.  Work with [repo maintainers](.github/CODEOWNERS.md) to get your change reviewed
+6.  Work with [repo maintainers](.github/CODEOWNERS) to get your change reviewed
 7.  Wait for your change to be pulled into main
 8.  Delete your feature branch
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a guide to running the Emmy project on your own, and submitting changes, see
 
 The Emmy core team is a group of technologists, composed of engineers, designers, product, and procurement specialists at Centers of Medicare and Medicaid Services (CMS). The products developed are open source and SHARE IT compliant.
 
-A list of core team members responsible for the code and documentation in this repository can be found in [COMMUNITY.md](/COMMUNITY.md) and [CODEOWNERS.md](/CODEOWNERS.md).
+A list of core team members responsible for the code and documentation in this repository can be found in [COMMUNITY.md](/COMMUNITY.md) and [CODEOWNERS](/.github/CODEOWNERS).
 
 ## Documentation
 


### PR DESCRIPTION
## [FFS-4511](https://jiraent.cms.gov/browse/FFS-4511)



## Changes

- replaces `CODEOWNERS.md` with a  `.github/CODEOWNERS` file
  - as placeholders, designates `/app/` and `/infra/` as directories that might have specific rules
  - designates ~@DSACMS/income-verification-cbv-payroll-committers~ `@DSACMS/emmy-app-committers` as owners ([slack](https://cmsgov.slack.com/archives/C066XS5543S/p1782741449375549?thread_ts=1782500226.123949&cid=C066XS5543S))
- updates links that were pointing to the .md to point to the new file

I verified that a text search for `CODEOWNERS.md` on the repo returns no results. 


## Context for reviewers

This PR implements CM-01a and aligns with the [Emmy PR Review Process](https://confluenceent.cms.gov/pages/viewpage.action?pageId=1398349805&spaceKey=SFIV&title=Emmy+PR+Review+Process).

Looking for help with: verifying `@DSACMS/income-verification-cbv-payroll-committers` maps to an existing team

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>