### PR TITLE
FFS-4316: Only list prefilled activities in a hub

### DIFF
--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -591,7 +591,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/app/app/assets/stylesheets/advanced-launcher.scss
+++ b/app/app/assets/stylesheets/advanced-launcher.scss
@@ -240,6 +240,14 @@
     & + & {
       border-top: 1px solid color("base-lighter");
     }
+
+    &--disabled {
+      opacity: 0.5;
+
+      .usa-checkbox__label {
+        cursor: not-allowed;
+      }
+    }
   }
 
   .advanced-launcher__activity-header {

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -61,15 +61,12 @@ class Api::InvitationsController < ApplicationController
   end
 
   def pre_populated_activities_param
+    activity_classes = ActivityFlowInvitation::ACTIVITY_TYPES.values
+    activity_fields = activity_classes.flat_map { |k| k::FIELDS }.uniq
+    month_fields = activity_classes.flat_map { |k| k.activity_months_class::FIELDS }.uniq.map(&:to_sym)
+
     params.fetch(:activities, []).map do |entry|
-      entry.permit(
-        :type,
-        *VolunteeringActivity::FIELDS,
-        *EmploymentActivity::FIELDS,
-        *EducationActivity::FIELDS,
-        *JobTrainingActivity::FIELDS,
-        months: (VolunteeringActivityMonth::FIELDS | EmploymentActivityMonth::FIELDS | EducationActivityMonth::FIELDS | JobTrainingActivityMonth::FIELDS).map(&:to_sym)
-      ).to_h
+      entry.permit(:type, *activity_fields, months: month_fields).to_h
     end
   end
 

--- a/app/app/controllers/launcher_controller.rb
+++ b/app/app/controllers/launcher_controller.rb
@@ -1,5 +1,5 @@
 class LauncherController < ApplicationController
-  helper_method :session_timeout_enabled?
+  helper_method :session_timeout_enabled?, :agency_activity_types
   before_action :set_launcher_flow, only: [ :advanced, :launcher ]
 
   def advanced; end
@@ -115,6 +115,12 @@ class LauncherController < ApplicationController
     false
   end
 
+  def agency_activity_types
+    Rails.application.config.client_agencies.client_agency_ids.index_with do |agency_id|
+      Rails.application.config.client_agencies[agency_id].activity_types.select { |_type, enabled| enabled }.keys
+    end
+  end
+
   def launcher_url_options
     opts = { host: request.host_with_port, protocol: request.protocol }
     # When behind a reverse proxy (e.g., ngrok), explicitly set port to nil so the scheme's default port is used.
@@ -215,10 +221,12 @@ class LauncherController < ApplicationController
   end
 
   def create_launcher_activity_flow_invitation!(attributes)
-    invitation = ActivityFlowInvitation.create!(attributes)
-    pre_populated = build_pre_populated_activities
-    invitation.update_columns(pre_populated_activities: pre_populated) if pre_populated.present?
-    invitation
+    ActivityFlowInvitation.create!(
+      attributes.merge(
+        pre_populated_activities: build_pre_populated_activities,
+        skip_month_window_validation: true
+      )
+    )
   end
 
   def launch_overrides(flow_type)

--- a/app/app/helpers/activities_helper.rb
+++ b/app/app/helpers/activities_helper.rb
@@ -1,4 +1,12 @@
 module ActivitiesHelper
+  def show_activity?(type)
+    if @flow&.pre_populated_session?
+      @flow.pre_populated_activity_types.include?(type.to_sym)
+    else
+      activity_type_enabled?(type)
+    end
+  end
+
   def activity_hub_state(any_activities_added:, monthly_results:, required_month_count: monthly_results.length)
     return :empty unless any_activities_added
 

--- a/app/app/javascript/controllers/advanced_launcher_controller.js
+++ b/app/app/javascript/controllers/advanced_launcher_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
     "monthButtons",
     "monthsInput",
     "ceOnly",
+    "activityRow",
     "datePickerWrapper",
     "genericButton",
     "renewalRequiredField",
@@ -17,6 +18,8 @@ export default class extends Controller {
     "openGeneratedLink",
   ]
 
+  static values = { agencyActivityTypes: Object }
+
   connect() {
     const selectedFlow = this.element.querySelector("input[name=flow_type]:checked")
     if (selectedFlow) this.applyFlowType(selectedFlow.value)
@@ -26,10 +29,16 @@ export default class extends Controller {
 
     const selectedScenario = this.element.querySelector("input[name=test_scenario]:checked")
     if (selectedScenario) this.applyScenario(selectedScenario)
+
+    this.applyAgency()
   }
 
   selectFlowType(event) {
     this.applyFlowType(event.currentTarget.value)
+  }
+
+  selectAgency() {
+    this.applyAgency()
   }
 
   selectWindow(event) {
@@ -138,6 +147,28 @@ export default class extends Controller {
       const selectedScenario = this.element.querySelector("input[name=test_scenario]:checked")
       if (selectedScenario) this.applyScenario(selectedScenario)
     }
+  }
+
+  applyAgency() {
+    if (!this.hasActivityRowTarget) return
+
+    const select = this.element.querySelector("#client_agency_id")
+    const enabled = (select && this.agencyActivityTypesValue[select.value]) || []
+
+    this.activityRowTargets.forEach((row) => {
+      const allowed = enabled.includes(row.dataset.activityType)
+      const checkbox = row.querySelector("input[type=checkbox]")
+
+      row.classList.toggle("demo-launcher__activity-row--disabled", !allowed)
+      if (checkbox) checkbox.disabled = !allowed
+      if (allowed) return
+
+      if (checkbox && checkbox.checked) {
+        checkbox.checked = false
+        const fields = row.querySelector(".demo-launcher__activity-fields")
+        if (fields) fields.classList.add("demo-launcher__activity-fields--hidden")
+      }
+    })
   }
 
   applyScenario(radio) {

--- a/app/app/models/activity.rb
+++ b/app/app/models/activity.rb
@@ -8,6 +8,18 @@ class Activity < ApplicationRecord
   scope :published, -> { where(draft: false) }
   scope :pre_populated_drafts, -> { where(draft: true, pre_populated: true) }
 
+  def self.display_name
+    raise NotImplementedError, "#{name} must define .#{__method__}"
+  end
+
+  def self.flow_association
+    model_name.plural.to_sym
+  end
+
+  def self.pre_populated_defaults
+    {}
+  end
+
   def publish!
     update!(draft: false)
   end

--- a/app/app/models/activity.rb
+++ b/app/app/models/activity.rb
@@ -8,7 +8,7 @@ class Activity < ApplicationRecord
   scope :published, -> { where(draft: false) }
   scope :pre_populated_drafts, -> { where(draft: true, pre_populated: true) }
 
-  def self.display_name
+  def self.activity_type
     raise NotImplementedError, "#{name} must define .#{__method__}"
   end
 

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -45,55 +45,23 @@ class ActivityFlow < Flow
 
     entries.each do |entry|
       attrs = entry.stringify_keys
-      case attrs["type"].to_s
-      when "volunteering"
-        next if flow.volunteering_activities.exists?
+      activity_class = ActivityFlowInvitation::ACTIVITY_TYPES[attrs["type"].to_s]
+      next unless activity_class
 
-        activity = flow.volunteering_activities.create(
-          attrs.slice(*VolunteeringActivity::FIELDS)
-            .merge("draft" => true, "pre_populated" => true)
+      association = flow.public_send(activity_class.flow_association)
+      next if association.exists?
+
+      activity = association.create(
+        attrs.slice(*activity_class::FIELDS)
+             .merge("draft" => true, "pre_populated" => true)
+             .merge(activity_class.pre_populated_defaults)
+      )
+      next unless activity.persisted?
+
+      Array(attrs["months"]).each do |month_entry|
+        activity.activity_months.create(
+          month_entry.stringify_keys.slice(*activity_class.activity_months_class::FIELDS)
         )
-        next unless activity.persisted?
-
-        Array(attrs["months"]).each do |month_entry|
-          activity.volunteering_activity_months.create(month_entry.stringify_keys.slice(*VolunteeringActivityMonth::FIELDS))
-        end
-      when "employment"
-        next if flow.employment_activities.exists?
-
-        activity = flow.employment_activities.create(
-          attrs.slice(*EmploymentActivity::FIELDS)
-            .merge("draft" => true, "pre_populated" => true)
-        )
-        next unless activity.persisted?
-
-        Array(attrs["months"]).each do |month_entry|
-          activity.employment_activity_months.create(month_entry.stringify_keys.slice(*EmploymentActivityMonth::FIELDS))
-        end
-      when "education"
-        next if flow.education_activities.exists?
-
-        activity = flow.education_activities.create(
-          attrs.slice(*EducationActivity::FIELDS)
-            .merge("draft" => true, "data_source" => "fully_self_attested", "pre_populated" => true)
-        )
-        next unless activity.persisted?
-
-        Array(attrs["months"]).each do |month_entry|
-          activity.education_activity_months.create(month_entry.stringify_keys.slice(*EducationActivityMonth::FIELDS))
-        end
-      when "job_training"
-        next if flow.job_training_activities.exists?
-
-        activity = flow.job_training_activities.create(
-          attrs.slice(*JobTrainingActivity::FIELDS)
-            .merge("draft" => true, "pre_populated" => true)
-        )
-        next unless activity.persisted?
-
-        Array(attrs["months"]).each do |month_entry|
-          activity.job_training_activity_months.create(month_entry.stringify_keys.slice(*JobTrainingActivityMonth::FIELDS))
-        end
       end
     end
   end

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -168,6 +168,14 @@ class ActivityFlow < Flow
     activity_flow_invitation_id
   end
 
+  def pre_populated_session?
+    activity_flow_invitation&.pre_populated_activities.present?
+  end
+
+  def pre_populated_activity_types
+    activity_flow_invitation&.pre_populated_hub_activity_types || []
+  end
+
   def after_payroll_sync_succeeded(payroll_account, report)
     ActivityFlowEmploymentSummary.persist_from_report(activity_flow: self, payroll_account: payroll_account, report: report)
     ActivityFlowMonthlySummary.upsert_from_report(activity_flow: self, payroll_account: payroll_account, report: report)

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -12,8 +12,10 @@ class ActivityFlowInvitation < ApplicationRecord
 
   has_secure_token :auth_token, length: 10
 
+  attr_accessor :skip_month_window_validation
+
   validate :pre_populated_activities_shape
-  validate :pre_populated_activity_months_in_window
+  validate :pre_populated_activity_months_in_window, unless: :skip_month_window_validation
 
   def to_url(host: ENV.fetch("DOMAIN_NAME", "localhost"), **url_params)
     Rails.application.routes.url_helpers.activities_flow_start_url(token: auth_token, host: host, **url_params)
@@ -25,12 +27,12 @@ class ActivityFlowInvitation < ApplicationRecord
 
   def supported_pre_populated_types
     agency = Rails.application.config.client_agencies[client_agency_id]
-    ACTIVITY_TYPES.select { |_type, klass| agency&.activity_types&.[](klass.display_name) }.keys
+    ACTIVITY_TYPES.select { |_type, klass| agency&.activity_types&.[](klass.activity_type) }.keys
   end
 
   def pre_populated_hub_activity_types
     pre_populated_activities
-      .filter_map { |e| ACTIVITY_TYPES[(e["type"] || e[:type]).to_s]&.display_name }
+      .filter_map { |e| ACTIVITY_TYPES[(e["type"] || e[:type]).to_s]&.activity_type }
       .uniq
   end
 

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -1,5 +1,10 @@
 class ActivityFlowInvitation < ApplicationRecord
-  SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES = %w[volunteering employment education job_training].freeze
+  ACTIVITY_TYPE_TO_HUB_TYPE = {
+    "volunteering" => :community_service,
+    "employment" => :employment,
+    "education" => :education,
+    "job_training" => :work_programs
+  }.freeze
   PRE_POPULATED_REQUIRED_FIELDS = {
     "volunteering" => %w[organization_name],
     "employment" => %w[employer_name],
@@ -24,6 +29,17 @@ class ActivityFlowInvitation < ApplicationRecord
     false
   end
 
+  def supported_pre_populated_types
+    agency = Rails.application.config.client_agencies[client_agency_id]
+    ACTIVITY_TYPE_TO_HUB_TYPE.select { |_model_type, hub_type| agency&.activity_types&.[](hub_type) }.keys
+  end
+
+  def pre_populated_hub_activity_types
+    pre_populated_activities
+      .filter_map { |e| ACTIVITY_TYPE_TO_HUB_TYPE[(e["type"] || e[:type]).to_s] }
+      .uniq
+  end
+
   private
 
   def pre_populated_activities_shape
@@ -31,8 +47,8 @@ class ActivityFlowInvitation < ApplicationRecord
 
     pre_populated_activities.each_with_index do |entry, idx|
       type = entry["type"] || entry[:type]
-      unless SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES.include?(type.to_s)
-        errors.add("pre_populated_activities[#{idx}].type", "must be one of #{SUPPORTED_PRE_POPULATED_ACTIVITY_TYPES.join(', ')}")
+      unless supported_pre_populated_types.include?(type.to_s)
+        errors.add("pre_populated_activities[#{idx}].type", "must be one of #{supported_pre_populated_types.join(', ')}")
         next
       end
 

--- a/app/app/models/activity_flow_invitation.rb
+++ b/app/app/models/activity_flow_invitation.rb
@@ -1,15 +1,9 @@
 class ActivityFlowInvitation < ApplicationRecord
-  ACTIVITY_TYPE_TO_HUB_TYPE = {
-    "volunteering" => :community_service,
-    "employment" => :employment,
-    "education" => :education,
-    "job_training" => :work_programs
-  }.freeze
-  PRE_POPULATED_REQUIRED_FIELDS = {
-    "volunteering" => %w[organization_name],
-    "employment" => %w[employer_name],
-    "education" => %w[school_name],
-    "job_training" => %w[program_name organization_name]
+  ACTIVITY_TYPES = {
+    "volunteering" => VolunteeringActivity,
+    "employment" => EmploymentActivity,
+    "education" => EducationActivity,
+    "job_training" => JobTrainingActivity
   }.freeze
 
   belongs_to :cbv_applicant, optional: true
@@ -31,12 +25,12 @@ class ActivityFlowInvitation < ApplicationRecord
 
   def supported_pre_populated_types
     agency = Rails.application.config.client_agencies[client_agency_id]
-    ACTIVITY_TYPE_TO_HUB_TYPE.select { |_model_type, hub_type| agency&.activity_types&.[](hub_type) }.keys
+    ACTIVITY_TYPES.select { |_type, klass| agency&.activity_types&.[](klass.display_name) }.keys
   end
 
   def pre_populated_hub_activity_types
     pre_populated_activities
-      .filter_map { |e| ACTIVITY_TYPE_TO_HUB_TYPE[(e["type"] || e[:type]).to_s] }
+      .filter_map { |e| ACTIVITY_TYPES[(e["type"] || e[:type]).to_s]&.display_name }
       .uniq
   end
 
@@ -52,7 +46,7 @@ class ActivityFlowInvitation < ApplicationRecord
         next
       end
 
-      PRE_POPULATED_REQUIRED_FIELDS[type.to_s].each do |field|
+      ACTIVITY_TYPES[type.to_s]::PRE_POPULATED_REQUIRED_FIELDS.each do |field|
         value = entry[field] || entry[field.to_sym]
         if value.blank?
           errors.add("pre_populated_activities[#{idx}].#{field}", "can't be blank")

--- a/app/app/models/concerns/has_activity_months.rb
+++ b/app/app/models/concerns/has_activity_months.rb
@@ -6,6 +6,11 @@ module HasActivityMonths
     # Usage: has_activity_months :volunteering_activity_months
     def has_activity_months(association_name)
       alias_method :activity_months, association_name
+      @activity_months_class = reflect_on_association(association_name).klass
+    end
+
+    def activity_months_class
+      @activity_months_class
     end
   end
 end

--- a/app/app/models/education_activity.rb
+++ b/app/app/models/education_activity.rb
@@ -20,7 +20,7 @@ class EducationActivity < Activity
   has_many :education_activity_months, dependent: :destroy
   has_activity_months :education_activity_months
 
-  def self.display_name
+  def self.activity_type
     :education
   end
 

--- a/app/app/models/education_activity.rb
+++ b/app/app/models/education_activity.rb
@@ -14,10 +14,19 @@ class EducationActivity < Activity
     contact_email
     contact_phone_number
   ].freeze
+  PRE_POPULATED_REQUIRED_FIELDS = %w[school_name].freeze
 
   has_many :nsc_enrollment_terms, dependent: :destroy
   has_many :education_activity_months, dependent: :destroy
   has_activity_months :education_activity_months
+
+  def self.display_name
+    :education
+  end
+
+  def self.pre_populated_defaults
+    { "data_source" => "fully_self_attested" }
+  end
 
   validates :school_name, presence: true, if: :fully_self_attested?
 

--- a/app/app/models/employment_activity.rb
+++ b/app/app/models/employment_activity.rb
@@ -14,9 +14,14 @@ class EmploymentActivity < Activity
     contact_email
     contact_phone_number
   ].freeze
+  PRE_POPULATED_REQUIRED_FIELDS = %w[employer_name].freeze
 
   has_many :employment_activity_months, dependent: :destroy
   has_activity_months :employment_activity_months
+
+  def self.display_name
+    :employment
+  end
 
   validates :employer_name, presence: { message: I18n.t("activities.employment_info.employer_name_error") }
 

--- a/app/app/models/employment_activity.rb
+++ b/app/app/models/employment_activity.rb
@@ -19,7 +19,7 @@ class EmploymentActivity < Activity
   has_many :employment_activity_months, dependent: :destroy
   has_activity_months :employment_activity_months
 
-  def self.display_name
+  def self.activity_type
     :employment
   end
 

--- a/app/app/models/job_training_activity.rb
+++ b/app/app/models/job_training_activity.rb
@@ -22,7 +22,7 @@ class JobTrainingActivity < Activity
   has_many :job_training_activity_months, dependent: :destroy
   has_activity_months :job_training_activity_months
 
-  def self.display_name
+  def self.activity_type
     :work_programs
   end
 

--- a/app/app/models/job_training_activity.rb
+++ b/app/app/models/job_training_activity.rb
@@ -15,11 +15,16 @@ class JobTrainingActivity < Activity
     contact_email
     contact_phone_number
   ].freeze
+  PRE_POPULATED_REQUIRED_FIELDS = %w[program_name organization_name].freeze
 
   validates :organization_name, :program_name, presence: true
 
   has_many :job_training_activity_months, dependent: :destroy
   has_activity_months :job_training_activity_months
+
+  def self.display_name
+    :work_programs
+  end
 
   def formatted_address
     locality = [ city, state ].compact_blank.join(", ")

--- a/app/app/models/volunteering_activity.rb
+++ b/app/app/models/volunteering_activity.rb
@@ -18,7 +18,7 @@ class VolunteeringActivity < Activity
   has_many :volunteering_activity_months, dependent: :destroy
   has_activity_months :volunteering_activity_months
 
-  def self.display_name
+  def self.activity_type
     :community_service
   end
 

--- a/app/app/models/volunteering_activity.rb
+++ b/app/app/models/volunteering_activity.rb
@@ -13,9 +13,14 @@ class VolunteeringActivity < Activity
     coordinator_email
     coordinator_phone_number
   ].freeze
+  PRE_POPULATED_REQUIRED_FIELDS = %w[organization_name].freeze
 
   has_many :volunteering_activity_months, dependent: :destroy
   has_activity_months :volunteering_activity_months
+
+  def self.display_name
+    :community_service
+  end
 
   def formatted_address
     locality = [ city, state ].compact_blank.join(", ")

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -79,7 +79,7 @@
 
   </div>
   <div class="activity-hub-columns__activities">
-    <% if activity_type_enabled?(:employment) %>
+    <% if show_activity?(:employment) %>
       <%# i18n-tasks-use t("activities.hub.cards.pre_populated_notice") %>
       <%# i18n-tasks-use t("activities.hub.cards.complete_action") %>
       <% employment_draft_card_data = employment_activity_draft_cards(@employment_draft_activities || []) %>
@@ -127,7 +127,7 @@
       <% end %>
     <% end %>
 
-    <% if activity_type_enabled?(:education) %>
+    <% if show_activity?(:education) %>
       <%# i18n-tasks-use t("activities.hub.cards.pre_populated_notice") %>
       <%# i18n-tasks-use t("activities.hub.cards.complete_action") %>
       <% education_draft_card_data = education_activity_draft_cards(@education_draft_activities || []) %>
@@ -168,7 +168,7 @@
       <% end %>
     <% end %>
 
-    <% if activity_type_enabled?(:community_service) %>
+    <% if show_activity?(:community_service) %>
       <%# i18n-tasks-use t("activities.hub.cards.pre_populated_notice") %>
       <%# i18n-tasks-use t("activities.hub.cards.complete_action") %>
       <% community_service_card_data = community_service_draft_cards(@community_service_draft_activities || []) +
@@ -204,7 +204,7 @@
       <% end %>
     <% end %>
 
-    <% if activity_type_enabled?(:work_programs) %>
+    <% if show_activity?(:work_programs) %>
       <%# i18n-tasks-use t("activities.hub.cards.pre_populated_notice") %>
       <%# i18n-tasks-use t("activities.hub.cards.complete_action") %>
       <% work_programs_card_data = work_program_draft_cards(@work_programs_draft_activities) +

--- a/app/app/views/launcher/advanced.html.erb
+++ b/app/app/views/launcher/advanced.html.erb
@@ -2,7 +2,7 @@
 <div class="grid-col-12 advanced-launcher">
   <h1>Emmy Launcher 🏆🚀</h1>
   <div class="usa-hint advanced-launcher__usa-hint">Configure settings and launch Emmy in a new tab.</div>
-  <%= form_with(url: "/launcher/advanced", method: :post, builder: UswdsFormBuilder, html: { class: "usa-form usa-form--large" }, data: { turbo: false, controller: "advanced-launcher", action: "input->advanced-launcher#invalidateShareLink change->advanced-launcher#invalidateShareLink" }) do |f| %>
+  <%= form_with(url: "/launcher/advanced", method: :post, builder: UswdsFormBuilder, html: { class: "usa-form usa-form--large" }, data: { turbo: false, controller: "advanced-launcher", "demo-launcher-agency-activity-types-value": agency_activity_types.to_json, action: "input->advanced-launcher#invalidateShareLink change->advanced-launcher#invalidateShareLink" }) do |f| %>
     <div class="advanced-launcher__two-col">
       <div class="advanced-launcher__left-col">
         <div class="advanced-launcher__test-scenarios" data-advanced-launcher-target="ceOnly">
@@ -161,7 +161,7 @@
           </div>
         <% end %>
         <%= render AdvancedLauncher::SettingComponent.new(title: "Agency", hint: "Select the agency the flow will use.") do %>
-          <select class="usa-select" name="client_agency_id" id="client_agency_id">
+          <select class="usa-select" name="client_agency_id" id="client_agency_id" data-action="change->demo-launcher#selectAgency">
             <% Rails.application.config.client_agencies.client_agency_ids.each do |agency_id| %>
               <option value="<%= agency_id %>" <%= "selected" if agency_id == "sandbox" %>><%= agency_id %></option>
             <% end %>
@@ -237,9 +237,9 @@
           </div>
         <% end %>
         <div data-advanced-launcher-target="ceOnly">
-          <%= render AdvancedLauncher::SettingComponent.new(title: "Pre-populated activities", hint: "Specify what data should appear automatically when visiting the hub for the first time. This is used to simulate the state sending us the data they have for this applicant. Note that this only works with tokenized links.") do %>
+          <%= render AdvancedLauncher::SettingComponent.new(title: "Pre-populated activities", hint: "Specify what data should appear automatically when visiting the hub for the first time. This is used to simulate the state sending us the data they have for this applicant. Note that this only works with tokenized links. Activities that aren't enabled for the selected agency are greyed out and can't be selected.") do %>
             <div class="advanced-launcher__activity-rows">
-              <div class="advanced-launcher__activity-row">
+              <div class="advanced-launcher__activity-row" data-demo-launcher-target="activityRow" data-activity-type="community_service">
                 <div class="advanced-launcher__activity-header">
                   <div class="usa-checkbox">
                     <input class="usa-checkbox__input" type="checkbox" id="volunteering_enabled" name="volunteering_enabled" value="1"
@@ -260,7 +260,7 @@
                   </div>
                 </div>
               </div>
-              <div class="advanced-launcher__activity-row">
+              <div class="advanced-launcher__activity-row" data-demo-launcher-target="activityRow" data-activity-type="employment">
                 <div class="advanced-launcher__activity-header">
                   <div class="usa-checkbox">
                     <input class="usa-checkbox__input" type="checkbox" id="employment_enabled" name="employment_enabled" value="1"
@@ -288,7 +288,7 @@
                   </div>
                 </div>
               </div>
-              <div class="advanced-launcher__activity-row">
+              <div class="advanced-launcher__activity-row" data-demo-launcher-target="activityRow" data-activity-type="education">
                 <div class="advanced-launcher__activity-header">
                   <div class="usa-checkbox">
                     <input class="usa-checkbox__input" type="checkbox" id="education_enabled" name="education_enabled" value="1"
@@ -309,7 +309,7 @@
                   </div>
                 </div>
               </div>
-              <div class="advanced-launcher__activity-row">
+              <div class="advanced-launcher__activity-row" data-demo-launcher-target="activityRow" data-activity-type="work_programs">
                 <div class="advanced-launcher__activity-header">
                   <div class="usa-checkbox">
                     <input class="usa-checkbox__input" type="checkbox" id="job_training_enabled" name="job_training_enabled" value="1"

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -1048,4 +1048,89 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       expect(work_program_cards).to have_text(I18n.t("activities.hub.cards.hours", count: 10))
     end
   end
+
+  context "when the session is pre-populated with a subset of activity types" do
+    let(:invitation) do
+      create(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" },
+        { "type" => "education", "school_name" => "Springfield Community College" }
+      ])
+    end
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        activity_flow_invitation: invitation,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "renders only the pre-filled activity type sections" do
+      rendered = Capybara.string(response.body)
+
+      expect(rendered).to have_css("[data-activity-type='community_service']")
+      expect(rendered).to have_css("[data-activity-type='education']")
+      expect(rendered).to have_no_css("[data-activity-type='employment']")
+      expect(rendered).to have_no_css("[data-activity-type='work_programs']")
+    end
+  end
+
+  context "when a pre-filled activity has already been published" do
+    let(:invitation) do
+      create(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" }
+      ])
+    end
+    let(:current_flow) { ActivityFlow.create_from_invitation(invitation, "device123") }
+
+    before do
+      current_flow.volunteering_activities.each(&:publish!)
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "still shows the section for the pre-filled type once its draft is published" do
+      rendered = Capybara.string(response.body)
+
+      expect(current_flow.volunteering_activities.pre_populated_drafts).to be_empty
+      expect(rendered).to have_css("[data-activity-type='community_service']")
+      expect(rendered).to have_no_css("[data-activity-type='employment']")
+      expect(rendered).to have_no_css("[data-activity-type='education']")
+      expect(rendered).to have_no_css("[data-activity-type='work_programs']")
+    end
+  end
+
+  context "when the session is not pre-populated" do
+    let(:current_flow) do
+      create(
+        :activity_flow,
+        volunteering_activities_count: 0,
+        job_training_activities_count: 0,
+        education_activities_count: 0
+      )
+    end
+
+    before do
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it "renders all agency-enabled activity type sections" do
+      rendered = Capybara.string(response.body)
+
+      expect(rendered).to have_css("[data-activity-type='employment']")
+      expect(rendered).to have_css("[data-activity-type='education']")
+      expect(rendered).to have_css("[data-activity-type='community_service']")
+      expect(rendered).to have_css("[data-activity-type='work_programs']")
+    end
+  end
 end

