### PR TITLE
Update bin/will-deploy to follow semantic version release process

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -36,17 +36,57 @@ def run_command(*command)
   stdout.strip
 end
 
-def fetch_production_ref
+def fetch_production_version
   response = URI.open("https://snap-income-pilot.com/health", &:read)
   JSON.parse(response).fetch("version")
 end
 
-def next_minor_version
-  current_version = JSON.parse(File.read(CODE_JSON_PATH)).fetch("version")
+def current_version
+  current_version = File.read(VERSION_PATH).strip
   match = current_version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
-  raise "Invalid semantic version in code.json: #{current_version}" unless match
+  raise "Invalid semantic version in version.txt: #{current_version}" unless match
 
-  "#{match[1]}.#{match[2].to_i + 1}.0"
+  current_version
+end
+
+def next_version(current_version, bump)
+  match = current_version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
+  raise "Invalid semantic version: #{current_version}" unless match
+
+  major, minor, patch = match.captures.map(&:to_i)
+
+  case bump
+  when "major"
+    "#{major + 1}.0.0"
+  when "minor"
+    "#{major}.#{minor + 1}.0"
+  when "patch"
+    "#{major}.#{minor}.#{patch + 1}"
+  else
+    raise "Invalid version bump: #{bump}"
+  end
+end
+
+def default_version_bump(current_version, user_facing_changes)
+  if user_facing_changes.any? && !current_version.start_with?("0.")
+    "major"
+  else
+    "minor"
+  end
+end
+
+def prompt_for_version_bump(current_version, user_facing_changes)
+  default_bump = default_version_bump(current_version, user_facing_changes)
+
+  loop do
+    warn "Which version bump? (Major, Minor, Patch) [#{default_bump.capitalize}]: "
+    bump = $stdin.gets&.strip&.downcase
+
+    return default_bump if bump.nil? || bump.empty?
+    return bump if %w[major minor patch].include?(bump)
+
+    warn "Invalid option. Please enter Major, Minor, or Patch."
+  end
 end
 
 def append_changelog_section(output, heading, changes, empty_message: nil)
@@ -93,7 +133,7 @@ def commit_lines(prod, current_sha)
   run_command(
     "git", "log", "--no-decorate",
     '--pretty=format:%s - %an|%H',
-    "#{prod}..#{current_sha}"
+    "v#{prod}..#{current_sha}"
   ).lines(chomp: true)
 end
 
@@ -156,7 +196,7 @@ if ARGV.first == "--test"
 end
 
 run_command("git", "fetch", "--quiet")
-prod = fetch_production_ref
+prod = fetch_production_version
 current_sha = run_command("git", "rev-parse", "origin/main")
 commits = commit_lines(prod, current_sha)
 
@@ -215,9 +255,14 @@ end
 other_changes.unshift("Bump #{dependabot_bumps.join(', ')}") unless dependabot_bumps.empty?
 
 tags = tags_for_changes(both_changes, income_changes, ce_changes)
+version_bump = prompt_for_version_bump(
+  current_version,
+  both_changes + income_changes + ce_changes
+)
+release_version = next_version(current_version, version_bump)
 
 output = +""
