### PR TITLE
Remove response body from JsonTransmitter exceptions

### DIFF
--- a/app/app/services/transmitters/json_transmitter.rb
+++ b/app/app/services/transmitters/json_transmitter.rb
@@ -44,8 +44,9 @@ class Transmitters::JsonTransmitter
   private
 
   def raise_response_error!(response, default_error_class)
-    message = "Unexpected response from agency: code=#{response.code} message=#{response.message} body=#{response.body}"
+    message = "Unexpected response from agency: code=#{response.code} message=#{response.message}"
     Rails.logger.error message
+    Rails.logger.error "Error response body: #{response.body}"
 
     error_class = silence_errors_from_response_codes.include?(response.code.to_s) ?
       ApplicationJob::SilencedError :

--- a/app/spec/services/transmitters/json_transmitter_spec.rb
+++ b/app/spec/services/transmitters/json_transmitter_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe Transmitters::JsonTransmitter do
           .to raise_error(Transmitters::JsonTransmitter::JsonTransmitterError, /Unexpected response from agency/)
       end
 
-      expect(Rails.logger).to have_received(:error).with(/Unexpected response from agency: code=500 message=Internal Server Error body=Internal Server Error/)
+      expect(Rails.logger).to have_received(:error).with(/Unexpected response from agency: code=500 message=Internal Server Error/)
+      expect(Rails.logger).to have_received(:error).with("Error response body: Internal Server Error")
     end
 
     it 'does not set json_transmitted_at on the cbv_flow when transmission fails' do
@@ -103,7 +104,8 @@ RSpec.describe Transmitters::JsonTransmitter do
           .to raise_error(Transmitters::JsonTransmitter::JsonTransmitterError, /Unexpected response from agency/)
       end
 
-      expect(Rails.logger).to have_received(:error).with(/Unexpected response from agency: code=418 message=I'm a teapot body=Here is my handle, here is my spout./)
+      expect(Rails.logger).to have_received(:error).with(/Unexpected response from agency: code=418 message=I'm a teapot/)
+      expect(Rails.logger).to have_received(:error).with("Error response body: Here is my handle, here is my spout.")
     end
   end
 
@@ -119,7 +121,7 @@ RSpec.describe Transmitters::JsonTransmitter do
       expect { described_class.new(cbv_flow, mock_client_agency, aggregator_report).deliver }
         .to raise_error(
           ApplicationJob::SilencedError,
-          /code=408 message=Request Timeout body=Request Timeout/
+          /code=408 message=Request Timeout/
         )
     end
   end


### PR DESCRIPTION
## No ticket: On-call relief ticket

## Changes
<!-- What was added, updated, or removed in this PR. -->

Keep JsonTransmitter exception messages limited to stable response
details so error grouping is not fragmented by dynamic bodies. Log the
response body separately for diagnostic context.

See #1807 where we did the same but for other exceptions.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: Codex
