### PR TITLE
Fix ruby dependency updater autofix PR by thawing the bundle

### DIFF
--- a/.github/scripts/fix-ruby-dependencies.rb
+++ b/.github/scripts/fix-ruby-dependencies.rb
@@ -63,7 +63,8 @@ end
 
 def update_gems(gems, runner:)
   gems.each do |gem_name|
-    warn "bundle update --conservative #{gem_name} failed" unless runner.call("bundle update --conservative #{gem_name}")
+    cmd = "BUNDLE_FROZEN=false bundle update --conservative #{gem_name}"
+    warn "#{cmd} failed" unless runner.call(cmd)
   end
 end
 

--- a/.github/scripts/fix-ruby-dependencies_test.rb
+++ b/.github/scripts/fix-ruby-dependencies_test.rb
@@ -101,8 +101,23 @@ class FixRubyDependenciesTest < Minitest::Test
       main(results: results, runner: runner.to_proc)
     end
 
-    assert_includes runner.commands, 'bundle update --conservative nokogiri'
-    assert_includes runner.commands, 'bundle update --conservative rack'
+    assert_includes runner.commands, 'BUNDLE_FROZEN=false bundle update --conservative nokogiri'
+    assert_includes runner.commands, 'BUNDLE_FROZEN=false bundle update --conservative rack'
+  ensure
+    ENV.delete('GITHUB_OUTPUT')
+  end
+
+  def test_update_disables_frozen_mode
+    results = [unpatched(name: 'loofah', version: '2.25.1', id: 'CVE-1', patched: ['>= 2.25.2'])]
+    runner = FakeRunner.new(diff_dirty: true)
+
+    Tempfile.create('gh_output') do |gh_out|
+      ENV['GITHUB_OUTPUT'] = gh_out.path
+      main(results: results, runner: runner.to_proc)
+    end
+
+    update = runner.commands.find { |c| c.include?('bundle update') }
+    assert_match(/\ABUNDLE_FROZEN=false /, update)
   ensure
     ENV.delete('GITHUB_OUTPUT')
   end

--- a/.github/scripts/fix-ruby-dependencies_test.rb
+++ b/.github/scripts/fix-ruby-dependencies_test.rb
@@ -117,6 +117,7 @@ class FixRubyDependenciesTest < Minitest::Test
     end
 
     update = runner.commands.find { |c| c.include?('bundle update') }
+    refute_nil update, 'expected a bundle update command to be run'
     assert_match(/\ABUNDLE_FROZEN=false /, update)
   ensure
     ENV.delete('GITHUB_OUTPUT')


### PR DESCRIPTION
## Changes
Fix Ruby dependency updater: prefix `bundle update --conservative` with `BUNDLE_FROZEN=false` so the autofix runs in a frozen-bundle CI environment; add test asserting frozen mode is disabled

## Context for reviewers
I noticed CI was failing but there was no corresponding fix to unblock us, reason being is the ruby dependency updater ran under `BUNDLE_FROZEN=true` in CI, which blocks `bundle update` from modifying `Gemfile.lock` so the autofix silently failed. Setting `BUNDLE_FROZEN=false` inline on the update command fixes that. It won't run until its merged so we'll have to wait til then to get it unblocked manually.

## Acceptance testing
After merge we should see an autofix PR with the correct ruby changes.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.