### PR TITLE
FFS-4463: Set up household flow foundation with test household

### DIFF
--- a/app/app/controllers/activities/base_controller.rb
+++ b/app/app/controllers/activities/base_controller.rb
@@ -1,5 +1,5 @@
 class Activities::BaseController < FlowController
-  before_action :redirect_on_prod, :set_flow
+  before_action :redirect_unless_activity_hub_enabled, :set_flow
 
   helper_method :current_identity, :progress_calculator
 
@@ -24,12 +24,6 @@ class Activities::BaseController < FlowController
   end
 
   private
-
-  def redirect_on_prod
-    return if Rails.env.development? || ENV["ACTIVITY_HUB_ENABLED"] == "true"
-
-    redirect_to root_url
-  end
 
   def after_activity_path
     progress_result = progress_calculator.overall_result

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  ALPHANUMERIC_PREFIX_REGEXP = /^([a-zA-Z0-9]+)[^a-zA-Z0-9]*$/
+
   helper :view
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
@@ -121,6 +123,20 @@ class ApplicationController < ActionController::Base
 
   def internal_environment?
     Rails.application.config.is_internal_environment
+  end
+
+  def activity_hub_enabled?
+    Rails.env.development? || ENV["ACTIVITY_HUB_ENABLED"] == "true"
+  end
+
+  def redirect_unless_activity_hub_enabled
+    return if activity_hub_enabled?
+
+    redirect_to root_url
+  end
+
+  def normalize_token(token)
+    ALPHANUMERIC_PREFIX_REGEXP.match(token.to_s)&.[](1)
   end
 
   def enable_mini_profiler_in_demo

--- a/app/app/controllers/demo_launcher_controller.rb
+++ b/app/app/controllers/demo_launcher_controller.rb
@@ -13,7 +13,9 @@ class DemoLauncherController < ApplicationController
     test_scenario = launcher_params[:test_scenario]
     overrides = launch_overrides(flow_type)
 
-    url = if flow_type == "cbv"
+    url = if launch_type == "household"
+            build_household_url(client_agency_id)
+          elsif flow_type == "cbv"
             if launch_type == "generic"
               build_cbv_generic_url(client_agency_id, overrides)
             else
@@ -320,6 +322,11 @@ class DemoLauncherController < ApplicationController
       **launcher_url_options,
       **overrides
     )
