### PR TITLE
FFS-4594: Move dependency & vulnerability checks to main

### DIFF
--- a/.github/actions/build-release-image/action.yml
+++ b/.github/actions/build-release-image/action.yml
@@ -1,0 +1,43 @@
+name: Build release image for scanning
+description: >
+  Log in to Docker Hub (when credentials are available) and build/tag the
+  release image, returning the image ref. Shared by every vulnerability scan
+  so image builds stay identical across the gating scans and the auto-fixer.
+
+inputs:
+  app_name:
+    description: Name of the application folder under the infra directory
+    required: false
+    default: app
+  dockerhub-username:
+    description: Docker Hub username
+    required: false
+    default: ""
+  dockerhub-token:
+    description: Docker Hub token; login is skipped when empty
+    required: false
+    default: ""
+
+outputs:
+  image:
+    description: Full image ref (name:tag) that was built
+    value: ${{ steps.build-image.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Docker Hub
+      if: inputs.dockerhub-token != '' && github.event.pull_request.head.repo.full_name == github.repository
+      uses: docker/login-action@v4
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Build and tag Docker image for scanning
+      id: build-image
+      shell: bash
+      run: |
+        make APP_NAME=${{ inputs.app_name }} release-build
+        IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
+        IMAGE_TAG=$(make release-image-tag)
+        echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-release-image/action.yml
+++ b/.github/actions/build-release-image/action.yml
@@ -27,11 +27,11 @@ runs:
   using: composite
   steps:
     - name: Login to Docker Hub
-      if: inputs.dockerhub-token != '' && github.event.pull_request.head.repo.full_name == github.repository
+      if: inputs['dockerhub-token'] != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: docker/login-action@v4
       with:
-        username: ${{ inputs.dockerhub-username }}
-        password: ${{ inputs.dockerhub-token }}
+        username: ${{ inputs['dockerhub-username'] }}
+        password: ${{ inputs['dockerhub-token'] }}
 
     - name: Build and tag Docker image for scanning
       id: build-image

--- a/.github/actions/grype-image-scan/action.yml
+++ b/.github/actions/grype-image-scan/action.yml
@@ -33,8 +33,8 @@ runs:
       uses: anchore/scan-action@v7
       with:
         image: ${{ inputs.image }}
-        output-format: ${{ inputs.output-format }}
-        output-file: ${{ inputs.output-file }}
+        output-format: ${{ inputs['output-format'] }}
+        output-file: ${{ inputs['output-file'] }}
         severity-cutoff: high
-        fail-build: ${{ inputs.fail-build }}
-        only-fixed: ${{ inputs.only-fixed }}
+        fail-build: ${{ inputs['fail-build'] }}
+        only-fixed: ${{ inputs['only-fixed'] }}

--- a/.github/actions/grype-image-scan/action.yml
+++ b/.github/actions/grype-image-scan/action.yml
@@ -1,0 +1,40 @@
+name: Grype image vulnerability scan
+description: >
+  Run Grype (anchore/scan-action) against a built image using the project's
+  canonical severity cutoff. Callers vary only the output format / fail
+  behaviour, so the gating scan and the auto-fixer share one cutoff. Edit it
+  here, once.
+
+inputs:
+  image:
+    description: Image ref to scan
+    required: true
+  output-format:
+    description: "Grype output format (e.g. table, json)"
+    required: false
+    default: table
+  output-file:
+    description: File to write results to; empty writes to stdout
+    required: false
+    default: ""
+  fail-build:
+    description: Whether to fail the build when vulnerabilities are found
+    required: false
+    default: true
+  only-fixed:
+    description: Only report vulnerabilities that have a fix available
+    required: false
+    default: false
+
+runs:
+  using: composite
+  steps:
+    - name: Run Grype vulnerability scan
+      uses: anchore/scan-action@v7
+      with:
+        image: ${{ inputs.image }}
+        output-format: ${{ inputs.output-format }}
+        output-file: ${{ inputs.output-file }}
+        severity-cutoff: high
+        fail-build: ${{ inputs.fail-build }}
+        only-fixed: ${{ inputs.only-fixed }}

--- a/.github/actions/js-dependency-audit/action.yml
+++ b/.github/actions/js-dependency-audit/action.yml
@@ -1,0 +1,50 @@
+name: Javascript dependency audit
+description: >
+  Audit Javascript dependencies with npm. With fix disabled it runs the
+  project's `npm:audit` rake task and fails on any non-ignored advisory (the
+  gating scan). With fix enabled it applies non-breaking `npm audit fix`
+  updates (the auto-fixer). Both paths live here so the gate and the fixer stay
+  in sync. Requires ./.github/actions/setup-languages to have run first.
+
+inputs:
+  fix:
+    description: When 'true', apply non-breaking `npm audit fix` updates instead of just failing.
+    required: false
+    default: false
+
+outputs:
+  changes_made:
+    description: "'true' when the fix run modified package-lock.json/package.json"
+    value: ${{ steps.fix.outputs.changes_made }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run npm audit
+      if: inputs.fix != 'true'
+      shell: bash
+      working-directory: app
+      run: bundle exec rake npm:audit
+
+    # npm audit fix applies non-breaking updates only (no --force). Fixes that
+    # require a major bump are surfaced by the audit but left for manual review.
+    - name: Apply non-breaking npm audit fixes
+      id: fix
+      if: inputs.fix == 'true'
+      shell: bash
+      working-directory: app
+      run: |
+        npm audit fix || true
+        if git diff --quiet -- package-lock.json package.json; then
+          echo "changes_made=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changes_made=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "### npm packages updated"
+            echo ""
+            echo '```'
+            git diff --stat -- package-lock.json package.json
+            echo '```'
+            echo ""
+          } >> "${PATCH_SUMMARY_FILE}"
+        fi

--- a/.github/actions/ruby-dependency-audit/action.yml
+++ b/.github/actions/ruby-dependency-audit/action.yml
@@ -1,0 +1,34 @@
+name: Ruby dependency audit
+description: >
+  Audit Ruby dependencies with bundler-audit. With fix disabled it runs the
+  project's `bundler:audit` rake task and fails on any advisory (the gating
+  scan). With fix enabled it conservatively updates each flagged gem (the
+  auto-fixer). Both paths live here so the gate and the fixer stay in sync.
+  Requires ./.github/actions/setup-languages to have run first.
+
+inputs:
+  fix:
+    description: When 'true', apply `bundle update --conservative` for flagged gems instead of just failing.
+    required: false
+    default: false
+
+outputs:
+  changes_made:
+    description: "'true' when the fix run modified Gemfile.lock"
+    value: ${{ steps.fix.outputs.changes_made }}
+
+runs:
+  using: composite
+  steps:
+    - name: Update advisory database and run checks
+      if: inputs.fix != 'true'
+      shell: bash
+      working-directory: app
+      run: bundle exec rake bundler:audit
+
+    - name: Conservatively update flagged gems
+      id: fix
+      if: inputs.fix == 'true'
+      shell: bash
+      working-directory: app
+      run: bundle exec ruby "${GITHUB_WORKSPACE}/.github/scripts/fix-ruby-dependencies.rb"

