### PR TITLE
Fix Solid Queue CMS deploy config

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -42,6 +42,7 @@ jobs:
       EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
       CLUSTER_NAME: emmy-${{ inputs.environment }}
       APP_TASK_FAMILY: emmy-${{ inputs.environment }}
+      SOLID_QUEUE_TASK_FAMILY: emmy-${{ inputs.environment }}-solid-queue
 
     steps:
       - uses: actions/checkout@v7
@@ -88,15 +89,11 @@ jobs:
           cluster: ${{ env.CLUSTER_NAME }}
           wait-for-service-stability: true
 
-      - name: Download solid-queue task definition
+      - name: Download latest solid-queue task definition
         run: |
-          task_def_arn=$(aws ecs describe-services \
-            --cluster "${CLUSTER_NAME}" \
-            --services "emmy-${{ inputs.environment }}-solid-queue" \
-            --query 'services[0].taskDefinition' --output text)
-          echo "Current solid-queue task definition: ${task_def_arn}"
+          echo "Downloading latest solid-queue task definition from family ${SOLID_QUEUE_TASK_FAMILY}"
           aws ecs describe-task-definition \
-            --task-definition "${task_def_arn}" \
+            --task-definition "${SOLID_QUEUE_TASK_FAMILY}" \
             --query taskDefinition --output json > solid-queue-task-definition.json
 
       - name: Render solid-queue task definition


### PR DESCRIPTION
## Changes
Update Solid Queue to use latest task definition.

## Context for reviewers
Because Solid Queue wasn't using the latest task definition, new Terraform environment variables were getting dropped during the deployment. We now have symmetry with how the app handles this.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.