### PR TITLE
FFS-4466: Return to household list after member submission

### DIFF
--- a/app/app/assets/stylesheets/households.scss
+++ b/app/app/assets/stylesheets/households.scss
@@ -9,3 +9,11 @@
     padding-top: units(2);
   }
 }
+
+.household-member-card__action {
+  width: 100%;
+
+  @include at-media("tablet") {
+    width: 8rem;
+  }
+}

--- a/app/app/controllers/activities/summary_controller.rb
+++ b/app/app/controllers/activities/summary_controller.rb
@@ -15,10 +15,17 @@ class Activities::SummaryController < Activities::BaseController
     ensure_confirmation_code
     mark_as_completed
 
-    redirect_to activities_flow_success_path
+    redirect_to after_submit_path
   end
 
   private
+
+  def after_submit_path
+    household = @flow.household_member&.household
+    return household_start_path(token: household.auth_token) if household
+
+    activities_flow_success_path
+  end
 
   def ensure_confirmation_code
     return if @flow.complete? || @flow.confirmation_code.present?

--- a/app/app/controllers/household_members_controller.rb
+++ b/app/app/controllers/household_members_controller.rb
@@ -2,6 +2,7 @@ class HouseholdMembersController < ApplicationController
   before_action :redirect_unless_activity_hub_enabled, :set_household, :set_household_member
 
   def create
+    # Completed household members should not re-enter an activity flow
     if @household_member.completed_activity_flow?
       set_flow_session(nil, :activity)
       return redirect_to household_start_path(token: @household.auth_token)

--- a/app/app/controllers/household_members_controller.rb
+++ b/app/app/controllers/household_members_controller.rb
@@ -2,6 +2,11 @@ class HouseholdMembersController < ApplicationController
   before_action :redirect_unless_activity_hub_enabled, :set_household, :set_household_member
 
   def create
+    if @household_member.completed_activity_flow?
+      set_flow_session(nil, :activity)
+      return redirect_to household_start_path(token: @household.auth_token)
+    end
+
     flow = ActivityFlow.resume_or_create_from_invitation(
       @household_member.activity_flow_invitation,
       cookies.permanent.signed[:device_id],

--- a/app/app/controllers/households_controller.rb
+++ b/app/app/controllers/households_controller.rb
@@ -2,6 +2,7 @@ class HouseholdsController < ApplicationController
   before_action :redirect_unless_activity_hub_enabled, :set_household
 
   def show
+    @household_members = @household.household_members.includes(:completed_activity_flows).order(:id)
     set_flow_session(nil, :activity)
   end
 

--- a/app/app/controllers/launcher_controller.rb
+++ b/app/app/controllers/launcher_controller.rb
@@ -325,7 +325,7 @@ class LauncherController < ApplicationController
   end
 
   def build_household_url(client_agency_id)
-    household = Launcher::HouseholdScenario.find_or_create!(client_agency_id: client_agency_id)
+    household = Launcher::HouseholdScenario.create_demo_household!(client_agency_id: client_agency_id)
     household.to_url(**launcher_url_options)
   end
 

--- a/app/app/models/activity_flow.rb
+++ b/app/app/models/activity_flow.rb
@@ -19,6 +19,7 @@ class ActivityFlow < Flow
 
   before_create :set_default_reporting_window, :set_default_renewal_required_months
 
+  scope :completed, -> { where.not(completed_at: nil) }
   scope :incomplete, -> { where(completed_at: nil) }
 
   def self.create_from_invitation(invitation, device_id, params = {})

--- a/app/app/models/household_member.rb
+++ b/app/app/models/household_member.rb
@@ -1,12 +1,14 @@
 class HouseholdMember < ApplicationRecord
   belongs_to :household
   belongs_to :activity_flow_invitation
+  has_many :activity_flows, through: :activity_flow_invitation
+  has_many :completed_activity_flows, -> { completed }, through: :activity_flow_invitation, source: :activity_flows
 
   validates :display_name, :role_label, :reference_id, presence: true
   validates :reference_id, uniqueness: { scope: :household_id }
   validates :activity_flow_invitation_id, uniqueness: true
 
   def completed_activity_flow?
-    activity_flow_invitation.activity_flows.completed.exists?
+    completed_activity_flows.any?
   end
 end

--- a/app/app/models/household_member.rb
+++ b/app/app/models/household_member.rb
@@ -5,4 +5,8 @@ class HouseholdMember < ApplicationRecord
   validates :display_name, :role_label, :reference_id, presence: true
   validates :reference_id, uniqueness: { scope: :household_id }
   validates :activity_flow_invitation_id, uniqueness: true
+
+  def completed_activity_flow?
+    activity_flow_invitation.activity_flows.completed.exists?
+  end
 end

--- a/app/app/services/launcher/household_scenario.rb
+++ b/app/app/services/launcher/household_scenario.rb
@@ -15,24 +15,26 @@ class Launcher::HouseholdScenario
     }
   ].freeze
 