--- a/.github/actions/trivy-image-scan/action.yml
+++ b/.github/actions/trivy-image-scan/action.yml
@@ -36,7 +36,7 @@ runs:
         image-ref: ${{ inputs.image }}
         format: ${{ inputs.format }}
         output: ${{ inputs.output }}
-        exit-code: ${{ inputs.exit-code }}
+        exit-code: ${{ inputs['exit-code'] }}
         severity: "HIGH,CRITICAL"
         ignore-unfixed: true
         vuln-type: os

--- a/.github/actions/trivy-image-scan/action.yml
+++ b/.github/actions/trivy-image-scan/action.yml
@@ -1,0 +1,43 @@
+name: Trivy image vulnerability scan
+description: >
+  Run Trivy against a built image using the project's canonical vulnerability
+  criteria (severity, vuln-type, ignore-unfixed). Callers vary only the output
+  format / exit behaviour, so the gating scan and the auto-fixer always detect
+  the same set of vulnerabilities. Edit the criteria here, once.
+
+inputs:
+  image:
+    description: Image ref to scan
+    required: true
+  format:
+    description: "Trivy output format (e.g. table, json)"
+    required: false
+    default: table
+  output:
+    description: File to write results to; empty writes to stdout
+    required: false
+    default: ""
+  exit-code:
+    description: Exit code when vulnerabilities are found (1 to fail, 0 to report)
+    required: false
+    default: "1"
+  scanners:
+    description: Comma-separated Trivy scanners to run
+    required: false
+    default: vuln
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy vulnerability scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: image
+        image-ref: ${{ inputs.image }}
+        format: ${{ inputs.format }}
+        output: ${{ inputs.output }}
+        exit-code: ${{ inputs.exit-code }}
+        severity: "HIGH,CRITICAL"
+        ignore-unfixed: true
+        vuln-type: os
+        scanners: ${{ inputs.scanners }}

