### PR TITLE
FFS-4483: Use AWS ECS Deploy task instead of jq to deploy to CMS

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,7 +35,7 @@ The CD workflow uses these reusable workflows:
 - [`database-migrations`](./database-migrations.yml): runs database migrations for an application
 - [`build-and-publish`](./build-and-publish.yml): builds a container image for an application and publishes it to an image repository
 - [`deploy-cms`](./deploy-cms.yml): builds and publishes a SHA-tagged CMS image, then deploys that same image tag to CMS
-- [`deploy-ecs`](./deploy-ecs.yml): updates a CMS ECS service to use an existing image tag
+- [`deploy-ecs`](./deploy-ecs.yml): updates the CMS ECS `app` and `solid-queue` services to an existing image tag, using `aws-actions/amazon-ecs-render-task-definition` and `aws-actions/amazon-ecs-deploy-task-definition`
 - [`build-and-publish-to-cms`](./build-and-publish-to-cms.yml): builds and publishes a SHA-tagged image to the CMS image repository
 
 ```mermaid
@@ -48,9 +48,11 @@ graph TD
   cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|build-and-publish
 ```
 
-CMS deploys use `deploy-cms` when the image should be built and deployed from
-one workflow dispatch. It resolves the requested ref to a commit SHA, publishes
-that SHA-tagged image if needed, and then deploys the same SHA tag.
+`deploy-cms` builds and deploys a CMS image in one run: it resolves the
+requested ref to a commit SHA, publishes that SHA-tagged image if needed, and
+then deploys the same SHA tag. It runs automatically on every push to `main`
+(deploying to `uat`) and can also be triggered via `workflow_dispatch` to pick a
+different environment or ref.
 
 ## ⛑️ Helper workflows
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,12 +48,6 @@ graph TD
   cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|build-and-publish
 ```
 
-`deploy-cms` builds and deploys a CMS image in one run: it resolves the
-requested ref to a commit SHA, publishes that SHA-tagged image if needed, and
-then deploys the same SHA tag. It runs automatically on every push to `main`
-(deploying to `uat`) and can also be triggered via `workflow_dispatch` to pick a
-different environment or ref.
-
 ## ⛑️ Helper workflows
 
 - [`check-ci-cd-auth`](./check-ci-cd-auth.yml): verifes that the project's Github repo is able to connect to AWS

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -1,7 +1,14 @@
 name: Deploy to CMS
-run-name: Deploy ${{ inputs.ref }} to CMS app (${{ inputs.environment }})
+run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment }})
 
 on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "app/**"
+      - "bin/**"
+      - "infra/**"
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -2,13 +2,14 @@ name: Deploy to CMS
 run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment }})
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "app/**"
-      - "bin/**"
-      - "infra/**"
+# TODO: Uncomment when were ready to push to environments automatically
+# push:
+#    branches:
+#      - "main"
+#    paths:
+#      - "app/**"
+#      - "bin/**"
+#      - "infra/**"
   workflow_call:
     inputs:
       environment:
@@ -24,7 +25,6 @@ on:
       environment:
         description: "the name of the application environment (e.g. uat)"
         required: true
-        default: "uat"
         type: string
       ref:
         description: "the branch, tag, or SHA to deploy"

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -1,5 +1,5 @@
 name: Deploy to CMS
-run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment || 'uat' }})
+run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment }})
 
 on:
   push:
@@ -31,7 +31,7 @@ on:
         required: true
         type: string
 
-concurrency: deploy-cms-app-${{ inputs.environment || 'uat' }}
+concurrency: deploy-cms-app-${{ inputs.environment }}
 
 jobs:
   get-commit-hash:
@@ -74,6 +74,6 @@ jobs:
       id-token: write
     with:
       app_name: app
-      environment: ${{ inputs.environment || 'uat' }}
+      environment: ${{ inputs.environment }}
       image_tag: ${{ needs.get-commit-hash.outputs.commit_hash }}
     secrets: inherit

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -1,5 +1,5 @@
 name: Deploy to CMS
-run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment }})
+run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment || 'uat' }})
 
 on:
   push:
@@ -31,7 +31,7 @@ on:
         required: true
         type: string
 
-concurrency: deploy-cms-app-${{ inputs.environment }}
+concurrency: deploy-cms-app-${{ inputs.environment || 'uat' }}
 
 jobs:
   get-commit-hash:
@@ -74,6 +74,6 @@ jobs:
       id-token: write
     with:
       app_name: app
-      environment: ${{ inputs.environment }}
+      environment: ${{ inputs.environment || 'uat' }}
       image_tag: ${{ needs.get-commit-hash.outputs.commit_hash }}
     secrets: inherit

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -41,12 +41,10 @@ jobs:
     env:
       EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
       AWS_REGION: us-east-1
+      CLUSTER_NAME: emmy-${{ inputs.environment }}
 
     steps:
       - uses: actions/checkout@v7
-
-      - name: Set up Terraform
-        uses: ./.github/actions/setup-terraform
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -54,11 +52,70 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
-      - name: Deploy release
-        shell: bash
+      - name: Verify image is published to ECR
         run: |
-          make APP_NAME=${{ inputs.app_name }} \
-            ENVIRONMENT=${{ inputs.environment }} \
-            EMMY_IMAGE_REPO=${{ env.EMMY_IMAGE_REPO }} \
-            EMMY_IMAGE_TAG=${{ inputs.image_tag }} \
-            release-update-ecs
+          is_image_published=$(./bin/is-ecr-image-published "${EMMY_IMAGE_REPO}" "${{ inputs.image_tag }}")
+          echo "Is image published: ${is_image_published}"
+          if [ "${is_image_published}" != "true" ]; then
+            echo "Error: image tag not found in ECR: ${EMMY_IMAGE_REPO}:${{ inputs.image_tag }}" >&2
+            echo "Run Deploy to CMS, or build-and-publish with publish_to_cms=true, before deploying." >&2
+            exit 1
+          fi
+
+      - name: Download app task definition
+        run: |
+          task_def_arn=$(aws ecs describe-services \
+            --cluster "${CLUSTER_NAME}" \
+            --services "emmy-${{ inputs.environment }}-app" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "Current app task definition: ${task_def_arn}"
+          aws ecs describe-task-definition \
+            --task-definition "${task_def_arn}" \
+            --query taskDefinition --output json > app-task-definition.json
+
+      - name: Render app task definition
+        id: render-app
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: app-task-definition.json
+          container-name: emmy-app
+          image: ${{ env.EMMY_IMAGE_REPO }}:${{ inputs.image_tag }}
+          environment-variables: |
+            IMAGE_TAG=${{ inputs.image_tag }}
+
+      - name: Deploy app service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-app.outputs.task-definition }}
+          service: emmy-${{ inputs.environment }}-app
+          cluster: ${{ env.CLUSTER_NAME }}
+          wait-for-service-stability: true
+
+      - name: Download solid-queue task definition
+        run: |
+          task_def_arn=$(aws ecs describe-services \
+            --cluster "${CLUSTER_NAME}" \
+            --services "emmy-${{ inputs.environment }}-solid-queue" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "Current solid-queue task definition: ${task_def_arn}"
+          aws ecs describe-task-definition \
+            --task-definition "${task_def_arn}" \
+            --query taskDefinition --output json > solid-queue-task-definition.json
+
+      - name: Render solid-queue task definition
+        id: render-solid-queue
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: solid-queue-task-definition.json
+          container-name: emmy-app-solid-queue
+          image: ${{ env.EMMY_IMAGE_REPO }}:${{ inputs.image_tag }}
+          environment-variables: |
+            IMAGE_TAG=${{ inputs.image_tag }}
+
+      - name: Deploy solid-queue service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-solid-queue.outputs.task-definition }}
+          service: emmy-${{ inputs.environment }}-solid-queue
+          cluster: ${{ env.CLUSTER_NAME }}
+          wait-for-service-stability: true


### PR DESCRIPTION
## [FFS-4483](https://jiraent.cms.gov/browse/FFS-4483)

## Changes
Deploying using a more standard AWS ECS deploy task. 

## Context for reviewers
We pulled the auto-deploy out of this ticket so it can only be triggered via API (which was how I tested it) or manually via `workflow_dispatch`. 

## Acceptance testing
- [X] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.

Accepted after [deploying successfully from the branch.](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/28829338249/job/85500257367). The UAT [/health endpoint shows the sha for the first commit (b85e428)](https://uat.emmy.cms.gov/health).


## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

## Infrastructure Changes
Yes, but not Terraform changes. Testing by deploying manually from this branch and ensuring UAT is up and operational. 