--- a/app/spec/controllers/launcher_controller_advanced_spec.rb
+++ b/app/spec/controllers/launcher_controller_advanced_spec.rb
@@ -738,6 +738,37 @@ RSpec.describe LauncherController, type: :controller do
         expect(activities[0]["months"]).to all(include("hours" => 6))
       end
 
+      it "rejects activity types that are not enabled for the agency" do
+        stub_client_agency_config_value("sandbox", :activity_types, { community_service: false, employment: true, education: true, work_programs: true })
+
+        expect {
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "tokenized",
+            volunteering_enabled: "1",
+            volunteering_organization_name: "Red Cross",
+            volunteering_hours_per_month: "4"
+          }
+        }.to raise_error(ActiveRecord::RecordInvalid).and not_change(ActivityFlowInvitation, :count)
+      end
+
+      it "allows pre-populated months outside the invitation's default reporting window" do
+        post :create, params: {
+          client_agency_id: "sandbox",
+          launch_type: "tokenized",
+          reporting_window: "application",
+          reporting_window_months: "3",
+          reporting_window_start: "07/01/2025",
+          job_training_enabled: "1",
+          job_training_program_name: "Career Prep",
+          job_training_organization_name: "Goodwill",
+          job_training_hours_per_month: "10"
+        }
+
+        months = ActivityFlowInvitation.last.pre_populated_activities.first["months"].map { |m| m["month"] }
+        expect(months).to eq(%w[2025-07-01 2025-08-01 2025-09-01])
+      end
+
       it "creates an invitation with a work program activity when work program is enabled" do
         expect {
           post :create, params: {

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -3,6 +3,39 @@ require "rails_helper"
 RSpec.describe ActivitiesHelper do
   include ActiveSupport::Testing::TimeHelpers
 
+  describe "#show_activity_type?" do
+    context "in a pre-populated session" do
+      before do
+        flow = instance_double(ActivityFlow, pre_populated_session?: true, pre_populated_activity_types: [ :community_service, :education ])
+        assign(:flow, flow)
+      end
+
+      it "shows only the pre-filled activity types" do
+        expect(helper.show_activity?(:community_service)).to be true
+        expect(helper.show_activity?(:education)).to be true
+      end
+
+      it "hides activity types that were not pre-filled" do
+        expect(helper.show_activity?(:employment)).to be false
+        expect(helper.show_activity?(:work_programs)).to be false
+      end
+    end
+
+    context "in a non-pre-populated session" do
+      before do
+        assign(:flow, instance_double(ActivityFlow, pre_populated_session?: false))
+      end
+
+      it "falls back to activity_type_enabled?" do
+        allow(helper).to receive(:activity_type_enabled?).with(:employment).and_return(true)
+        allow(helper).to receive(:activity_type_enabled?).with(:education).and_return(false)
+
+        expect(helper.show_activity?(:employment)).to be true
+        expect(helper.show_activity?(:education)).to be false
+      end
+    end
+  end
+
   describe "activity hub display helpers" do
     describe "#activity_hub_state" do
       let(:meeting_result) { instance_double(ActivityFlowProgressCalculator::MonthlyResult, meets_requirements: true) }

--- a/app/spec/helpers/activities_helper_spec.rb
+++ b/app/spec/helpers/activities_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ActivitiesHelper do
   include ActiveSupport::Testing::TimeHelpers
 
-  describe "#show_activity_type?" do
+  describe "#show_activity?" do
     context "in a pre-populated session" do
       before do
         flow = instance_double(ActivityFlow, pre_populated_session?: true, pre_populated_activity_types: [ :community_service, :education ])

--- a/app/spec/models/activity_flow_invitation_spec.rb
+++ b/app/spec/models/activity_flow_invitation_spec.rb
@@ -136,6 +136,17 @@ RSpec.describe ActivityFlowInvitation, type: :model do
     end
   end
 
+  describe "#pre_populated_hub_activity_types" do
+    it "maps stored entries to their activity_type" do
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" },
+        { "type" => "education", "school_name" => "Springfield Community College" }
+      ])
+
+      expect(invitation.pre_populated_hub_activity_types).to contain_exactly(:community_service, :education)
+    end
+  end
+
   describe "month-in-window validation" do
     let(:in_window_date) { ActivityFlow.expected_reporting_window_range("sandbox").end.iso8601 }
     let(:out_of_window_date) { (Date.current + 60.days).iso8601 }