--- a/.github/scripts/fix-ruby-dependencies.rb
+++ b/.github/scripts/fix-ruby-dependencies.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Conservative Ruby dependency vulnerability fixer.
+#
+# Usage: bundle exec ruby fix-ruby-dependencies.rb   (run from the app/ dir)
+#
+# Runs bundler-audit against the current bundle, then for each gem an advisory
+# flags runs `bundle update --conservative <gem>` to pull in the smallest
+# release that clears the advisory while respecting Gemfile constraints.
+# Emits changes_made to GITHUB_OUTPUT and a markdown summary to
+# PATCH_SUMMARY_FILE, mirroring patch-dockerfile.rb's output contract so the
+# same PR-opening plumbing consumes it.
+#
+# A gem whose fix needs a version outside the Gemfile constraint stays
+# unchanged (conservative update is a no-op); it is reported in the summary but
+# not auto-bumped, since that would require editing the Gemfile by hand.
+
+require 'json'
+
+LOCKFILE = 'Gemfile.lock'
+
+def sh(cmd)
+  puts "+ #{cmd}"
+  system(cmd)
+end
+
+# Pulls gem name / version / advisory details out of bundler-audit scan
+# results. Duck-typed so tests can pass plain stubs: an unpatched-gem result
+# responds to both #gem and #advisory.
+def advisories_from_results(results)
+  results.filter_map do |result|
+    next unless result.respond_to?(:gem) && result.respond_to?(:advisory)
+
+    spec = result.gem
+    advisory = result.advisory
+    patched = advisory.respond_to?(:patched_versions) ? Array(advisory.patched_versions) : []
+
+    {
+      gem: spec.name,
+      version: spec.version.to_s,
+      advisory: (advisory.id if advisory.respond_to?(:id)),
+      title: (advisory.title if advisory.respond_to?(:title)),
+      patched_versions: patched.map(&:to_s)
+    }
+  end
+end
+
+def scan_results(root)
+  require 'bundler/audit/database'
+  require 'bundler/audit/scanner'
+
+  Bundler::Audit::Database.update!(quiet: true)
+  Bundler::Audit::Scanner.new(root).scan.to_a
+rescue LoadError
+  warn 'bundler-audit not available; skipping Ruby dependency scan.'
+  []
+end
+
+def gems_to_update(advisories)
+  advisories.map { |a| a[:gem] }.uniq.sort
+end
+
+def update_gems(gems, runner:)
+  gems.each do |gem_name|
+    warn "bundle update --conservative #{gem_name} failed" unless runner.call("bundle update --conservative #{gem_name}")
+  end
+end
+
+def lockfile_changed?(runner:)
+  # git diff --quiet exits 0 with no diff, 1 when the lockfile changed.
+  !runner.call("git diff --quiet -- #{LOCKFILE}")
+end
+
+def set_github_output(key, value)
+  output_file = ENV['GITHUB_OUTPUT']
+  return unless output_file
+
+  File.open(output_file, 'a') { |f| f.puts("#{key}=#{value}") }
+end
+
+def write_summary(advisories)
+  summary_file = ENV['PATCH_SUMMARY_FILE']
+  return unless summary_file
+
+  out = +"### Vulnerable gems updated\n\n"
+  advisories.sort_by { |a| a[:gem] }.each do |a|
+    patched = a[:patched_versions].empty? ? 'n/a' : a[:patched_versions].join(', ')
+    out << "- `#{a[:gem]}` (was #{a[:version]}) — #{a[:advisory]}: patched in #{patched}\n"
+  end
+  out << "\n"
+
+  File.write(summary_file, out)
+end
+
+def main(results:, runner: method(:sh))
+  advisories = advisories_from_results(results)
+
+  if advisories.empty?
+    puts 'No vulnerable gems found.'
+    set_github_output('changes_made', 'false')
+    return
+  end
+
+  gems = gems_to_update(advisories)
+  puts "Vulnerable gems (#{gems.size}): #{gems.join(', ')}"
+  update_gems(gems, runner: runner)
+
+  if lockfile_changed?(runner: runner)
+    write_summary(advisories)
+    set_github_output('changes_made', 'true')
+    puts "#{LOCKFILE} updated."
+  else
+    puts "#{LOCKFILE} unchanged; fixes may require a manual major-version bump."
+    set_github_output('changes_made', 'false')
+  end
+end
+
+main(results: scan_results('.')) if $PROGRAM_NAME == __FILE__

