### PR TITLE
Fix health check version contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ functional change to the application.
 
 - **MINOR** — Adopt semantic versioning with interface changes promoted to
   MAJOR. Rubric documented in [docs/versioning.md](./docs/versioning.md).
-- **MINOR** — `GET /health` now reports a `release_version` field alongside the
-  existing `version` (deployed image tag).
+- **MINOR** — `GET /health` now reports the semantic version as `version` and
+  the deployed image tag as `ref`.
 
 ### Before this release
 

--- a/app/app/controllers/health_check_controller.rb
+++ b/app/app/controllers/health_check_controller.rb
@@ -4,7 +4,7 @@ class HealthCheckController < ActionController::Base
     ActiveRecord::Base.connection.execute("SELECT 1")
     # `version` is the deployed image tag (a git SHA) and is consumed by
     # bin/will-deploy; `release_version` is the semantic version from version.txt.
-    render json: { status: "ok", ref: ENV["IMAGE_TAG"], version: EmmyVersion.current }
+    render json: { status: "ok", version: ENV["IMAGE_TAG"], release_version: EmmyVersion.current }
   end
 
   def test_queueing

--- a/app/app/controllers/health_check_controller.rb
+++ b/app/app/controllers/health_check_controller.rb
@@ -2,9 +2,9 @@ class HealthCheckController < ActionController::Base
   def ok
     # keep the database connection alive
     ActiveRecord::Base.connection.execute("SELECT 1")
-    # `version` is the deployed image tag (a git SHA) and is consumed by
-    # bin/will-deploy; `release_version` is the semantic version from version.txt.
-    render json: { status: "ok", version: ENV["IMAGE_TAG"], release_version: EmmyVersion.current }
+    # `ref` is the deployed image tag (a git SHA) and is consumed by
+    # bin/will-deploy; `version` is the semantic version from version.txt.
+    render json: { status: "ok", ref: ENV["IMAGE_TAG"], version: EmmyVersion.current }
   end
 
   def test_queueing

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -31,9 +31,9 @@ def run_command(*command)
   stdout.strip
 end
 
-def fetch_production_version
+def fetch_production_ref
   response = URI.open("https://snap-income-pilot.com/health", &:read)
-  JSON.parse(response).fetch("version")
+  JSON.parse(response).fetch("ref")
 end
 
 def commit_lines(prod, current_sha)
@@ -103,7 +103,7 @@ if ARGV.first == "--test"
 end
 
 run_command("git", "fetch", "--quiet")
-prod = fetch_production_version
+prod = fetch_production_ref
 current_sha = run_command("git", "rev-parse", "origin/main")
 
 both_changes = []

--- a/app/spec/controllers/health_check_controller_spec.rb
+++ b/app/spec/controllers/health_check_controller_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe HealthCheckController do
   describe "#ok" do
     it "renders successfully" do
       get :ok
-      expect(response.body).to eq(JSON.generate(status: :ok, version: "foobar", release_version: EmmyVersion.current))
+      expect(response.body).to eq(JSON.generate(status: :ok, ref: "foobar", version: EmmyVersion.current))
     end
 
-    it "reports the release version from version.txt" do
+    it "reports the version from version.txt" do
       get :ok
-      expect(JSON.parse(response.body)["release_version"]).to match(/\A\d+\.\d+\.\d+\z/)
+      expect(JSON.parse(response.body)["version"]).to match(/\A\d+\.\d+\.\d+\z/)
     end
   end
 end

--- a/docs/app/runbooks/running-built-images-locally.md
+++ b/docs/app/runbooks/running-built-images-locally.md
@@ -10,7 +10,7 @@ AWS_PROFILE=prod aws ecr get-login-password --region us-east-1 | \
   docker login --username AWS --password-stdin 730335532059.dkr.ecr.us-east-1.amazonaws.com
 
 # 2. Get the latest Production image name
-image_tag=$(curl https://snap-income-pilot.com/health | jq -r .version)
+image_tag=$(curl https://snap-income-pilot.com/health | jq -r .ref)
 image_name="730335532059.dkr.ecr.us-east-1.amazonaws.com/iv-cbv-payroll-app:$image_tag"
 
 # 3. Run the docker image

--- a/docs/infra/vulnerability-management.md
+++ b/docs/infra/vulnerability-management.md
@@ -38,7 +38,7 @@ The Grype scanner is a Docker image scanner made by the company Anchore. It allo
 To debug a vulnerable system-level dependency of unknown origin, either build the image locally (with `make release-build`) or [download the CI-built image](/docs/app/runbooks/running-built-images-locally.md) and run:
 
 ```bash
-image_tag=$(curl https://verify-demo.navapbc.cloud/health | jq -r .version)
+image_tag=$(curl https://verify-demo.navapbc.cloud/health | jq -r .ref)
 image_name="730335532059.dkr.ecr.us-east-1.amazonaws.com/iv-cbv-payroll-app:$image_tag"
 
 # Login to container registry if necessary

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -79,9 +79,9 @@ three-slot rubric then.
   in the release PR.
 - [`code.json`](../code.json) mirrors it for federal source-code inventory.
 - `EmmyVersion.current` reads `version.txt` at runtime.
-- `GET /health` reports it as `release_version`, so states can check which
-  version an environment is running. (The `version` field in that response is
-  the deployed image tag, not the semantic version.)
+- `GET /health` reports it as `version`, so states can check which version an
+  environment is running. (The `ref` field in that response is the deployed
+  image tag.)
 
 ## Scope of this version line
 


### PR DESCRIPTION
## Changes
<!-- What was added, updated, or removed in this PR. -->
Fixed the stale health check test, deployment tooling, and docs related to semantic versioning. `/health` already returns the deployed image tag as `ref` and the semantic version as `version`. `will-deploy` and the runbooks now use `ref` for the image tag too.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
Follow-up on PR for [semantic versioning](https://github.com/DSACMS/iv-cbv-payroll/pull/1941)

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.