@@ -258,6 +269,30 @@ RSpec.describe ActivityFlowInvitation, type: :model do
       expect(invitation).not_to be_valid
       expect(invitation.errors.attribute_names.map(&:to_s))
         .to include("pre_populated_activities[0].months[0].month")
+    end
+
+    context "when skip_month_window_validation is set" do
+      it "allows months outside the expected reporting window" do
+        invitation = build(:activity_flow_invitation, skip_month_window_validation: true, pre_populated_activities: [
+          {
+            "type" => "volunteering",
+            "organization_name" => "Red Cross",
+            "months" => [ { "month" => out_of_window_date, "hours" => 4 } ]
+          }
+        ])
+
+        expect(invitation).to be_valid
+      end
+
+      it "still enforces the type gating" do
+        invitation = build(:activity_flow_invitation, skip_month_window_validation: true, pre_populated_activities: [
+          { "type" => "knitting", "organization_name" => "Yarn Co" }
+        ])
+
+        expect(invitation).not_to be_valid
+        expect(invitation.errors.attribute_names.map(&:to_s))
+          .to include("pre_populated_activities[0].type")
+      end
     end
   end
 end

--- a/app/spec/models/activity_flow_invitation_spec.rb
+++ b/app/spec/models/activity_flow_invitation_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe ActivityFlowInvitation, type: :model do
       expect(invitation).to be_valid
     end
 
