### PR TITLE
FFS-4634: Implement shared event filing for Emmy CE

### DIFF
--- a/app/app/controllers/activities/activities_controller.rb
+++ b/app/app/controllers/activities/activities_controller.rb
@@ -1,4 +1,6 @@
 class Activities::ActivitiesController < Activities::BaseController
+  after_action :track_hub_viewed_event, only: :index
+
   def index
     unless @flow.identity
       @flow.identity = IdentityService.new(request, @flow.cbv_applicant).get_identity
@@ -16,5 +18,11 @@ class Activities::ActivitiesController < Activities::BaseController
     @employment_activities = @flow.employment_activities.published.includes(:employment_activity_months).order(created_at: :desc)
     @employment_draft_activities = @flow.employment_activities.pre_populated_drafts.includes(:employment_activity_months).order(created_at: :desc)
     @persisted_report = PersistedReportAdapter.new(@flow) if @employment_payroll_accounts.any?
+  end
+
+  private
+
+  def track_hub_viewed_event
+    track_event(TrackEvent::HubViewed)
   end
 end

--- a/app/app/controllers/api/user_events_controller.rb
+++ b/app/app/controllers/api/user_events_controller.rb
@@ -1,8 +1,21 @@
 class Api::UserEventsController < ApplicationController
   def user_action
-    @flow = flow_class.find(session[:flow_id]) if session[:flow_id].present?
+    base_attributes = {
+      time: Time.now.to_i
+    }
 
-    event_attributes = (user_action_params[:attributes] || {}).merge(standard_track_attributes)
+    if session[:flow_id].present?
+      @flow = flow_class.find(session[:flow_id])
+
+      base_attributes.merge!({
+        cbv_flow_id: @flow.id,
+        cbv_applicant_id: @flow.cbv_applicant_id,
+        client_agency_id: @flow.cbv_applicant.client_agency_id,
+        invitation_id: @flow.invitation_id
+      })
+    end
+
+    event_attributes = (user_action_params[:attributes] || {}).merge(base_attributes)
     event_name = user_action_params[:event_name]
 
     if TrackEvent.constants.map(&:to_s).include?(event_name)

--- a/app/app/controllers/api/user_events_controller.rb
+++ b/app/app/controllers/api/user_events_controller.rb
@@ -1,21 +1,8 @@
 class Api::UserEventsController < ApplicationController
   def user_action
-    base_attributes = {
-      time: Time.now.to_i
-    }
+    @flow = flow_class.find(session[:flow_id]) if session[:flow_id].present?
 
-    if session[:flow_id].present?
-      @flow = flow_class.find(session[:flow_id])
-
-      base_attributes.merge!({
-        cbv_flow_id: @flow.id,
-        cbv_applicant_id: @flow.cbv_applicant_id,
-        client_agency_id: @flow.cbv_applicant.client_agency_id,
-        invitation_id: @flow.invitation_id
-      })
-    end
-
-    event_attributes = (user_action_params[:attributes] || {}).merge(base_attributes)
+    event_attributes = (user_action_params[:attributes] || {}).merge(standard_track_attributes)
     event_name = user_action_params[:event_name]
 
     if TrackEvent.constants.map(&:to_s).include?(event_name)

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Trackable
+
   ALPHANUMERIC_PREFIX_REGEXP = /^([a-zA-Z0-9]+)[^a-zA-Z0-9]*$/
 
   helper :view

