### PR TITLE
FFS-4146: Create S3 bucket of unscanned uploads

### DIFF
--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -62,6 +62,7 @@ output "notifications_config" {
 
 output "storage_config" {
   value = {
-    bucket_name = local.bucket_name
+    bucket_name                   = local.bucket_name
+    unscanned_uploads_bucket_name = "${local.bucket_name}-unscanned-uploads"
   }
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -211,7 +211,8 @@ module "service" {
 
   extra_environment_variables = merge(
     {
-      BUCKET_NAME = local.storage_config.bucket_name
+      BUCKET_NAME           = local.storage_config.bucket_name
+      UNSCANNED_BUCKET_NAME = local.storage_config.unscanned_uploads_bucket_name
     },
     local.ssm_env_vars,
     local.identity_provider_environment_variables,
@@ -231,8 +232,9 @@ module "service" {
 
   extra_policies = merge(
     {
-      storage_access = module.storage.access_policy_arn,
-      email_access   = aws_iam_policy.email_access_policy.arn,
+      storage_access           = module.storage.access_policy_arn,
+      unscanned_uploads_access = module.unscanned_uploads_storage.access_policy_arn,
+      email_access             = aws_iam_policy.email_access_policy.arn,
     },
     module.app_config.enable_identity_provider ? {
       identity_provider_access = module.identity_provider_client[0].access_policy_arn,
@@ -257,6 +259,13 @@ module "storage" {
   source       = "../../modules/storage"
   name         = local.storage_config.bucket_name
   is_temporary = local.is_temporary
+}
+
+module "unscanned_uploads_storage" {
+  source          = "../../modules/storage"
+  name            = local.storage_config.unscanned_uploads_bucket_name
+  is_temporary    = local.is_temporary
+  expiration_days = 7
 }
 
 module "email" {

--- a/infra/modules/storage/lifecycle.tf
+++ b/infra/modules/storage/lifecycle.tf
@@ -1,6 +1,8 @@
 resource "aws_s3_bucket_lifecycle_configuration" "storage" {
   bucket = aws_s3_bucket.storage.id
 
+  # checkov:skip=CKV_AWS_300:Abort period is set on the AbortIncompleteUpload rule; checkov miscounts when a second (dynamic) rule is present
+
   rule {
     id     = "AbortIncompleteUpload"
     status = "Enabled"
@@ -9,6 +11,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "storage" {
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.expiration_days == null ? [] : [var.expiration_days]
+    content {
+      id     = "ExpireObjects"
+      status = "Enabled"
+
+      filter {}
+
+      expiration {
+        days = rule.value
+      }
     }
   }
 }

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -8,3 +8,9 @@ variable "name" {
   type        = string
   description = "Name of the AWS S3 bucket. Needs to be globally unique across all regions."
 }
+
+variable "expiration_days" {
+  description = "Days after which objects are deleted (garbage collected). Null disables expiration. Matches DataRetentionService 7-day retention when set."
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
## [FFS-4146](https://jiraent.cms.gov/browse/FFS-4146)

## Changes
<!-- What was added, updated, or removed in this PR. -->
- Add an `unscanned_uploads_bucket_name` output to `env-config` (`<bucket_name>-unscanned-uploads`) and provision a second S3 bucket via a new `unscanned_uploads_storage` module instance.
- Expose the new bucket to the service as `UNSCANNED_BUCKET_NAME` and grant access via a new `unscanned_uploads_access` IAM policy.
- Add an optional `expiration_days` variable to the storage module with a `dynamic` lifecycle rule that expires objects after N days; set to 7 for the unscanned bucket.
- Add a `checkov:skip=CKV_AWS_300` on the lifecycle config (abort period is set; checkov miscounts when the dynamic rule is present).

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
The unscanned uploads bucket holds files pending virus scanning. Its 7-day expiration matches `DataRetentionService`'s existing 7-day retention. `expiration_days` defaults to `null`, so the primary storage bucket is unchanged (no expiration rule emitted). The checkov skip is required because the tool miscounts abort periods once a second (dynamic) lifecycle rule exists — the `AbortIncompleteUpload` rule still sets `days_after_initiation = 7`.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->
  - [ ] Plan reviewed
  - [x] Applied in dev before merge
  - [ ] Applied in demo after merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

## **Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
None. Additive infra change — new bucket, env var, and IAM policy; existing storage bucket behavior unchanged.