-  def self.find_or_create!(client_agency_id: "sandbox")
-    new(client_agency_id).find_or_create!
+  def self.create_demo_household!(client_agency_id: "sandbox")
+    new(client_agency_id).create_demo_household!
   end
 
   def initialize(client_agency_id)
     @client_agency_id = client_agency_id
+    @household_reference_id = "#{REFERENCE_ID}-#{client_agency_id}-#{SecureRandom.hex(4)}"
   end
 
-  def find_or_create!
+  def create_demo_household!
     Household.transaction do
-      household = Household.find_or_create_by!(reference_id: household_reference_id) do |record|
-        record.client_agency_id = client_agency_id
-      end
+      household = Household.create!(
+        reference_id: household_reference_id,
+        client_agency_id: client_agency_id
+      )
 
       MEMBERS.each do |member_data|
-        invitation = find_or_create_invitation(member_data)
-        member = household.household_members.find_or_initialize_by(reference_id: member_data.fetch(:reference_id))
-        member.update!(
+        invitation = create_invitation(member_data)
+        household.household_members.create!(
+          reference_id: member_data.fetch(:reference_id),
           activity_flow_invitation: invitation,
           display_name: member_data.fetch(:display_name),
           role_label: member_data.fetch(:role_label)
@@ -45,17 +47,14 @@ class Launcher::HouseholdScenario
 
   private
 
-  attr_reader :client_agency_id
+  attr_reader :client_agency_id, :household_reference_id
 
-  def household_reference_id
-    "#{REFERENCE_ID}-#{client_agency_id}"
-  end
-
-  def find_or_create_invitation(member_data)
-    ActivityFlowInvitation.find_or_create_by!(reference_id: "#{household_reference_id}-#{member_data.fetch(:reference_id)}") do |invitation|
-      invitation.client_agency_id = client_agency_id
-      invitation.cbv_applicant = create_applicant(member_data)
-    end
+  def create_invitation(member_data)
+    ActivityFlowInvitation.create!(
+      reference_id: "#{household_reference_id}-#{member_data.fetch(:reference_id)}",
+      client_agency_id: client_agency_id,
+      cbv_applicant: create_applicant(member_data)
+    )
   end
 
   def create_applicant(member_data)

--- a/app/app/views/households/show.html.erb
+++ b/app/app/views/households/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <div class="margin-top-4 maxw-mobile-lg">
-  <% @household.household_members.order(:id).each do |member| %>
+  <% @household_members.each do |member| %>
     <% completed = member.completed_activity_flow? %>
     <%= render(Uswds::Card.new(heading_text: member.display_name, class: "household-member-card margin-bottom-2")) do |card| %>
       <% card.with_body do %>
@@ -20,7 +20,7 @@
 
       <% card.with_footer do %>
         <% if completed %>
-          <%= button_tag(t(".completed"), class: "usa-button usa-button--success household-member-card__action", disabled: true) %>
+          <%= button_tag(t(".completed"), type: "button", class: "usa-button usa-button--success household-member-card__action", disabled: true) %>
         <% else %>
           <%= button_to(
                 t(".launch"),

--- a/app/app/views/households/show.html.erb
+++ b/app/app/views/households/show.html.erb
@@ -10,6 +10,7 @@
 
 <div class="margin-top-4 maxw-mobile-lg">
   <% @household.household_members.order(:id).each do |member| %>
+    <% completed = member.completed_activity_flow? %>
     <%= render(Uswds::Card.new(heading_text: member.display_name, class: "household-member-card margin-bottom-2")) do |card| %>
       <% card.with_body do %>
         <p class="margin-y-0">
@@ -18,12 +19,16 @@
       <% end %>
 
       <% card.with_footer do %>
-        <%= button_to(
-              t(".launch"),
-              household_member_launch_path(token: @household.auth_token, member_id: member.id),
-              method: :post,
-              class: "usa-button"
-            ) %>
+        <% if completed %>
+          <%= button_tag(t(".completed"), class: "usa-button usa-button--success household-member-card__action", disabled: true) %>
+        <% else %>
+          <%= button_to(
+                t(".launch"),
+                household_member_launch_path(token: @household.auth_token, member_id: member.id),
+                method: :post,
+                class: "usa-button household-member-card__action"
+              ) %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -1131,6 +1131,7 @@ en:
       invalid_member: The household member you selected is invalid.
       invalid_token: The link you used is invalid.
     show:
+      completed: Complete
       description: Select the person whose community engagement report you want to work on.
       launch: Get started
       title: Who are you reporting for?

--- a/app/spec/controllers/activities/summary_controller_spec.rb
+++ b/app/spec/controllers/activities/summary_controller_spec.rb
@@ -758,6 +758,17 @@ RSpec.describe Activities::SummaryController, type: :controller do
       expect(response).to redirect_to(activities_flow_success_path)
     end
 
+    it "returns household member flows to the household member list" do
+      member = create(:household_member)
+      activity_flow.update!(activity_flow_invitation: member.activity_flow_invitation)
+
+      expect {
+        patch :update, params: { activity_flow: { consent_to_submit: "1" } }
+      }.to change { activity_flow.reload.completed_at }.from(nil)
+
+      expect(response).to redirect_to(household_start_path(token: member.household.auth_token))
+    end
+
     it "re-renders summary with alert when consent is missing and keeps activity table content" do
       create(
         :volunteering_activity,

--- a/app/spec/controllers/household_members_controller_spec.rb
+++ b/app/spec/controllers/household_members_controller_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe HouseholdMembersController, type: :controller do
       expect(response).to redirect_to(activities_flow_root_path)
     end
 
+    it "does not create another activity flow for a completed member" do
+      completed_flow = create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: Time.zone.now)
+      session[:flow_id] = completed_flow.id
+      session[:flow_type] = :activity
+
+      expect {
+        post :create, params: { token: household.auth_token, member_id: member.id }
+      }.not_to change(ActivityFlow, :count)
+
+      expect(session[:flow_id]).to be_nil
+      expect(session[:flow_type]).to eq(:activity)
+      expect(response).to redirect_to(household_start_path(token: household.auth_token))
+    end
+
     it "does not use another member's incomplete activity flow" do
       member_a = create(:household_member, household: household)
       member_b = create(:household_member, household: household)

--- a/app/spec/controllers/households_controller_spec.rb
+++ b/app/spec/controllers/households_controller_spec.rb
@@ -7,20 +7,34 @@ RSpec.describe HouseholdsController, type: :controller do
 
   describe "GET #show" do
     let(:household) { create(:household) }
+    let(:title) { I18n.t("households.show.title") }
+    let(:launch_label) { I18n.t("households.show.launch") }
+    let(:completed_label) { I18n.t("households.show.completed") }
+    let(:invalid_token_message) { I18n.t("households.errors.invalid_token") }
 
     it "shows household members for a household token" do
-      create(:household_member, household: household, display_name: "Avery Johnson", role_label: "Primary applicant")
-      create(:household_member, household: household, display_name: "Riley Johnson", role_label: "Household member")
+      primary_member = create(
+        :household_member,
+        household: household,
+        display_name: "Avery Johnson",
+        role_label: "Primary applicant"
+      )
+      household_member = create(
+        :household_member,
+        household: household,
+        display_name: "Riley Johnson",
+        role_label: "Household member"
+      )
 
       get :show, params: { token: household.auth_token }
 
       rendered = Capybara.string(response.body)
       expect(response).to have_http_status(:success)
-      expect(rendered).to have_text("Who are you reporting for?")
-      expect(rendered).to have_text("Avery Johnson")
-      expect(rendered).to have_text("Primary applicant")
-      expect(rendered).to have_text("Riley Johnson")
-      expect(rendered).to have_text("Household member")
+      expect(rendered).to have_text(title)
+      expect(rendered).to have_text(primary_member.display_name)
+      expect(rendered).to have_text(primary_member.role_label)
+      expect(rendered).to have_text(household_member.display_name)
+      expect(rendered).to have_text(household_member.role_label)
       expect(rendered).to have_selector(".household-member-card", count: 2)
     end
 
@@ -33,8 +47,22 @@ RSpec.describe HouseholdsController, type: :controller do
       rendered = Capybara.string(response.body)
       expect(rendered).to have_selector(
         "form[action='#{member_launch_path}'][method='post']",
-        text: "Get started"
+        text: launch_label
       )
+      expect(rendered).to have_button(launch_label)
+      expect(rendered).to have_no_button(completed_label)
+    end
+
+    it "renders a disabled Complete button for completed members" do
+      member = create(:household_member, household: household)
+      create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: Time.zone.now)
+
+      get :show, params: { token: household.auth_token }
+
+      rendered = Capybara.string(response.body)
+      member_card = rendered.find(".household-member-card", text: member.display_name)
+      expect(member_card).to have_button(completed_label, disabled: true)
+      expect(member_card).to have_no_button(launch_label)
     end
 
     it "keeps the same household available when the link is reopened" do
@@ -58,7 +86,7 @@ RSpec.describe HouseholdsController, type: :controller do
       get :show, params: { token: "notatoken" }
 
       expect(response).to redirect_to(root_url)
-      expect(flash[:alert]).to eq("The link you used is invalid.")
+      expect(flash[:alert]).to eq(invalid_token_message)
     end
 
     it "accepts a household token with trailing URL-safe punctuation" do

--- a/app/spec/controllers/launcher_controller_advanced_spec.rb
+++ b/app/spec/controllers/launcher_controller_advanced_spec.rb
@@ -245,6 +245,32 @@ RSpec.describe LauncherController, type: :controller do
         end
         expect(pre_populated_activities).to all(eq([]))
       end
+
+      it "returns a new household URL for each household launch" do
+        first_url = nil
+        first_household = nil
+        expect {
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "household"
+          }, format: :json
+          first_household = Household.last
+          first_url = JSON.parse(response.body).fetch("url")
+        }.to change(Household, :count).by(1)
+        expect(first_url).to include("/households/start/#{first_household.auth_token}")
+
+        second_url = nil
+        second_household = nil
+        expect {
+          post :create, params: {
+            client_agency_id: "sandbox",
+            launch_type: "household"
+          }, format: :json
+          second_household = Household.last
+          second_url = JSON.parse(response.body).fetch("url")
+        }.to change(Household, :count).by(1)
+        expect(second_url).to include("/households/start/#{second_household.auth_token}")
+      end
     end
 
     context "with CBV flow type" do

--- a/app/spec/e2e/household_activity_flow_spec.rb
+++ b/app/spec/e2e/household_activity_flow_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "e2e Household activity flow", :js, type: :feature do
+  include E2e::TestHelpers
+  include_context "activity_hub"
+
+  let(:primary_member_name) { "Avery Johnson" }
+  let(:secondary_member_name) { "Riley Johnson" }
+
+  it "returns to the household list after each member submits" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    # Launch a fresh test household
+    visit "/launcher/advanced"
+    verify_page(page, title: "Emmy Launcher")
+
+    click_button "Test household"
+    household_url = find("#generated_tokenized_url", wait: 10).value
+    household_path = URI.parse(household_url).request_uri
+
+    visit household_path
+    verify_page(page, title: I18n.t("households.show.title"))
+
+    # Complete the primary member and return to the household list
+    submit_household_member_report(primary_member_name)
+
+    expect(page).to have_current_path(household_path)
+    verify_page(page, title: I18n.t("households.show.title"))
+    expect(completed_member_activity_flow_count(primary_member_name)).to eq(1)
+    within_household_member(primary_member_name) do
+      expect(page).to have_button(I18n.t("households.show.completed"), disabled: true)
+      expect(page).to have_no_button(I18n.t("households.show.launch"))
+    end
+    within_household_member(secondary_member_name) do
+      expect(page).to have_button(I18n.t("households.show.launch"))
+      expect(page).to have_no_button(I18n.t("households.show.completed"))
+    end
+
+    # Complete the second member from the same household link
+    submit_household_member_report(secondary_member_name)
+
+    expect(page).to have_current_path(household_path)
+    verify_page(page, title: I18n.t("households.show.title"))
+    expect(completed_member_activity_flow_count(primary_member_name)).to eq(1)
+    expect(completed_member_activity_flow_count(secondary_member_name)).to eq(1)
+  end
+
+  def submit_household_member_report(display_name)
+    within_household_member(display_name) do
+      click_button I18n.t("households.show.launch")
+    end
+
+    verify_page(page, title: I18n.t("activities.hub.empty_state_title"))
+
+    flow = member_activity_flows(display_name).order(created_at: :desc).first
+    add_community_service_activity(flow, "#{display_name} Food Pantry")
+
+    visit activities_flow_root_path
+    verify_page(page, title: I18n.t("activities.hub.completed_state_title"))
+
+    click_button I18n.t("activities.hub.review_and_submit")
+    verify_page(page, title: I18n.t("activities.summary.title", benefit: I18n.t("shared.benefit.sandbox")))
+
+    find("label[for='activity_flow_consent_to_submit']").click
+    click_button I18n.t("activities.summary.submit", agency_name: I18n.t("shared.agency_full_name.sandbox"))
+  end
+
+  def add_community_service_activity(flow, organization_name)
+    activity = create(
+      :volunteering_activity,
+      activity_flow: flow,
+      organization_name: organization_name,
+      draft: false
+    )
+
+    flow.reporting_months.each do |month|
+      create(
+        :volunteering_activity_month,
+        volunteering_activity: activity,
+        month: month.beginning_of_month,
+        hours: 80
+      )
+    end
+  end
+
+  def within_household_member(display_name, &block)
+    within(find(".household-member-card", text: display_name), &block)
+  end
+
+  def member_activity_flows(display_name)
+    HouseholdMember.find_by!(display_name: display_name).activity_flow_invitation.activity_flows
+  end
+
+  def completed_member_activity_flow_count(display_name)
+    member_activity_flows(display_name).completed.count
+  end
+end

--- a/app/spec/e2e/household_activity_flow_spec.rb
+++ b/app/spec/e2e/household_activity_flow_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "e2e Household activity flow", :js, type: :feature do
   it "returns to the household list after each member submits" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
     # Launch a fresh test household
     visit "/launcher/advanced"
-    verify_page(page, title: "Emmy Launcher")
 
     click_button "Test household"
     household_url = find("#generated_tokenized_url", wait: 10).value

--- a/app/spec/models/household_member_spec.rb
+++ b/app/spec/models/household_member_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe HouseholdMember, type: :model do
       expect(member.completed_activity_flow?).to be true
     end
 
+    it "uses preloaded activity flows when they are available" do
+      member = create(:household_member, household: household)
+      create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: Time.zone.now)
+      preloaded_member = described_class.includes(:completed_activity_flows).find(member.id)
+
+      expect(preloaded_member.completed_activity_flows).to be_loaded
+      expect(preloaded_member.completed_activity_flow?).to be true
+    end
+
     it "returns false when the member only has incomplete activity flows" do
       member = create(:household_member, household: household)
       create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: nil)