-output << "🚀 Will deploy `#{current_sha[0, 7]}` to production: 🚀 (cc #{tags})\n"
+output << "🚀 Will deploy `#{release_version}` to production: 🚀 (cc #{tags})\n"
 output << "🧪 *Open the launcher →* https://verify-demo.navapbc.cloud/launcher\n\n"
 append_changes(output, "👥 *User facing changes to Emmy Income + Emmy CE*", both_changes)
 append_changes(
@@ -236,9 +281,8 @@ append_changes(output, "⚙️ *Other/Maintenance (Not user facing)*", other_cha
 output << "\n"
 output << "See the full diff: https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}\n"
 
-next_version = next_minor_version
 update_release_files(
-  next_version,
+  release_version,
   both_changes: both_changes,
   income_changes: income_changes,
   ce_changes: ce_changes,

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -12,7 +12,12 @@ require "json"
 require "open-uri"
 require "open3"
 
-NO_CHANGES_PLACEHOLDER = "  • No changes, nothing to review!"
+NO_CHANGES_PLACEHOLDER = "- No changes, nothing to review!"
+APP_ROOT = File.expand_path("..", __dir__)
+REPOSITORY_ROOT = File.expand_path("..", APP_ROOT)
+CHANGELOG_PATH = File.join(REPOSITORY_ROOT, "CHANGELOG.md")
+CODE_JSON_PATH = File.join(REPOSITORY_ROOT, "code.json")
+VERSION_PATH = File.join(APP_ROOT, "version.txt")
 
 def linkify_jira(text)
   linked_text = text.gsub(/\(#(\d+)\)/) do
@@ -33,7 +38,55 @@ end
 
 def fetch_production_ref
   response = URI.open("https://snap-income-pilot.com/health", &:read)
-  JSON.parse(response).fetch("ref")
+  JSON.parse(response).fetch("version")
+end
+
+def next_minor_version
+  current_version = JSON.parse(File.read(CODE_JSON_PATH)).fetch("version")
+  match = current_version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
+  raise "Invalid semantic version in code.json: #{current_version}" unless match
+
+  "#{match[1]}.#{match[2].to_i + 1}.0"
+end
+
+def append_changelog_section(output, heading, changes, empty_message: nil)
+  original_length = output.length
+  append_changes(output, "### #{heading}", changes, empty_message: empty_message)
+  output << "\n" if output.length > original_length
+end
+
+def update_release_files(version, both_changes:, income_changes:, ce_changes:, other_changes:)
+  changelog = File.read(CHANGELOG_PATH)
+  first_release_heading = changelog.index(/^## /)
+  raise "Could not find a release heading in CHANGELOG.md" unless first_release_heading
+
+  changelog_entry = +"## #{version}\n\n"
+  append_changelog_section(
+    changelog_entry,
+    "User facing changes to Emmy Income + Emmy CE",
+    both_changes
+  )
+  append_changelog_section(
+    changelog_entry,
+    "Emmy Income only user facing changes",
+    income_changes,
+    empty_message: NO_CHANGES_PLACEHOLDER
+  )
+  append_changelog_section(
+    changelog_entry,
+    "Emmy CE only user facing changes",
+    ce_changes,
+    empty_message: NO_CHANGES_PLACEHOLDER
+  )
+  append_changelog_section(changelog_entry, "Other/Maintenance (Not user facing)", other_changes)
+  File.write(CHANGELOG_PATH, changelog.insert(first_release_heading, changelog_entry))
+
+  code_json = File.read(CODE_JSON_PATH)
+  updated_code_json = code_json.sub(/("version"\s*:\s*)"[^"]*"/) { "#{Regexp.last_match(1)}\"#{version}\"" }
+  raise "Could not find version in code.json" if updated_code_json == code_json
+
+  File.write(CODE_JSON_PATH, updated_code_json)
+  File.write(VERSION_PATH, "#{version}\n")
 end
 
 def commit_lines(prod, current_sha)
@@ -84,7 +137,7 @@ def append_changes(output, heading, changes, empty_message: nil)
     output << "#{empty_message}\n"
   else
     changes.each do |change|
-      output << "  • #{linkify_jira(change)}\n"
+      output << "- #{linkify_jira(change)}\n"
     end
   end
   output
@@ -105,6 +158,7 @@ end
 run_command("git", "fetch", "--quiet")
 prod = fetch_production_ref
 current_sha = run_command("git", "rev-parse", "origin/main")
+commits = commit_lines(prod, current_sha)
 
 both_changes = []
 income_changes = []
@@ -116,7 +170,7 @@ warn "Categorizing changes for deployment..."
 warn "======================================"
 warn ""
 
-commit_lines(prod, current_sha).each do |commit_line|
+commits.each do |commit_line|
   commit, commit_hash = commit_line.split("|", 2)
 
   if (match = commit.match(/\(#(\d+)\)/))
@@ -180,7 +234,16 @@ append_changes(
 )
 append_changes(output, "⚙️ *Other/Maintenance (Not user facing)*", other_changes)
 output << "\n"
-output << "See the [full diff on Github](https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}).\n"
+output << "See the full diff: https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}\n"
+
+next_version = next_minor_version
+update_release_files(
+  next_version,
+  both_changes: both_changes,
+  income_changes: income_changes,
+  ce_changes: ce_changes,
+  other_changes: other_changes
+)
 
 puts output
 copy_to_clipboard(output)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,8 +17,8 @@ Then, in a PR merged to `main` before the deploy:
 
 1. Update [`app/version.txt`](../app/version.txt) to the new version.
 2. Update the `"version"` field in [`code.json`](../code.json) to match.
-3. Add a [`CHANGELOG.md`](../CHANGELOG.md) entry with the tier of each
-   user-facing change.
+3. Annotate in [`CHANGELOG.md`](../CHANGELOG.md) breaking changes, if any,
+   which necessitated the major version bump.
 
 ## 2. Generate the release notes
 


### PR DESCRIPTION
## No ticket: side task for a deploy

## Changes
<!-- What was added, updated, or removed in this PR. -->

Automatically generate a minor semantic release version, prepend commit
notes to the changelog, and synchronize code.json and version.txt during
deploy preparation.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
