### PR TITLE
FFS-4675: Enable CMS dev/test deployments

### DIFF
--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -5,6 +5,9 @@ inputs:
   environment:
     description: CMS deployment environment.
     required: true
+  nonprod-role-to-assume:
+    description: Deploy role for dev and test.
+    required: true
   default-role-to-assume:
     description: Deploy role for sandbox, demo, UAT, and production.
     required: true
@@ -20,11 +23,12 @@ runs:
       shell: bash
       env:
         ENVIRONMENT: ${{ inputs.environment }}
+        NONPROD_ROLE_TO_ASSUME: ${{ inputs.nonprod-role-to-assume }}
         DEFAULT_ROLE_TO_ASSUME: ${{ inputs.default-role-to-assume }}
       run: |
         case "${ENVIRONMENT}" in
           dev|test)
-            role_to_assume="arn:aws:iam::554269192106:role/GitHubActionsIvCbvPayrollDeploy"
+            role_to_assume="${NONPROD_ROLE_TO_ASSUME}"
             ;;
           sandbox|demo|uat|prod)
             role_to_assume="${DEFAULT_ROLE_TO_ASSUME}"

--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -30,7 +30,7 @@ runs:
             role_to_assume="${DEFAULT_ROLE_TO_ASSUME}"
             ;;
           *)
-            echo "Unsupported CMS Cloud environment: ${ENVIRONMENT}" >&2
+            echo "Unsupported CMS Cloud environment: ${ENVIRONMENT}. Supported environments: dev, test, sandbox, demo, uat, prod." >&2
             exit 1
             ;;
         esac

--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -1,0 +1,45 @@
+name: Configure CMS AWS credentials
+description: Configure credentials for the CMS account that owns the deployment environment.
+
+inputs:
+  environment:
+    description: CMS deployment environment.
+    required: true
+  default-role-to-assume:
+    description: Deploy role for sandbox, demo, UAT, and production.
+    required: true
+  aws-region:
+    description: AWS region for the deployment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: target_role
+      name: Select target role
+      shell: bash
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        DEFAULT_ROLE_TO_ASSUME: ${{ inputs.default-role-to-assume }}
+      run: |
+        case "${ENVIRONMENT}" in
+          dev|test)
+            role_to_assume="arn:aws:iam::554269192106:role/GitHubActionsIvCbvPayrollDeploy"
+            ;;
+          sandbox|demo|uat|prod)
+            role_to_assume="${DEFAULT_ROLE_TO_ASSUME}"
+            ;;
+          *)
+            echo "Unsupported CMS Cloud environment: ${ENVIRONMENT}" >&2
+            exit 1
+            ;;
+        esac
+
+        echo "Using deploy role: ${role_to_assume}"
+        echo "role_to_assume=${role_to_assume}" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ steps.target_role.outputs.role_to_assume }}

--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -5,15 +5,6 @@ inputs:
   environment:
     description: CMS deployment environment.
     required: true
-  nonprod-role-to-assume:
-    description: Deploy role for dev and test.
-    required: true
-  default-role-to-assume:
-    description: Deploy role for sandbox, demo, UAT, and production.
-    required: true
-  aws-region:
-    description: AWS region for the deployment.
-    required: true
 
 runs:
   using: composite
@@ -23,8 +14,8 @@ runs:
       shell: bash
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        NONPROD_ROLE_TO_ASSUME: ${{ inputs.nonprod-role-to-assume }}
-        DEFAULT_ROLE_TO_ASSUME: ${{ inputs.default-role-to-assume }}
+        NONPROD_ROLE_TO_ASSUME: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
+        DEFAULT_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
       run: |
         case "${ENVIRONMENT}" in
           dev|test)
@@ -45,6 +36,6 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        aws-region: ${{ inputs.aws-region }}
+        aws-region: us-east-1
         role-to-assume: ${{ steps.target_role.outputs.role_to_assume }}
         role-session-name: gha-${{ inputs.environment }}-${{ github.run_id }}

--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -5,6 +5,12 @@ inputs:
   environment:
     description: CMS deployment environment.
     required: true
+  nonprod-role-to-assume:
+    description: Deploy role for dev and test.
+    required: true
+  default-role-to-assume:
+    description: Deploy role for sandbox, demo, UAT, and production.
+    required: true
 
 runs:
   using: composite
