### PR TITLE
Skip JS dependency autofix PR when packages pass audit

### DIFF
--- a/.github/actions/js-dependency-audit/action.yml
+++ b/.github/actions/js-dependency-audit/action.yml
@@ -28,12 +28,20 @@ runs:
 
     # npm audit fix applies non-breaking updates only (no --force). Fixes that
     # require a major bump are surfaced by the audit but left for manual review.
+    # Gated on the npm:audit task so it runs only when a non-ignored advisory is
+    # present; otherwise npm audit fix rewrites package-lock.json for cosmetic
+    # normalization (e.g. libc metadata) and churns out empty PRs.
     - name: Apply non-breaking npm audit fixes
       id: fix
       if: inputs.fix == 'true'
       shell: bash
       working-directory: app
       run: |
+        if bundle exec rake npm:audit; then
+          echo "No actionable npm advisories — skipping npm audit fix."
+          echo "changes_made=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         npm audit fix || true
         if git diff --quiet -- package-lock.json package.json; then
           echo "changes_made=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Changes
`npm audit fix` rewrites `package-lock.json` even when there aren't any vulnerability issues, producing PRs as we saw [yesterday](https://github.com/DSACMS/iv-cbv-payroll/pull/1907) and [today.](https://github.com/DSACMS/iv-cbv-payroll/pull/1908) 

This commits gates `npm audit fix` action on the result of `rake npm:audit` so it won't create PRs unless there's an actual dependency issue. 

## Context for reviewers

## Acceptance testing
I ran the action manually off of this branch and the [output confirms it skipped creating the PR.](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/29537643785/job/87753147300#step:7:32) Next time it runs on the cron we should see it skip as well. 

- [X] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester

## AI Usage
- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.