--- a/.github/scripts/fix-ruby-dependencies_test.rb
+++ b/.github/scripts/fix-ruby-dependencies_test.rb
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/AbcSize,Metrics/ClassLength,Metrics/MethodLength,Style/Documentation
+
+require 'minitest/autorun'
+require 'tempfile'
+
+require_relative 'fix-ruby-dependencies'
+
+class FixRubyDependenciesTest < Minitest::Test
+  # Minimal stand-ins for bundler-audit's UnpatchedGem result graph.
+  Spec = Struct.new(:name, :version)
+  Advisory = Struct.new(:id, :title, :patched_versions)
+  UnpatchedGem = Struct.new(:gem, :advisory)
+  InsecureSource = Struct.new(:source) # no #gem / #advisory — must be ignored
+
+  def unpatched(name:, version:, id:, patched:)
+    UnpatchedGem.new(Spec.new(name, version), Advisory.new(id, "#{name} advisory", patched))
+  end
+
+  # A command runner that records invocations and returns a caller-provided
+  # boolean per matched command prefix (mirrors system's true/false).
+  class FakeRunner
+    attr_reader :commands
+
+    def initialize(diff_dirty: false, update_ok: true)
+      @commands = []
+      @diff_dirty = diff_dirty
+      @update_ok = update_ok
+    end
+
+    def to_proc
+      proc do |cmd|
+        @commands << cmd
+        if cmd.start_with?('git diff --quiet')
+          @diff_dirty ? false : true # `git diff --quiet` exits 1 (false) when dirty
+        else
+          @update_ok
+        end
+      end
+    end
+  end
+
+  # --- advisories_from_results ---
+
+  def test_extracts_gem_advisory_fields
+    results = [unpatched(name: 'nokogiri', version: '1.13.0', id: 'CVE-2022-1', patched: ['>= 1.13.6'])]
+
+    advisories = advisories_from_results(results)
+
+    assert_equal 1, advisories.size
+    assert_equal 'nokogiri', advisories.first[:gem]
+    assert_equal '1.13.0', advisories.first[:version]
+    assert_equal 'CVE-2022-1', advisories.first[:advisory]
+    assert_equal ['>= 1.13.6'], advisories.first[:patched_versions]
+  end
+
+  def test_ignores_results_without_gem_and_advisory
+    results = [
+      unpatched(name: 'rack', version: '2.0.0', id: 'CVE-x', patched: ['>= 2.0.1']),
+      InsecureSource.new('git://example.com')
+    ]
+
+    advisories = advisories_from_results(results)
+
+    assert_equal ['rack'], advisories.map { |a| a[:gem] }
+  end
+
+  def test_gems_to_update_dedups_and_sorts
+    advisories = [
+      { gem: 'rack' }, { gem: 'nokogiri' }, { gem: 'rack' }
+    ]
+
+    assert_equal %w[nokogiri rack], gems_to_update(advisories)
+  end
+
+  # --- main orchestration ---
+
+  def test_no_vulnerabilities_emits_changes_made_false_and_no_update
+    runner = FakeRunner.new
+    Tempfile.create('gh_output') do |gh_out|
+      ENV['GITHUB_OUTPUT'] = gh_out.path
+      main(results: [], runner: runner.to_proc)
+      assert_match(/changes_made=false/, File.read(gh_out.path))
+    end
+    assert_empty runner.commands, 'no commands run when nothing is vulnerable'
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+  end
+
+  def test_updates_each_vulnerable_gem_conservatively
+    results = [
+      unpatched(name: 'nokogiri', version: '1.13.0', id: 'CVE-1', patched: ['>= 1.13.6']),
+      unpatched(name: 'rack', version: '2.0.0', id: 'CVE-2', patched: ['>= 2.0.1'])
+    ]
+    runner = FakeRunner.new(diff_dirty: true)
+
+    Tempfile.create('gh_output') do |gh_out|
+      ENV['GITHUB_OUTPUT'] = gh_out.path
+      main(results: results, runner: runner.to_proc)
+    end
+
+    assert_includes runner.commands, 'bundle update --conservative nokogiri'
+    assert_includes runner.commands, 'bundle update --conservative rack'
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+  end
+
+  def test_dirty_lockfile_emits_changes_made_true_and_writes_summary
+    results = [unpatched(name: 'nokogiri', version: '1.13.0', id: 'CVE-1', patched: ['>= 1.13.6'])]
+    runner = FakeRunner.new(diff_dirty: true)
+
+    Tempfile.create('gh_output') do |gh_out|
+      Tempfile.create('summary') do |summary|
+        ENV['GITHUB_OUTPUT'] = gh_out.path
+        ENV['PATCH_SUMMARY_FILE'] = summary.path
+        main(results: results, runner: runner.to_proc)
+        assert_match(/changes_made=true/, File.read(gh_out.path))
+        assert_match(/`nokogiri` \(was 1\.13\.0\).*>= 1\.13\.6/, File.read(summary.path))
+      end
+    end
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+    ENV.delete('PATCH_SUMMARY_FILE')
+  end
+
+  def test_clean_lockfile_emits_changes_made_false
+    results = [unpatched(name: 'nokogiri', version: '1.13.0', id: 'CVE-1', patched: ['>= 2.0.0'])]
+    runner = FakeRunner.new(diff_dirty: false)
+
+    Tempfile.create('gh_output') do |gh_out|
+      ENV['GITHUB_OUTPUT'] = gh_out.path
+      main(results: results, runner: runner.to_proc)
+      assert_match(/changes_made=false/, File.read(gh_out.path))
+    end
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+  end
+end
+# rubocop:enable Metrics/AbcSize,Metrics/ClassLength,Metrics/MethodLength,Style/Documentation