+  end
+
+  def build_household_url(client_agency_id)
+    household = DemoLauncher::HouseholdScenario.find_or_create!(client_agency_id: client_agency_id)
+    household.to_url(**launcher_url_options)
   end
 
   TEST_SCENARIOS = {

--- a/app/app/controllers/flow_controller.rb
+++ b/app/app/controllers/flow_controller.rb
@@ -1,6 +1,4 @@
 class FlowController < ApplicationController
-  ALPHANUMERIC_PREFIX_REGEXP = /^([a-zA-Z0-9]+)[^a-zA-Z0-9]*$/
-
   helper_method :next_path
 
   def set_generic_flow
@@ -111,11 +109,6 @@ class FlowController < ApplicationController
 
   def flow_attributes_from_params
     flow_class(flow_param).flow_attributes_from_params(params)
-  end
-
-  def normalize_token(token)
-    matches = ALPHANUMERIC_PREFIX_REGEXP.match(token)
-    matches[1] if matches
   end
 
   def apply_demo_overrides

--- a/app/app/controllers/household_members_controller.rb
+++ b/app/app/controllers/household_members_controller.rb
@@ -1,0 +1,35 @@
+class HouseholdMembersController < ApplicationController
+  before_action :redirect_unless_activity_hub_enabled, :set_household, :set_household_member
+
+  def create
+    flow = ActivityFlow.resume_or_create_from_invitation(
+      @household_member.activity_flow_invitation,
+      cookies.permanent.signed[:device_id],
+      params
+    )
+
+    set_flow_session(flow.id, :activity)
+    redirect_to activities_flow_root_path
+  end
+
+  private
+
+  def set_household
+    @household = Household.find_by(auth_token: normalize_token(params[:token]))
+    return if @household
+
+    redirect_to root_url, flash: { alert: t("households.errors.invalid_token") }
+  end
+
+  def set_household_member
+    @household_member = @household.household_members.find(params[:member_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to household_start_path(token: @household.auth_token), flash: { alert: t("households.errors.invalid_member") }
+  end
+
+  def current_agency
+    return agency_config[@household.client_agency_id] if @household
+
+    super
+  end
+end

--- a/app/app/controllers/households_controller.rb
+++ b/app/app/controllers/households_controller.rb
@@ -1,0 +1,22 @@
+class HouseholdsController < ApplicationController
+  before_action :redirect_unless_activity_hub_enabled, :set_household
+
+  def show
+    set_flow_session(nil, :activity)
+  end
+
+  private
+
+  def set_household
+    @household = Household.find_by(auth_token: normalize_token(params[:token]))
+    return if @household
+
+    redirect_to root_url, flash: { alert: t("households.errors.invalid_token") }
+  end
+
+  def current_agency
+    return agency_config[@household.client_agency_id] if @household
+
+    super
+  end
+end

--- a/app/app/javascript/controllers/demo_launcher_controller.js
+++ b/app/app/javascript/controllers/demo_launcher_controller.js
@@ -184,7 +184,14 @@ export default class extends Controller {
   }
 
   humanizeLaunchType(launchType) {
-    return launchType === "generic" ? "Generic" : "Tokenized"
+    switch (launchType) {
+      case "generic":
+        return "Generic"
+      case "household":
+        return "Household"
+      default:
+        return "Tokenized"
+    }
   }
 
   resetCopyButton() {

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -18,6 +18,8 @@ class ActivityFlow < Flow
 
   before_create :set_default_reporting_window, :set_default_renewal_required_months
 
+  scope :incomplete, -> { where(completed_at: nil) }
+
   def self.create_from_invitation(invitation, device_id, params = {})
     flow = create(
       activity_flow_invitation: invitation,
@@ -29,6 +31,11 @@ class ActivityFlow < Flow
     hydrate_pre_populated_activities!(flow, invitation) if flow.persisted?
 
     flow
+  end
+
+  def self.resume_or_create_from_invitation(invitation, device_id, params = {})
+    invitation.activity_flows.incomplete.order(created_at: :desc).first ||
+      create_from_invitation(invitation, device_id, params)
   end
 
   def self.hydrate_pre_populated_activities!(flow, invitation)

--- a/app/app/models/household.rb
+++ b/app/app/models/household.rb
@@ -1,0 +1,12 @@
+class Household < ApplicationRecord
+  has_many :household_members, dependent: :destroy
+
+  has_secure_token :auth_token, length: 10
+
+  validates :client_agency_id, inclusion: Rails.application.config.client_agencies.client_agency_ids
+  validates :reference_id, presence: true, uniqueness: true
+
+  def to_url(host: ENV.fetch("DOMAIN_NAME", "localhost"), **url_params)
+    Rails.application.routes.url_helpers.household_start_url(token: auth_token, host: host, **url_params)
+  end
+end

--- a/app/app/models/household_member.rb
+++ b/app/app/models/household_member.rb
@@ -1,0 +1,8 @@
+class HouseholdMember < ApplicationRecord
+  belongs_to :household
+  belongs_to :activity_flow_invitation
+
+  validates :display_name, :role_label, :reference_id, presence: true
+  validates :reference_id, uniqueness: { scope: :household_id }
+  validates :activity_flow_invitation_id, uniqueness: true
+end

--- a/app/app/services/demo_launcher/household_scenario.rb
+++ b/app/app/services/demo_launcher/household_scenario.rb
@@ -1,5 +1,5 @@
 class DemoLauncher::HouseholdScenario
-  REFERENCE_ID = "demo-household-v1"
+  REFERENCE_ID = "household-scenario"
   MEMBERS = [
     {
       reference_id: "avery",

--- a/app/app/services/demo_launcher/household_scenario.rb
+++ b/app/app/services/demo_launcher/household_scenario.rb
@@ -1,0 +1,74 @@
+class DemoLauncher::HouseholdScenario
+  REFERENCE_ID = "demo-household-v1"
+  MEMBERS = [
+    {
+      reference_id: "avery",
+      display_name: "Avery Johnson",
+      role_label: "Parent",
+      date_of_birth: Date.new(1985, 4, 12)
+    },
+    {
+      reference_id: "riley",
+      display_name: "Riley Johnson",
+      role_label: "Child",
+      date_of_birth: Date.new(2004, 9, 3)
+    }
+  ].freeze
+
+  def self.find_or_create!(client_agency_id: "sandbox")
+    new(client_agency_id).find_or_create!
+  end
+
+  def initialize(client_agency_id)
+    @client_agency_id = client_agency_id
+  end
+
+  def find_or_create!
+    Household.transaction do
+      household = Household.find_or_create_by!(reference_id: household_reference_id) do |record|
+        record.client_agency_id = client_agency_id
+      end
+
+      MEMBERS.each do |member_data|
+        invitation = find_or_create_invitation(member_data)
+        member = household.household_members.find_or_initialize_by(reference_id: member_data.fetch(:reference_id))
+        member.update!(
+          activity_flow_invitation: invitation,
+          display_name: member_data.fetch(:display_name),
+          role_label: member_data.fetch(:role_label)
+        )
+      end
+
+      household
+    end
+  end
+
+  private
+
+  attr_reader :client_agency_id
+
+  def household_reference_id
+    "#{REFERENCE_ID}-#{client_agency_id}"
+  end
+
+  def find_or_create_invitation(member_data)
+    applicant = find_or_create_applicant(member_data)
+    ActivityFlowInvitation.find_or_create_by!(reference_id: "#{household_reference_id}-#{member_data.fetch(:reference_id)}") do |invitation|
+      invitation.client_agency_id = client_agency_id
+      invitation.cbv_applicant = applicant
+    end.tap do |invitation|
+      invitation.update!(client_agency_id: client_agency_id, cbv_applicant: applicant)
+    end
+  end
+
+  def find_or_create_applicant(member_data)
+    CbvApplicant.find_or_create_by!(
+      client_agency_id: client_agency_id,
+      first_name: member_data.fetch(:display_name).split.first,
+      last_name: member_data.fetch(:display_name).split.last,
+      date_of_birth: member_data.fetch(:date_of_birth)
+    ) do |applicant|
+      applicant.snap_application_date = Date.current
+    end
+  end
+end

--- a/app/app/services/demo_launcher/household_scenario.rb
+++ b/app/app/services/demo_launcher/household_scenario.rb
@@ -52,23 +52,19 @@ class DemoLauncher::HouseholdScenario
   end
 
   def find_or_create_invitation(member_data)
-    applicant = find_or_create_applicant(member_data)
     ActivityFlowInvitation.find_or_create_by!(reference_id: "#{household_reference_id}-#{member_data.fetch(:reference_id)}") do |invitation|
       invitation.client_agency_id = client_agency_id
-      invitation.cbv_applicant = applicant
-    end.tap do |invitation|
-      invitation.update!(client_agency_id: client_agency_id, cbv_applicant: applicant)
+      invitation.cbv_applicant = create_applicant(member_data)
     end
   end
 
-  def find_or_create_applicant(member_data)
-    CbvApplicant.find_or_create_by!(
+  def create_applicant(member_data)
+    CbvApplicant.create!(
       client_agency_id: client_agency_id,
       first_name: member_data.fetch(:display_name).split.first,
       last_name: member_data.fetch(:display_name).split.last,
-      date_of_birth: member_data.fetch(:date_of_birth)
-    ) do |applicant|
-      applicant.snap_application_date = Date.current
-    end
+      date_of_birth: member_data.fetch(:date_of_birth),
+      snap_application_date: Date.current
+    )
   end
 end

--- a/app/app/views/demo_launcher/advanced.html.erb
+++ b/app/app/views/demo_launcher/advanced.html.erb
@@ -362,6 +362,14 @@
           data-demo-launcher-target="genericButton">
           Generic
         </button>
+        <button
+          type="submit"
+          name="launch_type"
+          value="household"
+          class="usa-button demo-launcher__launch-button"
+          data-action="demo-launcher#generateShareLink">
+          Test household
+        </button>
       </div>
 
       <div class="demo-launcher__share-widget" hidden data-demo-launcher-target="shareWidget">

--- a/app/app/views/households/show.html.erb
+++ b/app/app/views/households/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, t(".title") %>
+
+<h1>
+  <%= t(".title") %>
+</h1>
+
+<p>
+  <%= t(".description") %>
+</p>
+
+<div class="margin-top-4">
+  <% @household.household_members.order(:id).each do |member| %>
+    <div class="border border-base-lighter radius-md padding-3 margin-bottom-2">
+      <h2 class="font-heading-md margin-y-0">
+        <%= member.display_name %>
+      </h2>
+      <p class="margin-top-1 margin-bottom-2">
+        <%= member.role_label %>
+      </p>
+      <%= button_to(
+            t(".launch"),
+            household_member_launch_path(token: @household.auth_token, member_id: member.id),
+            method: :post,
+            class: "usa-button"
+          ) %>
+    </div>
+  <% end %>
+</div>

--- a/app/config/i18n-tasks.yml
+++ b/app/config/i18n-tasks.yml
@@ -150,6 +150,7 @@ ignore_missing:
     - "activerecord.errors.models.volunteering_activity_month.*" # Self attestation hours entry error messages
     - "activerecord.errors.models.job_training_activity_month.*" # Self attestation hours entry error messages
     - "shared.header.logo_alt_text.nh_dhhs"
+    - "households.*"
 
     # Currently awaiting translation:
     # - "example.strings.*"   # Tag with ticket number that created or modified the string

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -1124,6 +1124,14 @@ en:
           content: Ask your employer's HR team to help get your payroll login details.
           title: Contact your employer's Human Resource Team
         title: I don't know my username
+  households:
+    errors:
+      invalid_member: The household member you selected is invalid.
+      invalid_token: The link you used is invalid.
+    show:
+      description: Select the person whose community engagement report you want to work on.
+      launch: Get started
+      title: Who are you reporting for?
   maintenance:
     body_1: The site is not available right now. Any information you entered will not be saved.
     body_2: Visit your agency's website for more information on how to submit proof of income for your benefits.

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -111,6 +111,9 @@ Rails.application.routes.draw do
         root to: "entries#show", as: :new
       end
     end
+
+    get "/households/start/:token", to: "households#show", as: :household_start, token: /[^\/]+/
+    post "/households/start/:token/members/:member_id", to: "household_members#create", as: :household_member_launch, token: /[^\/]+/
   end
 
   namespace :webhooks do

--- a/app/db/migrate/20260629120000_create_households.rb
+++ b/app/db/migrate/20260629120000_create_households.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateHouseholds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :households do |t|
+      t.string :auth_token, null: false
+      t.string :reference_id, null: false
+      t.string :client_agency_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :households, :auth_token, unique: true
+    add_index :households, :reference_id, unique: true
+
+    create_table :household_members do |t|
+      t.references :household, null: false, foreign_key: true
+      t.references :activity_flow_invitation, null: false, foreign_key: true, index: { unique: true }
+      t.string :reference_id, null: false
+      t.string :display_name, null: false
+      t.string :role_label, null: false
+
+      t.timestamps
+    end
+
+    add_index :household_members, %i[household_id reference_id], unique: true
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -234,6 +234,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_120000) do
     t.date "month", null: false
     t.datetime "updated_at", null: false
     t.index ["employment_activity_id"], name: "index_employment_activity_months_on_employment_activity_id"
+  end
+
+  create_table "household_members", force: :cascade do |t|
+    t.bigint "activity_flow_invitation_id", null: false
+    t.datetime "created_at", null: false
+    t.string "display_name", null: false
+    t.bigint "household_id", null: false
+    t.string "reference_id", null: false
+    t.string "role_label", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_flow_invitation_id"], name: "index_household_members_on_activity_flow_invitation_id", unique: true
+    t.index ["household_id", "reference_id"], name: "index_household_members_on_household_id_and_reference_id", unique: true
+    t.index ["household_id"], name: "index_household_members_on_household_id"
+  end
+
+  create_table "households", force: :cascade do |t|
+    t.string "auth_token", null: false
+    t.string "client_agency_id", null: false
+    t.datetime "created_at", null: false
+    t.string "reference_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["auth_token"], name: "index_households_on_auth_token", unique: true
+    t.index ["reference_id"], name: "index_households_on_reference_id", unique: true
   end
 
   create_table "identities", force: :cascade do |t|
@@ -506,6 +529,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_120000) do
   add_foreign_key "education_activity_months", "education_activities"
   add_foreign_key "employment_activities", "activity_flows"
   add_foreign_key "employment_activity_months", "employment_activities"
+  add_foreign_key "household_members", "activity_flow_invitations"
+  add_foreign_key "household_members", "households"
   add_foreign_key "job_training_activities", "activity_flows"
   add_foreign_key "job_training_activity_months", "job_training_activities"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/app/spec/controllers/demo_launcher_controller_spec.rb
+++ b/app/spec/controllers/demo_launcher_controller_spec.rb
@@ -206,6 +206,47 @@ RSpec.describe DemoLauncherController, type: :controller do
       end
     end
 
+    context "with a household launch" do
+      it "creates the test household and redirects to its URL" do
+        expect {
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "household"
+          }
+        }.to change(Household, :count).by(1)
+          .and change(HouseholdMember, :count).by(2)
+
+        expect(response).to redirect_to(Household.last.to_url(host: "test.host"))
+      end
+
+      it "returns the household URL as JSON" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "household"
+        }, format: :json
+
+        parsed_response = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:success)
+        expect(parsed_response.fetch("url")).to include("/households/start/#{Household.last.auth_token}")
+      end
+
+      it "does not apply pre-populated activity controls to the test household invitations" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "household",
+          volunteering_enabled: "1",
+          volunteering_organization_name: "Red Cross",
+          volunteering_hours_per_month: "12"
+        }
+
+        pre_populated_activities = Household.last.household_members.map do |member|
+          member.activity_flow_invitation.pre_populated_activities
+        end
+        expect(pre_populated_activities).to all(eq([]))
+      end
+    end
+
     context "with CBV flow type" do
       context "with a generic launch" do
         it "redirects to the CBV generic link" do

--- a/app/spec/controllers/household_members_controller_spec.rb
+++ b/app/spec/controllers/household_members_controller_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe HouseholdMembersController, type: :controller do
+  include_context "activity_hub"
+
+  describe "POST #create" do
+    let(:household) { create(:household) }
+    let(:member) { create(:household_member, household: household) }
+
+    it "creates a member activity flow, sets the activity session, and routes to the activity hub" do
+      expect {
+        post :create, params: { token: household.auth_token, member_id: member.id }
+      }.to change(ActivityFlow, :count).by(1)
+
+      flow = ActivityFlow.last
+      expect(flow.activity_flow_invitation).to eq(member.activity_flow_invitation)
+      expect(session[:flow_id]).to eq(flow.id)
+      expect(session[:flow_type]).to eq(:activity)
+      expect(response).to redirect_to(activities_flow_root_path)
+    end
+
+    it "uses separate activity flows for separate members" do
+      member_a = create(:household_member, household: household)
+      member_b = create(:household_member, household: household)
+
+      post :create, params: { token: household.auth_token, member_id: member_a.id }
+      member_a_flow_id = session[:flow_id]
+
+      post :create, params: { token: household.auth_token, member_id: member_b.id }
+      member_b_flow_id = session[:flow_id]
+
+      expect(member_b_flow_id).not_to eq(member_a_flow_id)
+      expect(ActivityFlow.find(member_a_flow_id).activity_flow_invitation).to eq(member_a.activity_flow_invitation)
+      expect(ActivityFlow.find(member_b_flow_id).activity_flow_invitation).to eq(member_b.activity_flow_invitation)
+    end
+
+    it "resumes an incomplete member activity flow" do
+      existing_flow = create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: nil)
+
+      expect {
+        post :create, params: { token: household.auth_token, member_id: member.id }
+      }.not_to change(ActivityFlow, :count)
+
+      expect(session[:flow_id]).to eq(existing_flow.id)
+      expect(response).to redirect_to(activities_flow_root_path)
+    end
+
+    it "does not use another member's incomplete activity flow" do
+      member_a = create(:household_member, household: household)
+      member_b = create(:household_member, household: household)
+      create(:activity_flow, activity_flow_invitation: member_a.activity_flow_invitation, completed_at: nil)
+
+      expect {
+        post :create, params: { token: household.auth_token, member_id: member_b.id }
+      }.to change(ActivityFlow, :count).by(1)
+
+      expect(ActivityFlow.find(session[:flow_id]).activity_flow_invitation).to eq(member_b.activity_flow_invitation)
+    end
+
+    it "does not launch a member from another household" do
+      other_member = create(:household_member, household: create(:household))
+
+      expect {
+        post :create, params: { token: household.auth_token, member_id: other_member.id }
+      }.not_to change(ActivityFlow, :count)
+
+      expect(response).to redirect_to(household_start_path(token: household.auth_token))
+      expect(flash[:alert]).to eq("The household member you selected is invalid.")
+      expect(session[:flow_id]).to be_nil
+    end
+
+    it "uses the household client agency as the current agency" do
+      la_household = create(:household, client_agency_id: "la_ldh")
+      la_member = create(:household_member, household: la_household)
+
+      post :create, params: { token: la_household.auth_token, member_id: la_member.id }
+
+      expect(controller.send(:current_agency)).to eq(Rails.application.config.client_agencies["la_ldh"])
+    end
+
+    it "redirects to home when ACTIVITY_HUB_ENABLED is not set" do
+      stub_environment_variable("ACTIVITY_HUB_ENABLED", nil) do
+        post :create, params: { token: household.auth_token, member_id: member.id }
+      end
+
+      expect(response).to redirect_to(root_url)
+    end
+  end
+end