--- a/app/spec/models/household_member_spec.rb
+++ b/app/spec/models/household_member_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe HouseholdMember, type: :model do
 
     expect(member).to be_valid
   end
+
+  describe "#completed_activity_flow?" do
+    it "returns true when the member has a completed activity flow" do
+      member = create(:household_member, household: household)
+      create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: Time.zone.now)
+
+      expect(member.completed_activity_flow?).to be true
+    end
+
+    it "returns false when the member only has incomplete activity flows" do
+      member = create(:household_member, household: household)
+      create(:activity_flow, activity_flow_invitation: member.activity_flow_invitation, completed_at: nil)
+
+      expect(member.completed_activity_flow?).to be false
+    end
+  end
 end

--- a/app/spec/services/launcher/household_scenario_spec.rb
+++ b/app/spec/services/launcher/household_scenario_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Launcher::HouseholdScenario do
-  describe ".find_or_create!" do
+  describe ".create_demo_household!" do
     it "creates a test household with two members and member invitations" do
-      household = described_class.find_or_create!(client_agency_id: "sandbox")
+      household = described_class.create_demo_household!(client_agency_id: "sandbox")
 
       expect(household.client_agency_id).to eq("sandbox")
+      expect(household.reference_id).to start_with("household-scenario-sandbox-")
       expect(household.household_members.map(&:display_name)).to contain_exactly("Avery Johnson", "Riley Johnson")
       expect(household.household_members.map(&:role_label)).to contain_exactly("Primary applicant", "Household member")
       invitations = household.household_members.map(&:activity_flow_invitation)