--- a/.github/workflows/auto-fix-dependencies.yml
+++ b/.github/workflows/auto-fix-dependencies.yml
@@ -54,32 +54,17 @@ jobs:
 
       - uses: ./.github/actions/setup-languages
 
-      # Runs bundler-audit and applies `bundle update --conservative` per flagged gem.
       - name: Fix Ruby dependency vulnerabilities
         id: fix-ruby
-        working-directory: app
-        run: bundle exec ruby "${GITHUB_WORKSPACE}/.github/scripts/fix-ruby-dependencies.rb"
+        uses: ./.github/actions/ruby-dependency-audit
+        with:
+          fix: true
 
-      # `npm audit fix` applies non-breaking updates only (no --force). Fixes that
-      # require a major bump are surfaced by the scan but left for manual review.
       - name: Fix Javascript dependency vulnerabilities
         id: fix-js
-        working-directory: app
-        run: |
-          npm audit fix || true
-          if git diff --quiet -- package-lock.json package.json; then
-            echo "changes_made=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changes_made=true" >> "$GITHUB_OUTPUT"
-            {
-              echo "### npm packages updated"
-              echo ""
-              echo '```'
-              git diff --stat -- package-lock.json package.json
-              echo '```'
-              echo ""
-            } >> "${PATCH_SUMMARY_FILE}"
-          fi
+        uses: ./.github/actions/js-dependency-audit
+        with:
+          fix: true
 
       - name: Determine whether any fixes were applied
         id: patch