--- a/app/spec/controllers/households_controller_spec.rb
+++ b/app/spec/controllers/households_controller_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe HouseholdsController, type: :controller do
+  include_context "activity_hub"
+
+  render_views
+
+  describe "GET #show" do
+    let(:household) { create(:household) }
+
+    it "shows household members for a household token" do
+      create(:household_member, household: household, display_name: "Avery Johnson", role_label: "Parent")
+      create(:household_member, household: household, display_name: "Riley Johnson", role_label: "Child")
+
+      get :show, params: { token: household.auth_token }
+
+      rendered = Capybara.string(response.body)
+      expect(response).to have_http_status(:success)
+      expect(rendered).to have_text("Who are you reporting for?")
+      expect(rendered).to have_text("Avery Johnson")
+      expect(rendered).to have_text("Parent")
+      expect(rendered).to have_text("Riley Johnson")
+      expect(rendered).to have_text("Child")
+    end
+
+    it "renders launch controls for each member" do
+      member = create(:household_member, household: household)
+
+      get :show, params: { token: household.auth_token }
+
+      member_launch_path = household_member_launch_path(token: household.auth_token, member_id: member.id)
+      rendered = Capybara.string(response.body)
+      expect(rendered).to have_selector(
+        "form[action='#{member_launch_path}'][method='post']",
+        text: "Get started"
+      )
+    end
+
+    it "keeps the same household available when the link is reopened" do
+      get :show, params: { token: household.auth_token }
+      get :show, params: { token: household.auth_token }
+
+      expect(assigns(:household)).to eq(household)
+    end
+
+    it "clears any previous flow session before member selection" do
+      session[:flow_id] = create(:activity_flow).id
+      session[:flow_type] = :activity
+
+      get :show, params: { token: household.auth_token }
+
+      expect(session[:flow_id]).to be_nil
+      expect(session[:flow_type]).to eq(:activity)
+    end
+
+    it "redirects invalid household tokens to home" do
+      get :show, params: { token: "notatoken" }
+
+      expect(response).to redirect_to(root_url)
+      expect(flash[:alert]).to eq("The link you used is invalid.")
+    end
+
+    it "accepts a household token with trailing URL-safe punctuation" do
+      get :show, params: { token: "#{household.auth_token}_" }
+
+      expect(assigns(:household)).to eq(household)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "uses the household client agency as the current agency" do
+      la_household = create(:household, client_agency_id: "la_ldh")
+      create(:household_member, household: la_household)
+
+      get :show, params: { token: la_household.auth_token }
+
+      expect(controller.send(:current_agency)).to eq(Rails.application.config.client_agencies["la_ldh"])
+    end
+
+    it "redirects to home when ACTIVITY_HUB_ENABLED is not set" do
+      stub_environment_variable("ACTIVITY_HUB_ENABLED", nil) do
+        get :show, params: { token: household.auth_token }
+      end
+
+      expect(response).to redirect_to(root_url)
+    end
+  end
+end

