### PR TITLE
FFS-4623: Disable rack-mini-profiler in Sandbox, UAT, Production [by 8/18]

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -78,10 +78,6 @@ gem "aws-sdk-rails"
 gem "aws-sdk-s3"
 gem "aws-actionmailer-ses"
 
-# profiling
-gem "rack-mini-profiler"
-gem "stackprof"
-
 # https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/
 gem "rexml", "~> 3.4.2"
 gem "gpgme", "~> 2.0"
@@ -91,6 +87,10 @@ gem "cgi", ">= 0.4.2"     # Fixing GHSA-mhwm-jh88-3gjf
 gem "thor", ">= 1.4.0"    # Fixing GHSA-mqcp-p2hv-vw6x
 
 group :development, :test do
+  # profiling
+  gem "rack-mini-profiler"
+  gem "stackprof"
+
   gem "brakeman"
   gem "bundler-audit", "~> 0.9"
   gem "capybara"
@@ -115,9 +115,6 @@ group :development do
   gem "debase", "~> 0.2.9", require: false
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   helper :view
   helper_method :current_agency, :show_menu?, :pilot_ended?, :get_site_alert_title, :get_site_alert_body, :activity_flow?, :session_timeout_enabled?, :session_timeout_duration, :internal_environment?
   around_action :switch_locale
-  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :enable_mini_profiler_in_demo, :set_device_id_cookie
+  before_action :add_newrelic_metadata, :redirect_if_maintenance_mode, :set_device_id_cookie
   after_action :apply_iframe_embedding
 
   rescue_from ActionController::InvalidAuthenticityToken do
@@ -137,12 +137,6 @@ class ApplicationController < ActionController::Base
 
   def normalize_token(token)
     ALPHANUMERIC_PREFIX_REGEXP.match(token.to_s)&.[](1)
-  end
-
-  def enable_mini_profiler_in_demo
-    return unless Rails.application.config.is_internal_environment
-
-    Rack::MiniProfiler.authorize_request
   end
 
   def client_agency_from_domain

--- a/app/spec/controllers/application_controller_spec.rb
+++ b/app/spec/controllers/application_controller_spec.rb
@@ -49,34 +49,6 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe '#enable_mini_profiler_in_demo' do
-    before do
-      routes.draw do
-        get 'test_action', to: 'anonymous#test_action'
-      end
-
-      allow(Rails.application.config).to receive(:is_internal_environment).and_return(is_internal_environment)
-    end
-
-    context 'when in demo environment' do
-      let(:is_internal_environment) { true }
-
-      it 'authorizes mini profiler' do
-        expect(Rack::MiniProfiler).to receive(:authorize_request)
-        get :test_action
-      end
-    end
-
-    context 'when not in demo environment' do
-      let(:is_internal_environment) { false }
-
-      it 'does not authorize mini profiler' do
-        expect(Rack::MiniProfiler).not_to receive(:authorize_request)
-        get :test_action
-      end
-    end
-  end
-
   describe '#detect_client_agency_from_domain' do
     before do
       routes.draw do


### PR DESCRIPTION
## [FFS-4623](https://jiraent.cms.gov/browse/FFS-4623)

## Changes
- `rack-mini-profiler` and `stackprof` limited to test/development
- Internal-environment profiler authorization removed

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.