--- a/.github/workflows/auto-fix-dependencies.yml
+++ b/.github/workflows/auto-fix-dependencies.yml
@@ -1,0 +1,174 @@
+name: Auto-fix Ruby and Javascript Dependency Vulnerabilities
+
+on:
+  workflow_run:
+    workflows: [ "Ruby and Javascript dependency scans" ]
+    types: [ completed ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *' # Daily noon UTC, matches the dependency scan schedule
+
+# Prevent parallel runs from creating conflicting lockfile edits or duplicate PRs.
+concurrency:
+  group: auto-fix-dependencies
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  patch-dependencies:
+    name: Patch Ruby/JS dependency vulnerabilities
+    runs-on: ubuntu-latest
+    # For workflow_run: only run when the triggering scan failed.
+    # For workflow_dispatch and schedule: always run.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
+
+    env:
+      PATCH_SUMMARY_FILE: ${{ github.workspace }}/patch-summary.md
+
+    steps:
+      - name: Generate branch timestamp
+        id: timestamp
+        run: echo "value=$(date -u +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
+
+      - name: Determine reviewer
+        id: reviewer
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Tag the person whose push/PR triggered the failing scan
+            echo "login=${{ github.event.workflow_run.actor.login }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Tag whoever manually triggered this workflow
+            echo "login=${{ github.actor }}" >> "$GITHUB_OUTPUT"
+          else
+            # Scheduled run — no specific person to tag
+            echo "login=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-languages
+
+      # Runs bundler-audit and applies `bundle update --conservative` per flagged gem.
+      - name: Fix Ruby dependency vulnerabilities
+        id: fix-ruby
+        working-directory: app
+        run: bundle exec ruby "${GITHUB_WORKSPACE}/.github/scripts/fix-ruby-dependencies.rb"
+
+      # `npm audit fix` applies non-breaking updates only (no --force). Fixes that
+      # require a major bump are surfaced by the scan but left for manual review.
+      - name: Fix Javascript dependency vulnerabilities
+        id: fix-js
+        working-directory: app
+        run: |
+          npm audit fix || true
+          if git diff --quiet -- package-lock.json package.json; then
+            echo "changes_made=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes_made=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### npm packages updated"
+              echo ""
+              echo '```'
+              git diff --stat -- package-lock.json package.json
+              echo '```'
+              echo ""
+            } >> "${PATCH_SUMMARY_FILE}"
+          fi
+
+      - name: Determine whether any fixes were applied
+        id: patch
+        run: |
+          if [ "${{ steps.fix-ruby.outputs.changes_made }}" = "true" ] || \
+             [ "${{ steps.fix-js.outputs.changes_made }}" = "true" ]; then
+            echo "changes_made=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes_made=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate PR body
+        if: steps.patch.outputs.changes_made == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TRIGGER_RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          TRIGGER_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          {
+            echo "## Automated Ruby/JS Dependency Vulnerability Fix"
+            echo ""
+            if [ "$EVENT_NAME" = "workflow_run" ]; then
+              echo "<table>"
+              echo "<tr><td><b>Failed scan</b></td><td><a href=\"${TRIGGER_RUN_URL}\">${TRIGGER_RUN_TITLE}</a></td></tr>"
+              if [ -n "$TRIGGER_PR_NUMBER" ] && [ "$TRIGGER_PR_NUMBER" != "null" ]; then
+                echo "<tr><td><b>Source PR</b></td><td>#${TRIGGER_PR_NUMBER}</td></tr>"
+              fi
+              echo "</table>"
+            else
+              echo "**Triggered by:** manual \`${EVENT_NAME}\`"
+            fi
+            echo ""
+            echo "bundler-audit and/or npm audit flagged vulnerable dependencies. The lockfiles"
+            echo "have been updated with the smallest release that clears each advisory while"
+            echo "respecting the existing Gemfile/package.json constraints:"
+            echo ""
+            cat "${PATCH_SUMMARY_FILE}"
+            echo "---"
+            echo ""
+            echo "> [!IMPORTANT]"
+            echo "> **Trigger CI before merging.** This PR was opened by an automated workflow."
+            echo "> GitHub does not run CI on \`GITHUB_TOKEN\`-created PRs automatically."
+            echo "> To run the dependency scans:"
+            echo "> 1. Click **Close pull request** at the bottom of this page"
+            echo "> 2. Click **Reopen pull request**"
+            echo ""
+            echo "Fixes needing a major-version bump are not applied automatically — bump the"
+            echo "Gemfile/package.json constraint by hand if the scan still fails after this PR."
+            echo ""
+            echo "## AI Usage"
+            echo "- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR."
+            echo "- [x] NO_AI: I did not use AI."
+            echo ""
+          } > pr-body.md
+
+      - name: Check for existing open fix PR
+        if: steps.patch.outputs.changes_made == 'true'
+        id: check-existing-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label security \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("auto-fix/dependencies"))] | first | .number')
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            echo "Open fix PR #$EXISTING already exists — skipping creation."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update fix PR
+        if: steps.patch.outputs.changes_made == 'true' && steps.check-existing-pr.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            app/Gemfile.lock
+            app/package-lock.json
+            app/package.json
+          branch: auto-fix/dependencies-${{ steps.timestamp.outputs.value }}
+          base: main
+          delete-branch: false
+          title: 'fix: patch Ruby/JS dependencies for CVEs flagged by bundler-audit/npm audit'
+          labels: security
+          body-path: pr-body.md
+          reviewers: ${{ steps.reviewer.outputs.login }}
+          commit-message: 'fix: patch Ruby/JS dependencies for CVEs flagged by bundler-audit/npm audit'