--- a/app/spec/factories/household_members.rb
+++ b/app/spec/factories/household_members.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :household_member do
+    household
+    activity_flow_invitation
+    sequence(:reference_id) { |n| "member-#{n}" }
+    display_name { "Avery Johnson" }
+    role_label { "Parent" }
+  end
+end

--- a/app/spec/factories/households.rb
+++ b/app/spec/factories/households.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :household do
+    client_agency_id { "sandbox" }
+    sequence(:reference_id) { |n| "household-#{n}" }
+  end
+end

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -344,6 +344,42 @@ RSpec.describe ActivityFlow, type: :model do
     end
   end
 
+  describe ".resume_or_create_from_invitation" do
+    let(:device_id) { "device123" }
+    let(:invitation) { create(:activity_flow_invitation) }
+
+    it "creates a flow when the invitation has no incomplete flows" do
+      flow = described_class.resume_or_create_from_invitation(invitation, device_id)
+
+      expect(flow).to be_persisted
+      expect(flow.activity_flow_invitation).to eq(invitation)
+      expect(flow.device_id).to eq(device_id)
+    end
+
+    it "resumes an incomplete flow for the invitation" do
+      existing_flow = create(:activity_flow, activity_flow_invitation: invitation, completed_at: nil)
+
+      expect {
+        expect(described_class.resume_or_create_from_invitation(invitation, device_id)).to eq(existing_flow)
+      }.not_to change(described_class, :count)
+    end
+
+    it "resumes an incomplete flow for the invitation across devices" do
+      existing_flow = create(:activity_flow, activity_flow_invitation: invitation, device_id: "other-device", completed_at: nil)
+
+      expect(described_class.resume_or_create_from_invitation(invitation, "new-device")).to eq(existing_flow)
+    end
+
+    it "creates a new flow when the invitation only has completed flows" do
+      create(:activity_flow, activity_flow_invitation: invitation, completed_at: Time.current)
+
+      expect {
+        flow = described_class.resume_or_create_from_invitation(invitation, device_id)
+        expect(flow).not_to be_complete
+      }.to change(described_class, :count).by(1)
+    end
+  end
+
   describe "reporting_window" do
     let(:flow) { create(:activity_flow, reporting_window_months: 2) }
 