@@ -15,22 +16,17 @@ RSpec.describe Launcher::HouseholdScenario do
       expect(invitations.map(&:cbv_applicant).uniq.size).to eq(invitations.size)
     end
 
-    it "reuses the same household and members" do
-      household = described_class.find_or_create!(client_agency_id: "sandbox")
-      counts = {
-        households: Household.count,
-        household_members: HouseholdMember.count,
-        activity_flow_invitations: ActivityFlowInvitation.count,
-        cbv_applicants: CbvApplicant.count
-      }
+    it "creates a fresh test household each time" do
+      household = described_class.create_demo_household!(client_agency_id: "sandbox")
 
-      same_household = described_class.find_or_create!(client_agency_id: "sandbox")
+      expect {
+        described_class.create_demo_household!(client_agency_id: "sandbox")
+      }.to change(Household, :count).by(1)
+        .and change(HouseholdMember, :count).by(2)
+        .and change(ActivityFlowInvitation, :count).by(2)
+        .and change(CbvApplicant, :count).by(2)
 
-      expect(same_household).to eq(household)
-      expect(Household.count).to eq(counts.fetch(:households))
-      expect(HouseholdMember.count).to eq(counts.fetch(:household_members))
-      expect(ActivityFlowInvitation.count).to eq(counts.fetch(:activity_flow_invitations))
-      expect(CbvApplicant.count).to eq(counts.fetch(:cbv_applicants))
+      expect(Household.last).not_to eq(household)
     end
 
     it "does not reuse an existing applicant that matches a member's name and date of birth" do