+    it "is invalid when an entry's type is not enabled for the agency" do
+      stub_client_agency_config_value("sandbox", :activity_types, { community_service: false, employment: true, education: true, work_programs: true })
+      invitation = build(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" }
+      ])
+
+      expect(invitation).not_to be_valid
+      expect(invitation.errors.attribute_names.map(&:to_s))
+        .to include("pre_populated_activities[0].type")
+    end
+
     it "is valid with a well-formed employment entry" do
       invitation = build(:activity_flow_invitation, pre_populated_activities: [
         { "type" => "employment", "employer_name" => "Acme Corp" }

--- a/app/spec/models/activity_flow_spec.rb
+++ b/app/spec/models/activity_flow_spec.rb
@@ -17,6 +17,49 @@ RSpec.describe ActivityFlow, type: :model do
     expect(activity_flow.cbv_applicant).to eq(cbv_applicant)
   end
 
+  describe "#pre_populated_session?" do
+    it "is true when the invitation has pre_populated_activities" do
+      invitation = create(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" }
+      ])
+      flow = create(:activity_flow, activity_flow_invitation: invitation)
+
+      expect(flow.pre_populated_session?).to be true
+    end
+
+    it "is false when the invitation has no pre_populated_activities" do
+      invitation = create(:activity_flow_invitation, pre_populated_activities: [])
+      flow = create(:activity_flow, activity_flow_invitation: invitation)
+
+      expect(flow.pre_populated_session?).to be false
+    end
+
+    it "is false when there is no invitation" do
+      flow = create(:activity_flow, activity_flow_invitation: nil)
+
+      expect(flow.pre_populated_session?).to be false
+    end
+  end
+
+  describe "#pre_populated_activity_types" do
+    it "maps pre-populated model types to hub types, deduped" do
+      invitation = create(:activity_flow_invitation, pre_populated_activities: [
+        { "type" => "volunteering", "organization_name" => "Red Cross" },
+        { "type" => "job_training", "program_name" => "Career Prep", "organization_name" => "Goodwill" },
+        { "type" => "volunteering", "organization_name" => "Habitat" }
+      ])
+      flow = create(:activity_flow, activity_flow_invitation: invitation)
+
+      expect(flow.pre_populated_activity_types).to contain_exactly(:community_service, :work_programs)
+    end
+
+    it "returns an empty array when there is no invitation" do
+      flow = create(:activity_flow, activity_flow_invitation: nil)
+
+      expect(flow.pre_populated_activity_types).to eq([])
+    end
+  end
+
   describe ".create_from_invitation" do
     let(:device_id) { "device123" }
 

--- a/app/spec/models/activity_spec.rb
+++ b/app/spec/models/activity_spec.rb
@@ -45,4 +45,35 @@ RSpec.describe Activity do
       expect(build(:volunteering_activity, activity_flow: flow, draft: true, pre_populated: false)).not_to be_pre_populated_draft
     end
   end
+
+  describe ".display_name" do
+    it "raises NotImplementedError on the abstract base" do
+      expect { described_class.display_name }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "activity type subclass contract" do
+    ActivityFlowInvitation::ACTIVITY_TYPES.each do |type, klass|
+      context "#{klass}" do
+        it "defines FIELDS and PRE_POPULATED_REQUIRED_FIELDS (a subset of FIELDS)" do
+          expect(klass::FIELDS).to be_an(Array)
+          expect(klass::PRE_POPULATED_REQUIRED_FIELDS).to be_an(Array)
+          expect(klass::FIELDS).to include(*klass::PRE_POPULATED_REQUIRED_FIELDS)
+        end
+
+        it "defines a Symbol .display_name" do
+          expect(klass.display_name).to be_a(Symbol)
+        end
+
+        it "exposes .activity_months_class via HasActivityMonths" do
+          expect(klass.activity_months_class).to be_a(Class)
+        end
+
+        it "resolves .flow_association to an ActivityFlow association matching its registered type" do
+          expect(ActivityFlow.reflect_on_association(klass.flow_association)).to be_present
+          expect(klass.flow_association).to eq(:"#{type}_activities")
+        end
+      end
+    end
+  end
 end

--- a/app/spec/models/activity_spec.rb
+++ b/app/spec/models/activity_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe Activity do
     end
   end
 
-  describe ".display_name" do
+  describe ".activity_type" do
     it "raises NotImplementedError on the abstract base" do
-      expect { described_class.display_name }.to raise_error(NotImplementedError)
+      expect { described_class.activity_type }.to raise_error(NotImplementedError)
     end
   end
 
@@ -61,8 +61,8 @@ RSpec.describe Activity do
           expect(klass::FIELDS).to include(*klass::PRE_POPULATED_REQUIRED_FIELDS)
         end
 
-        it "defines a Symbol .display_name" do
-          expect(klass.display_name).to be_a(Symbol)
+        it "defines a Symbol .activity_type" do
+          expect(klass.activity_type).to be_a(Symbol)
         end
 
         it "exposes .activity_months_class via HasActivityMonths" do

--- a/app/spec/requests/launcher_spec.rb
+++ b/app/spec/requests/launcher_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe "Launcher routes", type: :request do
       get "/launcher/advanced"
       expect(response).to have_http_status(:ok)
     end
+
+    it "exposes each agency's enabled activity types so the form can gate the checkboxes" do
+      get "/launcher/advanced"
+
+      expected = Rails.application.config.client_agencies.client_agency_ids.index_with do |agency_id|
+        Rails.application.config.client_agencies[agency_id].activity_types.select { |_type, enabled| enabled }.keys
+      end
+
+      expect(response.body).to include("data-demo-launcher-agency-activity-types-value=\"#{ERB::Util.html_escape(expected.to_json)}\"")
+      expect(response.body).to include('data-activity-type="community_service"')
+      expect(response.body).to include('data-activity-type="work_programs"')
+    end
   end
 
   describe "GET /demo" do


### PR DESCRIPTION
## [FFS-4316](https://jiraent.cms.gov/browse/FFS-4316)
Now only the invitation's activity types render on the hub, anything not provided won't be shown. 

## Context for reviewers
- Made a little refactor: the old `case`/constant approach had the same block of activity / month creation four separate times, it's now one loop keyed off `ACTIVITY_TYPES`. If (in the unlikely event) that we add an activity type, there are required fields and methods to implement that the `activity_spec.rb` enforces.
- You can no longer pre-populate activities that an agency doesn't support. Now it just boils down to what activities are enabled for that agency in its config.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1886.navapbc.cloud/launcher/advanced
- Deployed commit: 7754079c175e79f347cd16d70c405bb8d2e97b7a
<!-- end PR environment info -->