--- a/app/spec/models/household_member_spec.rb
+++ b/app/spec/models/household_member_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe HouseholdMember, type: :model do
+  let(:household) { create(:household) }
+
+  it "connects a household member to an activity flow invitation" do
+    invitation = create(:activity_flow_invitation)
+    member = create(:household_member, activity_flow_invitation: invitation)
+
+    expect(member.activity_flow_invitation).to eq(invitation)
+  end
+
+  it "requires a member-specific activity flow invitation" do
+    invitation = create(:activity_flow_invitation)
+    create(:household_member, activity_flow_invitation: invitation)
+
+    member = build(:household_member, activity_flow_invitation: invitation)
+
+    expect(member).not_to be_valid
+    expect(member.errors[:activity_flow_invitation_id]).to include("has already been taken")
+  end
+
+  it "requires display fields and a reference id" do
+    member = build(:household_member, display_name: nil, role_label: nil, reference_id: nil)
+
+    expect(member).not_to be_valid
+    expect(member.errors[:display_name]).to include("can't be blank")
+    expect(member.errors[:role_label]).to include("can't be blank")
+    expect(member.errors[:reference_id]).to include("can't be blank")
+  end
+
+  it "requires a member reference id to be unique within the household" do
+    create(:household_member, household: household, reference_id: "avery")
+
+    member = build(:household_member, household: household, reference_id: "avery")
+
+    expect(member).not_to be_valid
+    expect(member.errors[:reference_id]).to include("has already been taken")
+  end
+
+  it "allows the same member reference id in different households" do
+    create(:household_member, household: household, reference_id: "avery")
+
+    member = build(:household_member, reference_id: "avery")
+
+    expect(member).to be_valid
+  end
+end