--- a/app/app/controllers/concerns/trackable.rb
+++ b/app/app/controllers/concerns/trackable.rb
@@ -1,0 +1,43 @@
+# Shared Mixpanel event-tracking helper for both the CBV (Income) and
+# Activities (CE) flows. See the taxonomy design doc for the full naming
+# convention and standard-parameter list:
+# docs/superpowers/specs/2026-08-06-ce-mixpanel-taxonomy-confluence-page.txt
+#
+# Usage from a controller:
+#
+#   track_event(TrackEvent::HubViewed, some_extra_param: "value")
+#
+# `client_agency_id`, `cbv_flow_id`, `cbv_applicant_id`, and `invitation_id`
+# are attached automatically from `current_agency`/`@flow`. `time`,
+# `flow_type`, `device_id`, and `locale` are attached automatically further
+# downstream in GenericEventTracker#prep_request_attributes. Add new event
+# names to TrackEvent before referencing them here.
+#
+# From frontend/Stimulus code, use `trackUserAction()`
+# (app/javascript/utilities/api.js) instead, which round-trips through this
+# same pipeline via Api::UserEventsController.
+module Trackable
+  extend ActiveSupport::Concern
+
+  def track_event(event_name, extra_attributes = {})
+    event_logger.track(event_name, request, standard_track_attributes.merge(extra_attributes))
+  end
+
+  private
+
+  def standard_track_attributes
+    # Snapshot @flow before calling current_agency: ApplicationController#current_agency
+    # reassigns `@flow = @cbv_flow` as a legacy compatibility shim, which clobbers @flow
+    # back to nil in any controller (like Api::UserEventsController) that sets @flow
+    # directly without also setting the legacy @cbv_flow alias.
+    flow = @flow
+    attrs = { client_agency_id: current_agency&.id }
+    return attrs unless flow
+
+    attrs.merge(
+      cbv_flow_id: flow.id,
+      cbv_applicant_id: flow.cbv_applicant_id,
+      invitation_id: flow.invitation_id
+    )
+  end
+end

--- a/app/app/controllers/concerns/trackable.rb
+++ b/app/app/controllers/concerns/trackable.rb
@@ -29,7 +29,9 @@ module Trackable
     # Snapshot @flow before calling current_agency: ApplicationController#current_agency
     # reassigns `@flow = @cbv_flow` as a legacy compatibility shim, which clobbers @flow
     # back to nil in any controller (like Api::UserEventsController) that sets @flow
-    # directly without also setting the legacy @cbv_flow alias.
+    # directly without also setting the legacy @cbv_flow alias. This snapshot (and the
+    # shim itself, in ApplicationController#current_agency) can be deleted once every
+    # controller is converted to use @flow exclusively and @cbv_flow is retired.
     flow = @flow
     attrs = { client_agency_id: current_agency&.id }
     return attrs unless flow

--- a/app/app/controllers/concerns/trackable.rb
+++ b/app/app/controllers/concerns/trackable.rb
@@ -1,21 +1,3 @@
-# Shared Mixpanel event-tracking helper for both the CBV (Income) and
-# Activities (CE) flows. See the taxonomy design doc for the full naming
-# convention and standard-parameter list:
-# docs/superpowers/specs/2026-08-06-ce-mixpanel-taxonomy-confluence-page.txt
-#
-# Usage from a controller:
-#
-#   track_event(TrackEvent::HubViewed, some_extra_param: "value")
-#
-# `client_agency_id`, `cbv_flow_id`, `cbv_applicant_id`, and `invitation_id`
-# are attached automatically from `current_agency`/`@flow`. `time`,
-# `flow_type`, `device_id`, and `locale` are attached automatically further
-# downstream in GenericEventTracker#prep_request_attributes. Add new event
-# names to TrackEvent before referencing them here.
-#
-# From frontend/Stimulus code, use `trackUserAction()`
-# (app/javascript/utilities/api.js) instead, which round-trips through this
-# same pipeline via Api::UserEventsController.
 module Trackable
   extend ActiveSupport::Concern
 

--- a/app/app/models/track_event.rb
+++ b/app/app/models/track_event.rb
@@ -80,5 +80,6 @@ module TrackEvent
   CaseworkerInvitedApplicantToFlow = "CaseworkerInvitedApplicantToFlow"
   CbvPageView = "CbvPageView"
   EmailSent = "EmailSent"
+  HubViewed = "HubViewed"
   IncomeSummaryMatchedAgencyNames = "IncomeSummaryMatchedAgencyNames"
 end

--- a/app/lib/generic_event_tracker.rb
+++ b/app/lib/generic_event_tracker.rb
@@ -25,6 +25,7 @@ class GenericEventTracker
         device_id: request.cookie_jar.signed[:device_id],
         ip: request.remote_ip,
         cbv_flow_id: request.session[:flow_id],
+        flow_type: request.session[:flow_type].to_s == "activity" ? "ce" : "income",
         client_agency_id: url_params["client_agency_id"],
         locale: url_params["locale"] || I18n.locale.to_s,
         user_agent: request.headers["User-Agent"]

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -4,20 +4,10 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
   include_context "activity_hub"
   render_views
 
