### PR TITLE
FFS-4526: Deploy to Solid Queue ECS container too

### DIFF
--- a/bin/deploy-ecs-manual
+++ b/bin/deploy-ecs-manual
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script updates an ECS service's task definition with a new image
+# This script updates ECS service task definitions with a new image
 # without relying on Terraform to manage the task definition resource.
 #
 # Usage: bin/deploy-ecs-manual <app_name> <environment> <image_repo> <image_tag>
 #
 # cluster_name is presumed as emmy-{environment}
 # service_name is presumed as emmy-{environment}-app
+# solid_queue_service_name is presumed as emmy-{environment}-solid-queue
 
 app_name="$1"
 environment="$2"
@@ -24,19 +25,12 @@ echo "  image_repo=${image_repo}"
 echo "  image_tag=${image_tag}"
 echo
 
-# 1. Determine Cluster and Service names
-# We use naming conventions based on the environment:
-# Cluster: emmy-{env}
-# Service: emmy-{env}-app
-
-# Let's try to get them from naming conventions, but allow overrides via ENV vars
 cluster_name=${ECS_CLUSTER_NAME:-emmy-${environment}}
 service_name=${ECS_SERVICE_NAME:-emmy-${environment}-app}
+solid_queue_service_name=${ECS_SOLID_QUEUE_SERVICE_NAME:-emmy-${environment}-solid-queue}
 
 echo "Targeting Cluster: ${cluster_name}"
-echo "Targeting Service: ${service_name}"
 
-# 2. Confirm the requested image tag exists before updating ECS
 echo "Checking for image ${image_repo}:${image_tag}..."
 is_image_published=$(./bin/is-ecr-image-published "${image_repo}" "${image_tag}")
 if [ "${is_image_published}" != "true" ]; then
@@ -47,42 +41,55 @@ fi
 
 echo "Image exists in ECR."
 
-# 3. Describe the current service to find the current task definition
-current_task_def_arn=$(aws ecs describe-services --cluster "${cluster_name}" --services "${service_name}" --query 'services[0].taskDefinition' --output text)
+deploy_service() {
+  local target_service_name="$1"
+  local container_name="$2"
+  local current_task_def_arn
+  local current_task_def
+  local new_task_def
+  local new_task_def_arn
 
-echo "Current Task Definition: ${current_task_def_arn}"
+  echo "Targeting Service: ${target_service_name}"
 
-# 4. Download the current task definition JSON
-# We strip out metadata fields that aren't allowed in register-task-definition
-current_task_def=$(aws ecs describe-task-definition --task-definition "${current_task_def_arn}" --query 'taskDefinition' --output json)
+  current_task_def_arn=$(aws ecs describe-services --cluster "${cluster_name}" --services "${target_service_name}" --query 'services[0].taskDefinition' --output text)
 
-# 5. Create a new task definition JSON with the updated image
-# We use jq to update the image of the first container (assuming it's the main one)
-# or all containers if they should use the same image (less likely).
-# Typically there's one main container with the same name as the service.
-new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" '
-  del(.taskDefinitionArn) |
-  del(.revision) |
-  del(.status) |
-  del(.requiresAttributes) |
-  del(.compatibilities) |
-  del(.registeredAt) |
-  del(.registeredBy) |
-  (.containerDefinitions[] | select(.name == "'"emmy-app"'")) .image = $IMAGE
-')
+  echo "Current Task Definition: ${current_task_def_arn}"
 
-# 6. Register the new task definition
-echo "Registering new task definition revision..."
-new_task_def_arn=$(aws ecs register-task-definition --cli-input-json "${new_task_def}" --query 'taskDefinition.taskDefinitionArn' --output text)
+  # Strip out metadata fields that aren't allowed in register-task-definition.
+  current_task_def=$(aws ecs describe-task-definition --task-definition "${current_task_def_arn}" --query 'taskDefinition' --output json)
 
-echo "New Task Definition ARN: ${new_task_def_arn}"
+  new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" --arg CONTAINER_NAME "${container_name}" '
+    del(.taskDefinitionArn) |
+    del(.revision) |
+    del(.status) |
+    del(.requiresAttributes) |
+    del(.compatibilities) |
+    del(.registeredAt) |
+    del(.registeredBy) |
+    (.containerDefinitions[] | select(.name == $CONTAINER_NAME)) .image = $IMAGE
+  ')
 
-# 7. Update the service to use the new task definition
-echo "Updating service ${service_name} to use new task definition..."
-aws ecs update-service --cluster "${cluster_name}" --service "${service_name}" --task-definition "${new_task_def_arn}" > /dev/null
+  echo "Registering new task definition revision..."
+  new_task_def_arn=$(aws ecs register-task-definition --cli-input-json "${new_task_def}" --query 'taskDefinition.taskDefinitionArn' --output text)
 
-# 8. Wait for the service to become stable
-echo "Waiting for service ${service_name} to become stable..."
-aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+  echo "New Task Definition ARN: ${new_task_def_arn}"
+
+  echo "Updating service ${target_service_name} to use new task definition..."
+  aws ecs update-service --cluster "${cluster_name}" --service "${target_service_name}" --task-definition "${new_task_def_arn}" > /dev/null
+  echo
+}
+
+wait_for_service_stability() {
+  local target_service_name="$1"
+  echo "Waiting for service ${target_service_name} to become stable..."
+  aws ecs wait services-stable --cluster "${cluster_name}" --services "${target_service_name}"
+  echo
+}
+
+deploy_service "${service_name}" "emmy-app"
+deploy_service "${solid_queue_service_name}" "emmy-app-solid-queue"
+
+wait_for_service_stability "${service_name}"
+wait_for_service_stability "${solid_queue_service_name}"
 
 echo "Deployment completed successfully!"


### PR DESCRIPTION
## [FFS-4526](https://jiraent.cms.gov/browse/FFS-4526)

## Changes
<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

This updates the deploy script to also bump the image_tag of the
solid-queue worker container(s) when deploying an app container.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