--- a/app/spec/models/household_spec.rb
+++ b/app/spec/models/household_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Household, type: :model do
+  let(:household) { create(:household) }
+
+  it "has a tokenized household URL" do
+    expect(household.to_url(host: "example.test")).to eq("http://example.test/households/start/#{household.auth_token}")
+  end
+
+  it "has household members" do
+    member = create(:household_member, household: household)
+
+    expect(household.household_members).to contain_exactly(member)
+  end
+
+  it "requires a reference id" do
+    household = build(:household, reference_id: nil)
+
+    expect(household).not_to be_valid
+    expect(household.errors[:reference_id]).to include("can't be blank")
+  end
+
+  it "requires a unique reference id" do
+    existing_household = create(:household)
+    household = build(:household, reference_id: existing_household.reference_id)
+
+    expect(household).not_to be_valid
+    expect(household.errors[:reference_id]).to include("has already been taken")
+  end
+
+  it "requires a known client agency" do
+    household = build(:household, client_agency_id: "not_an_agency")
+
+    expect(household).not_to be_valid
+    expect(household.errors[:client_agency_id]).to include("is not included in the list")
+  end
+end

--- a/app/spec/services/demo_launcher/household_scenario_spec.rb
+++ b/app/spec/services/demo_launcher/household_scenario_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe DemoLauncher::HouseholdScenario do
       invitations = household.household_members.map(&:activity_flow_invitation)
       expect(invitations).to all(be_present)
       expect(invitations.uniq.size).to eq(invitations.size)