@@ -44,7 +40,7 @@ RSpec.describe Launcher::HouseholdScenario do
 
       household = nil
       expect {
-        household = described_class.find_or_create!(client_agency_id: "sandbox")
+        household = described_class.create_demo_household!(client_agency_id: "sandbox")
       }.to change(CbvApplicant, :count).by(2)
 
       avery_member = household.household_members.find_by!(reference_id: "avery")
@@ -57,8 +53,8 @@ RSpec.describe Launcher::HouseholdScenario do
     end
 
     it "creates separate test households per agency" do
-      sandbox_household = described_class.find_or_create!(client_agency_id: "sandbox")
-      la_household = described_class.find_or_create!(client_agency_id: "la_ldh")
+      sandbox_household = described_class.create_demo_household!(client_agency_id: "sandbox")
+      la_household = described_class.create_demo_household!(client_agency_id: "la_ldh")
 
       expect(la_household).not_to eq(sandbox_household)
       expect(la_household.reference_id).not_to eq(sandbox_household.reference_id)

--- a/app/spec/support/e2e/test_helpers.rb
+++ b/app/spec/support/e2e/test_helpers.rb
@@ -28,7 +28,7 @@ module E2e
 
       # Infer flow from URL
       current_path = URI.parse(page.current_url).path
-      if current_path&.start_with?("/activities")
+      if current_path&.start_with?("/activities") || current_path&.start_with?("/households") || current_path&.start_with?("/launcher")
         pilot_name ||= I18n.t("shared.pilot_name_hr1_full")
       elsif current_path&.include?("/cbv/")
         pilot_name ||= I18n.t("shared.pilot_name")


### PR DESCRIPTION
## [FFS-4466](https://jiraent.cms.gov/browse/FFS-4466)

## Changes
<!-- What was added, updated, or removed in this PR. -->
- Household activity flows return to the household member list after submitting, bypassing the normal success/download report page
- Shows completed household members with a disabled "Complete" button, preventing a completed member from starting another flow
- Advanced launcher now creates a fresh household each time
- E2E coverage for completing both household members from the same household link

## Context for reviewers
- Nixed making the "Complete" button green. USWDS uses gray for disabled buttons to signal that they aren’t usable, and I think we should stick with that for now, especially since "Complete" button in general was added by eng and outside the current designs.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<img width="574" height="480" alt="Screenshot 2026-07-09 at 1 18 35 PM" src="https://github.com/user-attachments/assets/db82c9bb-d5fb-40fb-8be4-bdf584a4ec02" />

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1891.navapbc.cloud/launcher/advanced
- Deployed commit: fff25a945ecc220246e2f01432959a4800fb3477
<!-- end PR environment info -->