### PR TITLE
FFS-4526: Update IMAGE_TAG on ECS deployment too

### DIFF
--- a/bin/deploy-ecs-manual
+++ b/bin/deploy-ecs-manual
@@ -58,7 +58,7 @@ deploy_service() {
   # Strip out metadata fields that aren't allowed in register-task-definition.
   current_task_def=$(aws ecs describe-task-definition --task-definition "${current_task_def_arn}" --query 'taskDefinition' --output json)
 
-  new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" --arg CONTAINER_NAME "${container_name}" '
+  new_task_def=$(echo "${current_task_def}" | jq --arg IMAGE "${image_repo}:${image_tag}" --arg IMAGE_TAG "${image_tag}" --arg CONTAINER_NAME "${container_name}" '
     del(.taskDefinitionArn) |
     del(.revision) |
     del(.status) |
@@ -66,7 +66,10 @@ deploy_service() {
     del(.compatibilities) |
     del(.registeredAt) |
     del(.registeredBy) |
-    (.containerDefinitions[] | select(.name == $CONTAINER_NAME)) .image = $IMAGE
+    (.containerDefinitions[] | select(.name == $CONTAINER_NAME)) |= (
+      .image = $IMAGE |
+      .environment = ((.environment // []) | map(if .name == "IMAGE_TAG" then .value = $IMAGE_TAG else . end))
+    )
   ')
 
   echo "Registering new task definition revision..."


### PR DESCRIPTION
## [FFS-4526](https://jiraent.cms.gov/browse/FFS-4526)

## Changes
<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

The ECS deploy worked to CMS Cloud (it updated the container's image to
the new `$image_tag`). However, the IMAGE_TAG environment variable was
unchanged to the new `$image_tag` value, leading to an outdated SHA
being displayed on the `/health` endpoint.

This commit extends the jq manipulation to also update the IMAGE_TAG
within the "environment" array of the task definition.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