--- a/.github/workflows/auto-fix-vulnerabilities.yml
+++ b/.github/workflows/auto-fix-vulnerabilities.yml
@@ -52,41 +52,28 @@ jobs:
 
       - uses: actions/checkout@v7
 
-      - name: Login to Docker Hub
-        if: env.DOCKERHUB_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-
-      - name: Build Docker image for scanning
+      - name: Build image for scanning
         id: build-image
-        run: |
-          make APP_NAME=app release-build
-          IMAGE_NAME=$(make APP_NAME=app release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/build-release-image
+        with:
+          app_name: app
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Run Trivy scan (JSON output)
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/actions/trivy-image-scan
         with:
-          scan-type: image
-          image-ref: ${{ steps.build-image.outputs.image }}
+          image: ${{ steps.build-image.outputs.image }}
           format: json
           output: trivy-results.json
-          exit-code: 0 # Don't fail here — we process results below
-          severity: 'HIGH,CRITICAL'
-          ignore-unfixed: true
-          vuln-type: os
-          scanners: vuln
+          exit-code: "0" # Don't fail here — we process results below
 
       - name: Run Grype scan (JSON output)
-        uses: anchore/scan-action@v7
+        uses: ./.github/actions/grype-image-scan
         with:
           image: ${{ steps.build-image.outputs.image }}
           output-format: json
           output-file: grype-results.json
-          severity-cutoff: high
           fail-build: false
           only-fixed: true
 

--- a/.github/workflows/ci-app-vulnerability-scans.yml
+++ b/.github/workflows/ci-app-vulnerability-scans.yml
@@ -24,6 +24,9 @@ on:
       - .dockleconfig
       - .github/workflows/ci-app-vulnerability-scans.yml
       - .github/workflows/vulnerability-scans.yml
+      - .github/actions/trivy-image-scan/**
+      - .github/actions/grype-image-scan/**
+      - .github/actions/build-release-image/**
 
 jobs:
   vulnerability-scans:

--- a/.github/workflows/ci-app-vulnerability-scans.yml
+++ b/.github/workflows/ci-app-vulnerability-scans.yml
@@ -13,10 +13,15 @@ on:
       - .github/workflows/vulnerability-scans.yml
   pull_request:
     paths:
-      - app/**
+      - app/Dockerfile
+      - app/Gemfile
+      - app/Gemfile.lock
+      - app/package.json
+      - app/package-lock.json
       - .grype.yml
       - .hadolint.yaml
       - .trivyignore
+      - .dockleconfig
       - .github/workflows/ci-app-vulnerability-scans.yml
       - .github/workflows/vulnerability-scans.yml
 

--- a/.github/workflows/dependency-scans.yml
+++ b/.github/workflows/dependency-scans.yml
@@ -14,6 +14,8 @@ on:
       - 'app/package.json'
       - 'app/package-lock.json'
       - '.github/workflows/dependency-scans.yml'
+      - '.github/actions/ruby-dependency-audit/**'
+      - '.github/actions/js-dependency-audit/**'
   schedule:
     # cron format: 'minute hour dayofmonth month dayofweek'
     # this will run at noon UTC every day (7am EST / 8am EDT)

--- a/.github/workflows/dependency-scans.yml
+++ b/.github/workflows/dependency-scans.yml
@@ -8,7 +8,12 @@ on:
       - 'app/README.md'
   pull_request:
     branches: [ main ]
-    paths: ['app/**']
+    paths:
+      - 'app/Gemfile'
+      - 'app/Gemfile.lock'
+      - 'app/package.json'
+      - 'app/package-lock.json'
+      - '.github/workflows/dependency-scans.yml'
   schedule:
     # cron format: 'minute hour dayofmonth month dayofweek'
     # this will run at noon UTC every day (7am EST / 8am EDT)

--- a/.github/workflows/dependency-scans.yml
+++ b/.github/workflows/dependency-scans.yml
@@ -29,9 +29,8 @@ jobs:
 
       - uses: ./.github/actions/setup-languages
 
-      - name: Update advisory database and run checks
-        run: bundle exec rake bundler:audit
-        working-directory: app
+      - name: Audit Ruby dependencies
+        uses: ./.github/actions/ruby-dependency-audit
 
   npm-audit:
     name: npm audit
@@ -42,9 +41,8 @@ jobs:
 
       - uses: ./.github/actions/setup-languages
 
-      - name: Run npm audit
-        working-directory: app
-        run: bundle exec rake npm:audit
+      - name: Audit Javascript dependencies
+        uses: ./.github/actions/js-dependency-audit
 
   ruby-bom:
     name: Ruby SBOM Generation

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,9 @@ on:
       - app/**
       - .github/workflows/secret-scan.yml
 
+permissions:
+  contents: read
+
 jobs:
   trivy-secret-scan:
     name: Trivy secret scan

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret scan
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'app/**' ]
+  pull_request:
+    paths:
+      - app/**
+      - .github/workflows/secret-scan.yml
+
+jobs:
+  trivy-secret-scan:
+    name: Trivy secret scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Trivy secret scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: app
+          scanners: secret
+          format: table
+          exit-code: 1
+
+      - name: Save output to workflow summary
+        if: always() # Runs even if there is a failure
+        run: echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,6 +23,9 @@ jobs:
           scan-type: fs
           scan-ref: app
           scanners: secret
+          severity: "HIGH,CRITICAL"
+          # VCR cassettes are recorded sandbox API responses, not real secrets.
+          skip-files: "**/vcr_http_requests.yml"
           format: table
           exit-code: 1
 

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -42,31 +42,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Login to Docker Hub
-        if: env.DOCKERHUB_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-
-      - name: Build and tag Docker image for scanning
+      - name: Build image for scanning
         id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/actions/trivy-image-scan
         with:
-          scan-type: image
-          image-ref: ${{ steps.build-image.outputs.image }}
-          format: table
-          exit-code: 1
-          severity: 'HIGH,CRITICAL'
-          ignore-unfixed: true
-          vuln-type: os
+          image: ${{ steps.build-image.outputs.image }}
           scanners: vuln,secret
 
       - name: Save output to workflow summary
@@ -80,27 +67,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Login to Docker Hub
-        if: env.DOCKERHUB_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-
-      - name: Build and tag Docker image for scanning
+      - name: Build image for scanning
         id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Run Anchore vulnerability scan
-        uses: anchore/scan-action@v7
+        uses: ./.github/actions/grype-image-scan
         with:
           image: ${{ steps.build-image.outputs.image }}
-          output-format: table
-          severity-cutoff: high
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
@@ -112,20 +90,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Login to Docker Hub
-        if: env.DOCKERHUB_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-
-      - name: Build and tag Docker image for scanning
+      - name: Build image for scanning
         id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
+          dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ env.DOCKERHUB_TOKEN }}
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,13 @@ repos:
     files: '^(\.github/scripts/patch-dockerfile.*\.rb|app/Dockerfile)$'
     pass_filenames: false
 