+      expect(invitations.map(&:cbv_applicant)).to all(be_present)
+      expect(invitations.map(&:cbv_applicant).uniq.size).to eq(invitations.size)
     end
 
     it "reuses the same household and members" do
@@ -18,7 +20,8 @@ RSpec.describe DemoLauncher::HouseholdScenario do
       counts = {
         households: Household.count,
         household_members: HouseholdMember.count,
-        activity_flow_invitations: ActivityFlowInvitation.count
+        activity_flow_invitations: ActivityFlowInvitation.count,
+        cbv_applicants: CbvApplicant.count
       }
 
       same_household = described_class.find_or_create!(client_agency_id: "sandbox")
@@ -27,6 +30,30 @@ RSpec.describe DemoLauncher::HouseholdScenario do
       expect(Household.count).to eq(counts.fetch(:households))
       expect(HouseholdMember.count).to eq(counts.fetch(:household_members))
       expect(ActivityFlowInvitation.count).to eq(counts.fetch(:activity_flow_invitations))
+      expect(CbvApplicant.count).to eq(counts.fetch(:cbv_applicants))
+    end
+
+    it "does not reuse an existing applicant that matches a member's name and date of birth" do
+      create(
+        :cbv_applicant,
+        client_agency_id: "sandbox",
+        first_name: "Avery",
+        last_name: "Johnson",
+        date_of_birth: Date.new(1985, 4, 12)
+      )
+
+      household = nil
+      expect {
+        household = described_class.find_or_create!(client_agency_id: "sandbox")
+      }.to change(CbvApplicant, :count).by(2)
+
+      avery_member = household.household_members.find_by!(reference_id: "avery")
+
+      expect(avery_member.activity_flow_invitation.cbv_applicant).to have_attributes(
+        first_name: "Avery",
+        last_name: "Johnson",
+        date_of_birth: Date.new(1985, 4, 12)
+      )
     end
 
     it "creates separate test households per agency" do

