### PR TITLE
FFS-4269: Add scripts to run commands in CMS Cloud

### DIFF
--- a/bin/ecs-console-cms
+++ b/bin/ecs-console-cms
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Open a Rails console in a temporary, audited CMS Cloud ECS Exec task.
+# Usage: bin/ecs-console-cms [environment] [readonly|admin]
+set -euo pipefail
+
+environment="${1:-dev}"
+access_mode="${2:-readonly}"
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
+exec "$script_dir/run-command-cms" \
+  --access-mode "$access_mode" \
+  "$environment" \
+  '["bin/rails", "console"]'

--- a/bin/run-command-cms
+++ b/bin/run-command-cms
@@ -1,0 +1,201 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Run a command in a temporary, audited CMS Cloud ECS Exec task.
+#
+# The CMS Cloud infrastructure provides separate read-only and administrative
+# console task definitions and operator roles. This script assumes the
+# requested operator role, starts its task, waits for its ECS Exec agent, runs
+# the command interactively, and stops the task when the session ends.
+#
+# Optional parameters:
+#   --access-mode - Console task access level: readonly (default) or admin.
+#
+# Positional parameters:
+#   environment (required) - Application environment, such as dev, demo, or
+#     prod.
+#   command (required) - JSON list representing the command to run.
+#     e.g. '["bin/rails", "runner", "puts Rails.env"]'
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 [--access-mode readonly|admin] environment command
+
+Example: $0 dev '["bin/rails", "runner", "puts Rails.env"]'
+Example: $0 --access-mode admin prod '["bin/rails", "console"]'
+EOF
+}
+
+access_mode="readonly"
+while (($#)); do
+  case "$1" in
+    --access-mode)
+      access_mode="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ "$access_mode" != "readonly" && "$access_mode" != "admin" ]]; then
+  echo "--access-mode must be readonly or admin" >&2
+  exit 2
+fi
+
+if (($# != 2)); then
+  usage >&2
+  exit 2
+fi
+
+environment="$1"
+command="$2"
+
+case "$environment" in
+  dev|test)
+    aws_account_id="554269192106"
+    ;;
+  sandbox|demo|uat|prod)
+    aws_account_id="162263641551"
+    ;;
+  *)
+    echo "Unsupported CMS Cloud environment: ${environment}" >&2
+    echo "Supported environments: dev, test, sandbox, demo, uat, prod" >&2
+    exit 2
+    ;;
+esac
+
+command_for_shell=$(jq -er '
+  if type == "array" and length > 0 and all(.[]; type == "string") then
+    @sh
+  else
+    error("command must be a non-empty JSON array of strings")
+  end
+' <<<"$command")
+
+cluster_name="emmy-${environment}"
+service_name="emmy-${environment}-app"
+task_definition="emmy-${environment}-console-${access_mode}"
+container_name="emmy-console-${access_mode}"
+operator_role_arn="arn:aws:iam::${aws_account_id}:role/${task_definition}-operator"
+task_arn=""
+
+cleanup() {
+  if [[ -z "$task_arn" ]]; then
+    return
+  fi
+
+  echo
+  echo "Stopping temporary CMS console task ${task_arn}..."
+  aws ecs stop-task \
+    --no-cli-pager \
+    --cluster "$cluster_name" \
+    --task "$task_arn" \
+    --reason "CMS Cloud console session ended" >/dev/null || true
+  aws ecs wait tasks-stopped \
+    --no-cli-pager \
+    --cluster "$cluster_name" \
+    --tasks "$task_arn" || true
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+echo "========================="
+echo "Running CMS Cloud command"
+echo "========================="
+echo "  environment=${environment}"
+echo "  access_mode=${access_mode}"
+echo "  command=${command}"
+echo
+
+network_configuration=$(aws ecs describe-services \
+  --no-cli-pager \
+  --cluster "$cluster_name" \
+  --services "$service_name" \
+  --query 'services[0].networkConfiguration' \
+  --output json)
+
+if [[ "$network_configuration" == "null" ]]; then
+  echo "Could not find network configuration for ${service_name} in ${cluster_name}" >&2
+  exit 1
+fi
+
+echo "Assuming CMS Cloud console operator role ${operator_role_arn}..."
+read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN < <(
+  aws sts assume-role \
+    --no-cli-pager \
+    --role-arn "$operator_role_arn" \
+    --role-session-name "emmy-console-$(date +%s)" \
+    --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+    --output text
+)
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+caller_arn=$(aws sts get-caller-identity --no-cli-pager --query Arn --output text)
+echo "Using CMS Cloud identity ${caller_arn}"
+echo
+
+task_arn=$(aws ecs run-task \
+  --no-cli-pager \
+  --cluster "$cluster_name" \
+  --task-definition "$task_definition" \
+  --enable-execute-command \
+  --propagate-tags TASK_DEFINITION \
+  --launch-type FARGATE \
+  --network-configuration "$network_configuration" \
+  --query 'tasks[0].taskArn' \
+  --output text)
+
+if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
+  echo "Failed to start ${task_definition}" >&2
+  exit 1
+fi
+
+echo "Started temporary CMS console task ${task_arn}"
+echo "Waiting for the ECS Exec agent..."
+
+for _ in {1..60}; do
+  task_status=$(aws ecs describe-tasks \
+    --no-cli-pager \
+    --cluster "$cluster_name" \
+    --tasks "$task_arn" \
+    --query 'tasks[0].lastStatus' \
+    --output text)
+  agent_status=$(aws ecs describe-tasks \
+    --no-cli-pager \
+    --cluster "$cluster_name" \
+    --tasks "$task_arn" \
+    --query "tasks[0].containers[?name=='${container_name}'] | [0].managedAgents[?name=='ExecuteCommandAgent'] | [0].lastStatus" \
+    --output text)
+
+  if [[ "$agent_status" == "RUNNING" ]]; then
+    break
+  fi
+  if [[ "$task_status" == "STOPPED" ]]; then
+    echo "Console task stopped before ECS Exec became available:" >&2
+    aws ecs describe-tasks --no-cli-pager --cluster "$cluster_name" --tasks "$task_arn" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+if [[ "$agent_status" != "RUNNING" ]]; then
+  echo "Timed out waiting for the ECS Exec agent in ${task_arn}" >&2
+  exit 1
+fi
+
+echo "Starting ECS Exec session..."
+aws ecs execute-command \
+  --no-cli-pager \
+  --cluster "$cluster_name" \
+  --task "$task_arn" \
+  --container "$container_name" \
+  --interactive \
+  --command "sh -lc $(printf '%q' "exec ${command_for_shell}")"


### PR DESCRIPTION
## [FFS-4269](https://jiraent.cms.gov/browse/FFS-4269)

## Changes
<!-- What was added, updated, or removed in this PR. -->

The script uses ECS Exec by first starting a task (using an "operator"
role), and then connecting to it.

It's not fast to set up, but it does work OK.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

The corresponding infrastructure changes have already been deployed. I ran this
script already to test it.

I broke out fixing the "readonly" functionality into [FFS-4613](https://jiraent.cms.gov/browse/FFS-4613).

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