+  - id: fix-ruby-dependencies-test
+    name: fix-ruby-dependencies.rb test
+    entry: ruby .github/scripts/fix-ruby-dependencies_test.rb
+    language: system
+    files: '^\.github/scripts/fix-ruby-dependencies.*\.rb$'
+    pass_filenames: false
+
   - id: actionlint
     name: ActionLint
     entry: actionlint


### PR DESCRIPTION
## [FFS-4594](https://jiraent.cms.gov/browse/FFS-4594)
PRs are blocked when the build is red, which is getting in the way of bringing work into main. This change skips running those checks when the PR doesn't change any vulnerability or dependency, safely unblocking us to commit those changes. Instead we'll run those checks whenever we merge to `main`, and if something fails we should see an autofix PR generated so we can patch the failure independently. 

Proof that skips are working as expected:
- [x] [Secret Scan works](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/29045328232/job/86212467785?pr=1890)
- [X] Vuln and deps scans skipped on [Test PR that didn't change those files](https://github.com/DSACMS/iv-cbv-payroll/pull/1892)
- [X] Vuln and deps scanned ran on [Test PR that did change them](https://github.com/DSACMS/iv-cbv-payroll/pull/1893)

Two things to check following the merge to `main`:
- [ ] All vulnerability and dependency scans run
- [ ] Autofix PR gets created on dependency failures

## Context for reviewers
- The ruby script that updates the gems has a test that runs in the pre-commit hook if that script changes. 
- I consolidated some of the shared behavior in these actions in the second commit, that way if the way scan deps/vulns changes, the scripts that patch them will as well. 

## Acceptance testing
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.