--- a/app/spec/services/demo_launcher/household_scenario_spec.rb
+++ b/app/spec/services/demo_launcher/household_scenario_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe DemoLauncher::HouseholdScenario do
+  describe ".find_or_create!" do
+    it "creates a test household with two members and member invitations" do
+      household = described_class.find_or_create!(client_agency_id: "sandbox")
+
+      expect(household.client_agency_id).to eq("sandbox")
+      expect(household.household_members.map(&:display_name)).to contain_exactly("Avery Johnson", "Riley Johnson")
+      expect(household.household_members.map(&:role_label)).to contain_exactly("Parent", "Child")
+      invitations = household.household_members.map(&:activity_flow_invitation)
+      expect(invitations).to all(be_present)
+      expect(invitations.uniq.size).to eq(invitations.size)
+    end
+
+    it "reuses the same household and members" do
+      household = described_class.find_or_create!(client_agency_id: "sandbox")
+      counts = {
+        households: Household.count,
+        household_members: HouseholdMember.count,
+        activity_flow_invitations: ActivityFlowInvitation.count
+      }
+
+      same_household = described_class.find_or_create!(client_agency_id: "sandbox")
+
+      expect(same_household).to eq(household)
+      expect(Household.count).to eq(counts.fetch(:households))
+      expect(HouseholdMember.count).to eq(counts.fetch(:household_members))
+      expect(ActivityFlowInvitation.count).to eq(counts.fetch(:activity_flow_invitations))
+    end
+
+    it "creates separate test households per agency" do
+      sandbox_household = described_class.find_or_create!(client_agency_id: "sandbox")
+      la_household = described_class.find_or_create!(client_agency_id: "la_ldh")
+
+      expect(la_household).not_to eq(sandbox_household)
+      expect(la_household.reference_id).not_to eq(sandbox_household.reference_id)
+      sandbox_invitations = sandbox_household.household_members.map(&:activity_flow_invitation)
+      la_invitations = la_household.household_members.map(&:activity_flow_invitation)
+      expect(la_invitations & sandbox_invitations).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## [FFS-4463](https://jiraent.cms.gov/browse/FFS-4463)

## Changes
- We have a new household link path that opens member selection
- Created the minimal Household / HouseholdMember models for the V1 MVP bridge
- Advanced launcher has a hardcoded household with two members
- Member launch behavior resumes an incomplete member flow or creates one

## Context for reviewers
Did a little refactoring of shared methods into `ApplicationController`.

Addressed the applicant collision without using `case_number` which is agency-specific. The household scenario now uses its invitation reference as the anchor. In the future, we can slot in any household or member reference ID from another source. 

Session management is a future conversation with more clarity and out of scope.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1873.navapbc.cloud/launcher/advanced
- Deployed commit: f34a322f5791aa51f6b036dcd4c444db7a4bdd28
<!-- end PR environment info -->