@@ -14,8 +20,8 @@ runs:
       shell: bash
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        NONPROD_ROLE_TO_ASSUME: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
-        DEFAULT_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
+        NONPROD_ROLE_TO_ASSUME: ${{ inputs.nonprod-role-to-assume }}
+        DEFAULT_ROLE_TO_ASSUME: ${{ inputs.default-role-to-assume }}
       run: |
         case "${ENVIRONMENT}" in
           dev|test)

--- a/.github/actions/configure-cms-aws-credentials/action.yml
+++ b/.github/actions/configure-cms-aws-credentials/action.yml
@@ -47,3 +47,4 @@ runs:
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ steps.target_role.outputs.role_to_assume }}
+        role-session-name: gha-${{ inputs.environment }}-${{ github.run_id }}

--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -51,6 +51,8 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
+          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
+          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
       - name: Verify image is published to ECR
         run: |

--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -42,7 +42,6 @@ jobs:
       id-token: write
     env:
       EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
-      AWS_REGION: us-east-1
       CLUSTER_NAME: emmy-${{ inputs.environment }}
 
     steps:
@@ -52,9 +51,6 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
-          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
-          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Verify image is published to ECR
         run: |

--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -52,6 +52,7 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
+          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
           default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -49,10 +49,11 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/configure-cms-aws-credentials
         with:
+          environment: ${{ inputs.environment }}
+          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
       - name: Verify image is published to ECR
         run: |

--- a/.github/workflows/database-migrations-cms.yml
+++ b/.github/workflows/database-migrations-cms.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       environment:
-        description: "the name of the application environment (e.g. dev, staging, prod)"
+        description: "the name of the application environment (e.g. dev, test, sandbox, demo, uat, prod)"
         required: true
         type: string
       image_tag:
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       environment:
-        description: "the name of the application environment (e.g. dev, staging, prod)"
+        description: "the name of the application environment (e.g. dev, test, sandbox, demo, uat, prod)"
         required: true
         type: string
       image_tag:

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -25,7 +25,14 @@ on:
       environment:
         description: "the name of the application environment (e.g. uat)"
         required: true
-        type: string
+        type: choice
+        options:
+          - dev
+          - test
+          - sandbox
+          - demo
+          - uat
+          - prod
       ref:
         description: "the branch, tag, or SHA to deploy"
         required: true

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -40,7 +40,6 @@ jobs:
       id-token: write
     env:
       EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
-      AWS_REGION: us-east-1
       CLUSTER_NAME: emmy-${{ inputs.environment }}
       APP_TASK_FAMILY: emmy-${{ inputs.environment }}
 
@@ -51,9 +50,6 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
-          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
-          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Verify image is published to ECR
         run: |

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -51,6 +51,7 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
+          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
           default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -50,6 +50,8 @@ jobs:
         uses: ./.github/actions/configure-cms-aws-credentials
         with:
           environment: ${{ inputs.environment }}
+          nonprod-role-to-assume: ${{ vars.AWS_NONPROD_ROLE_TO_ASSUME }}
+          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
       - name: Verify image is published to ECR
         run: |

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       environment:
-        description: "the name of the application environment (e.g. dev, staging, prod)"
+        description: "the name of the application environment (e.g. dev, test, sandbox, demo, uat, prod)"
         required: true
         type: string
       image_tag:
@@ -23,7 +23,7 @@ on:
         required: true
         type: string
       environment:
-        description: "the name of the application environment (e.g. dev, staging, prod)"
+        description: "the name of the application environment (e.g. dev, test, sandbox, demo, uat, prod)"
         required: true
         type: string
       image_tag:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -48,10 +48,11 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/configure-cms-aws-credentials
         with:
+          environment: ${{ inputs.environment }}
+          default-role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', vars.AWS_ACCOUNT_ID, vars.AWS_ROLE_NAME) }}
 
       - name: Verify image is published to ECR
         run: |


### PR DESCRIPTION
## [FFS-4675](https://jiraent.cms.gov/browse/FFS-4675)

## Changes

- Use the nonprod deploy role for CMS `dev` and `test`
- Leave `sandbox`, `demo`, `uat`, and `prod` on the existing role
- Make the CMS deploy environment a dropdown instead of free text

## Context for reviewers
Dev deployments were using prod credentials and failed trying to find dev ECS resources.

The companion ECR permission change in `emmy-infra` needs to land before we test this in dev.

### Testing Plan

1. Apply the ECR permission change
2. Deploy this branch to CMS dev
3. Confirm migrations and services finish successfully

[Successful test run
](https://github.com/DSACMS/iv-cbv-payroll/actions/runs/31522996649)

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.