-  describe "tracking" do
-    let(:current_flow) { create(:activity_flow) }
-    let(:tracked_flow) { current_flow }
-    let(:perform_tracked_action) do
-      session[:flow_id] = current_flow.id
-      session[:flow_type] = :activity
-      get :index
-    end
-
-    it_behaves_like "tracks an event", TrackEvent::HubViewed
-  end
-
   describe "#index" do
     let(:current_flow) { create(:activity_flow) }
+    let(:tracked_flow) { current_flow }
+    let(:perform_tracked_action) { get :index }
 
     before do
       create(:activity_flow) # ensure there is a second flow that might get mixed up
@@ -29,6 +19,8 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       session[:flow_type] = :activity
       get :index
     end
+
+    it_behaves_like "tracks an event", TrackEvent::HubViewed
 
     it "shows current flow community service activities" do
       expect(

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
   include_context "activity_hub"
   render_views
 
+  describe "tracking" do
+    let(:current_flow) { create(:activity_flow) }
+    let(:tracked_flow) { current_flow }
+    let(:perform_tracked_action) do
+      session[:flow_id] = current_flow.id
+      session[:flow_type] = :activity
+      get :index
+    end
+
+    it_behaves_like "tracks an event", TrackEvent::HubViewed
+  end
+
   describe "#index" do
     let(:current_flow) { create(:activity_flow) }
 

--- a/app/spec/controllers/concerns/trackable_spec.rb
+++ b/app/spec/controllers/concerns/trackable_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Trackable do
+  let(:trackable_test_class) do
+    Class.new do
+      include Trackable
+      attr_accessor :current_agency, :event_logger, :request
+
+      def flow=(flow)
+        @flow = flow
+      end
+    end
+  end
+  let(:instance) { trackable_test_class.new }
+  let(:event_logger) { instance_double(GenericEventTracker, track: nil) }
+  let(:current_agency) { instance_double(ClientAgencyConfig::ClientAgency, id: "test_agency") }
+  let(:fake_request) { instance_double(ActionDispatch::Request) }
+
+  before do
+    instance.event_logger = event_logger
+    instance.current_agency = current_agency
+    instance.request = fake_request
+  end
+
+  describe "#track_event" do
+    context "when @flow is present" do
+      let(:cbv_applicant) { create(:cbv_applicant) }
+      let(:flow) { create(:cbv_flow, cbv_applicant: cbv_applicant) }
+
+      before { instance.flow = flow }
+
+      it "tracks the event with the flow's standard attributes merged with any extras" do
+        instance.track_event("SomeEvent", num_results: 3)
+
+        expect(event_logger).to have_received(:track).with(
+          "SomeEvent",
+          fake_request,
+          {
+            client_agency_id: "test_agency",
+            cbv_flow_id: flow.id,
+            cbv_applicant_id: flow.cbv_applicant_id,
+            invitation_id: flow.invitation_id,
+            num_results: 3
+          }
+        )
+      end
+    end
+
+    context "when @flow is absent" do
+      it "still tracks client_agency_id from current_agency, without flow-derived keys" do
+        instance.track_event("SomeEvent")
+
+        expect(event_logger).to have_received(:track).with(
+          "SomeEvent",
+          fake_request,
+          { client_agency_id: "test_agency" }
+        )
+      end
+    end
+
+    context "when current_agency has the side effect of resetting @flow (as ApplicationController#current_agency does, via its `@flow = @cbv_flow` legacy compatibility shim)" do
+      let(:trackable_test_class) do
+        Class.new do
+          include Trackable
+          attr_accessor :event_logger, :request
+
+          def flow=(flow)
+            @flow = flow
+          end
+
+          # Mirrors ApplicationController#current_agency's `@flow = @cbv_flow`
+          # side effect: a controller that only ever sets @flow (not the legacy
+          # @cbv_flow alias) would have @flow clobbered back to nil by this call.
+          def current_agency
+            @flow = @cbv_flow
+            Struct.new(:id).new("resolved_agency")
+          end
+
+          # No-op setter so the shared `before` block's `instance.current_agency =`
+          # call doesn't blow up; the getter above is what actually matters here.
+          def current_agency=(_agency); end
+        end
+      end
+
+      let(:cbv_applicant) { create(:cbv_applicant) }
+      let(:flow) { create(:cbv_flow, cbv_applicant: cbv_applicant) }
+
+      before { instance.flow = flow }
+
+      it "still includes flow-derived attributes, unaffected by current_agency's side effect" do
+        instance.track_event("SomeEvent")
+
+        expect(event_logger).to have_received(:track).with(
+          "SomeEvent",
+          fake_request,
+          {
+            client_agency_id: "resolved_agency",
+            cbv_flow_id: flow.id,
+            cbv_applicant_id: flow.cbv_applicant_id,
+            invitation_id: flow.invitation_id
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/spec/generic_event_tracker_spec.rb
+++ b/app/spec/generic_event_tracker_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe GenericEventTracker do
       expect(EventTrackingJob).to receive(:perform_later).with("myEvent", anything, hash_including(
         time: an_instance_of(Integer),
         cbv_flow_id: "cbv_flow_id",
+        flow_type: "income",
         locale: an_instance_of(String),
         user_agent: "user_agent",
         client_agency_id: "client_agency_id",
@@ -21,6 +22,13 @@ RSpec.describe GenericEventTracker do
       ))
       cookie_jar = instance_double(ActionDispatch::Cookies::CookieJar, signed: { device_id: nil })
       request_mock = instance_double(ActionDispatch::Request, params: { "client_agency_id" => "client_agency_id" }, session: { flow_id: "cbv_flow_id" }, remote_ip: "ip", headers: { "User-Agent" => "user_agent" }, cookie_jar: cookie_jar)
+      described_class.new.track("myEvent", request_mock, {})
+    end
+
+    it 'populates flow_type as "ce" when the session flow_type is activity' do
+      expect(EventTrackingJob).to receive(:perform_later).with("myEvent", anything, hash_including(flow_type: "ce"))
+      cookie_jar = instance_double(ActionDispatch::Cookies::CookieJar, signed: { device_id: nil })
+      request_mock = instance_double(ActionDispatch::Request, params: { "client_agency_id" => "client_agency_id" }, session: { flow_id: "activity_flow_id", flow_type: "activity" }, remote_ip: "ip", headers: { "User-Agent" => "user_agent" }, cookie_jar: cookie_jar)
       described_class.new.track("myEvent", request_mock, {})
     end
 

--- a/app/spec/support/shared_examples/tracks_event_examples.rb
+++ b/app/spec/support/shared_examples/tracks_event_examples.rb
@@ -1,0 +1,27 @@
+# Reusable assertion for controller specs verifying a Trackable#track_event
+# call, so per-flow tickets can add coverage for a new event without writing
+# a new EventTrackingJob expectation from scratch each time. The including
+# spec must define:
+#   - `tracked_flow` — the CbvFlow/ActivityFlow the request is scoped to
+#   - `perform_tracked_action` — the request that should fire the event (e.g. `get :index`)
+#
+# Usage:
+#   it_behaves_like "tracks an event", TrackEvent::HubViewed
+#   it_behaves_like "tracks an event", TrackEvent::SomeEvent, extra_attributes: { foo: "bar" }
+RSpec.shared_examples "tracks an event" do |event_name, extra_attributes: {}|
+  it "tracks #{event_name}" do
+    expect(EventTrackingJob).to receive(:perform_later).with(
+      event_name,
+      anything,
+      hash_including(
+        cbv_flow_id: tracked_flow.id,
+        cbv_applicant_id: tracked_flow.cbv_applicant_id,
+        invitation_id: tracked_flow.invitation_id,
+        client_agency_id: tracked_flow.cbv_applicant.client_agency_id,
+        **extra_attributes
+      )
+    )
+
+    perform_tracked_action
+  end
+end


### PR DESCRIPTION
## [FFS-4634](https://jiraent.cms.gov/browse/FFS-4634)

## Changes
Added the Trackable concern to allow Emmy CE flows to easily file Mixpanel events.
Emmy Income flows should be entirely unchanged.
Created the HubViewed event as a demonstration of how to use the concern.

## Context for reviewers
Noticed that the continuing dichotomy of flow vs cbv_flow causes some complexity; we might want to do a cleanup ticket soon.

## Acceptance testing
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>

<!-- begin PR environment info -->
## Preview environment
- Link to launcher: https://p-1957.navapbc.cloud/launcher/advanced
- Deployed commit: 89bb7f7b07cdaa8acf1bc489b6f4cf8813d8e31a
<!-- end PR environment info -->