### PR TITLE
FFS-4555: Send activity documents over HTTP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,13 @@ To acceptance test the JSON API, you can run the independent **reference server 
    LA_LDH_INCOME_REPORT_APIKEY=foo
    LA_LDH_INCLUDE_REPORT_PDF=false
    LA_LDH_INCOME_REPORT_ACCOUNTCODE=foobar
+
+   # For activity supporting documents
+   SANDBOX_ACTIVITY_FLOW_TRANSMISSION_METHOD=http
+   SANDBOX_ACTIVITY_DOCUMENTS_API_URL=http://localhost:4567/documents
    ```
 
-This starts a standalone test server on port 4567 that logs incoming JSON data and verifies HMAC signatures. The receiver is completely independent and can be used as a reference implementation for agencies building their own JSON API endpoints.
+This starts a standalone test server on port 4567 that logs incoming JSON data, verifies HMAC signatures, and writes activity documents to `app/tmp/transmitted_documents`. The receiver is completely independent and can be used as a reference implementation for agencies building their own JSON API endpoints.
 
 ### Branching model
 When beginning work on a feature, create a new branch based off of `main` and make the commits for that feature there.
@@ -250,12 +254,12 @@ authorship metadata will be preserved.
 <!--
 ## Shipping Releases
 
-<!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? 
+<!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so?
 -->
 
 ## Documentation
 
-Place new documentation in the [/docs](docs/) repository 
+Place new documentation in the [/docs](docs/) repository
 
 
 # Security

--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -65,6 +65,11 @@ NSC_ACCOUNT_ID_SANDBOX=
 # LA_LDH_INCOME_REPORT_ACCOUNTCODE=
 # LA_LDH_CASEWORKER_FALLBACK_EMAIL=
 
+# (Optional) Set these to test activity document HTTP transmission against
+# `ruby lib/json_api_receiver.rb`.
+# SANDBOX_ACTIVITY_FLOW_TRANSMISSION_METHOD=http
+# SANDBOX_ACTIVITY_DOCUMENTS_API_URL=http://localhost:4567/documents
+
 # (Optional/Deprecated) Set these from 1Password if you need to log into the caseworker portal:
 # AZURE_SANDBOX_CLIENT_ID=
 # AZURE_SANDBOX_CLIENT_SECRET=

--- a/app/app/jobs/activity_flow_transmitter_job.rb
+++ b/app/app/jobs/activity_flow_transmitter_job.rb
@@ -32,6 +32,8 @@ class ActivityFlowTransmitterJob < ApplicationJob
     case transmission_method
     when Transmitters::ActivityS3Transmitter::TRANSMISSION_METHOD
       Transmitters::ActivityS3Transmitter
+    when Transmitters::HttpDocumentTransmitter::TRANSMISSION_METHOD
+      Transmitters::HttpDocumentTransmitter
     else
       raise "Unsupported activity flow transmission method: #{transmission_method}"
     end

--- a/app/app/services/activity_documents_service.rb
+++ b/app/app/services/activity_documents_service.rb
@@ -1,0 +1,49 @@
+require "rack/mime"
+
+class ActivityDocumentsService
+  ACTIVITY_ASSOCIATIONS = %i[
+    volunteering_activities
+    job_training_activities
+    education_activities
+    employment_activities
+  ].freeze
+
+  Document = Struct.new(:attachment, :file_name)
+
+  def initialize(activity_flow)
+    @activity_flow = activity_flow
+  end
+
+  def all
+    page_numbers = Hash.new(0)
+
+    ACTIVITY_ASSOCIATIONS.flat_map do |association|
+      @activity_flow.public_send(association).published.order(:id).flat_map do |activity|
+        activity.document_uploads_attachments.includes(:blob).order(:id).map do |attachment|
+          activity_type = activity.class.activity_type
+          document_name, extension = document_name_and_extension(attachment)
+          page_number_key = [ activity_type, document_name ]
+          page_number = page_numbers[page_number_key] += 1
+
+          Document.new(
+            attachment,
+            [ @activity_flow.confirmation_code, activity_type, document_name, page_number ].join("_") + extension
+          )
+        end
+      end
+    end
+  end
+
+  private
+
+  def document_name_and_extension(attachment)
+    file_name = attachment.filename.to_s
+    original_extension = File.extname(file_name)
+    extension = original_extension.downcase
+    extension = Rack::Mime::MIME_TYPES.key(attachment.blob.content_type) || ".bin" if extension.blank?
+
+    document_name = File.basename(file_name, original_extension).parameterize(separator: "_")
+    document_name = "document" if document_name.blank?
+    [ document_name, extension ]
+  end
+end

--- a/app/app/services/processed_download_service.rb
+++ b/app/app/services/processed_download_service.rb
@@ -1,0 +1,11 @@
+class ProcessedDownloadService
+  SERVICE_NAME = ENV["PROCESSED_BUCKET_NAME"].present? ? :processed : :processed_local
+
+  def initialize(service: ActiveStorage::Blob.services.fetch(SERVICE_NAME))
+    @service = service
+  end
+
+  def download_file(key, destination)
+    File.binwrite(destination, @service.download(key))
+  end
+end

--- a/app/app/services/transmitters/activity_s3_transmitter.rb
+++ b/app/app/services/transmitters/activity_s3_transmitter.rb
@@ -7,7 +7,7 @@ class Transmitters::ActivityS3Transmitter
   def initialize(activity_flow, current_agency)
     @activity_flow = activity_flow
     @transmission_config = current_agency.transmission_method_configuration
-    @processed_s3_service = S3Service.new("bucket" => ENV.fetch("PROCESSED_BUCKET_NAME"))
+    @processed_s3_service = ProcessedDownloadService.new
     @destination_s3_service = S3Service.new("bucket" => @transmission_config.fetch("bucket"))
   end
 

--- a/app/app/services/transmitters/activity_s3_transmitter.rb
+++ b/app/app/services/transmitters/activity_s3_transmitter.rb
@@ -1,17 +1,8 @@
 require "tmpdir"
-require "rack/mime"
 
 class Transmitters::ActivityS3Transmitter
   TRANSMISSION_METHOD = "encrypted_s3"
-  ACTIVITY_ASSOCIATIONS = %i[
-    volunteering_activities
-    job_training_activities
-    education_activities
-    employment_activities
-  ].freeze
   PDF_MARGIN = { top: 10, bottom: 10, left: 10, right: 10 }.freeze
-
-  Document = Struct.new(:attachment, :file_name)
 
   def initialize(activity_flow, current_agency)
     @activity_flow = activity_flow
@@ -45,39 +36,7 @@ class Transmitters::ActivityS3Transmitter
   private
 
   def supporting_documents
-    page_numbers = Hash.new(0)
-
-    ACTIVITY_ASSOCIATIONS.flat_map do |association|
-      @activity_flow.public_send(association).published.order(:id).flat_map do |activity|
-        activity.document_uploads_attachments.includes(:blob).order(:id).map do |attachment|
-          activity_type = activity.class.activity_type
-          document_name, extension = document_name_and_extension(attachment)
-          page_number_key = [ activity_type, document_name ]
-          page_number = page_numbers[page_number_key] += 1
-
-          Document.new(
-            attachment,
-            [
-              @activity_flow.confirmation_code,
-              activity_type,
-              document_name,
-              page_number
-            ].join("_") + extension
-          )
-        end
-      end
-    end
-  end
-
-  def document_name_and_extension(attachment)
-    file_name = attachment.filename.to_s
-    original_extension = File.extname(file_name)
-    extension = original_extension.downcase
-    extension = Rack::Mime::MIME_TYPES.key(attachment.blob.content_type) || ".bin" if extension.blank?
-
-    document_name = File.basename(file_name, original_extension).parameterize(separator: "_")
-    document_name = "document" if document_name.blank?
-    [ document_name, extension ]
+    ActivityDocumentsService.new(@activity_flow).all
   end
 
   def report_file_name

--- a/app/app/services/transmitters/http_document_transmitter.rb
+++ b/app/app/services/transmitters/http_document_transmitter.rb
@@ -1,0 +1,111 @@
+require "tmpdir"
+
+class Transmitters::HttpDocumentTransmitter
+  TRANSMISSION_METHOD = "http"
+
+  def initialize(activity_flow, current_agency)
+    @activity_flow = activity_flow
+    @current_agency = current_agency
+    @processed_s3_service = S3Service.new("bucket" => ENV.fetch("PROCESSED_BUCKET_NAME"))
+  end
+
+  def deliver
+    documents = ActivityDocumentsService.new(@activity_flow).all
+
+    Dir.mktmpdir("activity-flow-http-transmission-") do |directory|
+      documents.each do |document|
+        file_path = File.join(directory, document.file_name)
+        @processed_s3_service.download_file(document.attachment.blob.key, file_path)
+        deliver_document(document, File.binread(file_path))
+      end
+    end
+
+    Rails.logger.info(
+      "Activity flow HTTP transmission flow_id=#{@activity_flow.id} " \
+      "confirmation_code=#{@activity_flow.confirmation_code} " \
+      "document_count=#{documents.size}"
+    )
+  end
+
+  private
+
+  def deliver_document(document, content)
+    url = destination_url!
+    request = Net::HTTP::Post.new(url)
+    request.content_type = document.attachment.blob.content_type.presence || "application/octet-stream"
+    request.content_length = content.bytesize
+    request.body = content
+    request["Content-Disposition"] = %(attachment; filename="#{document.file_name}")
+    request["X-IVAAS-Timestamp"] = timestamp
+    request["X-IVAAS-Signature"] = signature(content)
+    request["X-IVAAS-Confirmation-Code"] = @activity_flow.confirmation_code
+
+    custom_headers.each { |header_name, header_value| request[header_name] = header_value }
+
+    Rails.logger.info "Sending activity document transmission to #{url}: filename=#{document.file_name}"
+    request_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    response = Net::HTTP.start(url.hostname, url.port, use_ssl: url.scheme == "https") do |http|
+      http.request(request)
+    end
+    request_duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_started_at
+    Rails.logger.info(
+      "Activity document transmission response from #{url}: status=#{response.code} " \
+      "duration=#{format("%.3f", request_duration)}s filename=#{document.file_name}"
+    )
+
+    return if response.is_a?(Net::HTTPSuccess)
+
+    raise_response_error!(response)
+  end
+
+  def destination_url!
+    url = @current_agency.transmission_method_configuration["documents_api_url"]
+    unless url.present?
+      raise ArgumentError, "Invalid documents_api_url #{url.inspect}: must be an absolute HTTP(S) URL"
+    end
+
+    uri = URI.parse(url)
+    return uri if uri.is_a?(URI::HTTP) && uri.host.present?
+
+    raise ArgumentError, "Invalid documents_api_url #{url.inspect}: must be an absolute HTTP(S) URL"
+  rescue URI::InvalidURIError
+    raise ArgumentError, "Invalid documents_api_url #{url.inspect}: must be an absolute HTTP(S) URL"
+  end
+
+  def custom_headers
+    @current_agency.transmission_method_configuration["custom_headers"] || {}
+  end
+
+  def timestamp
+    @timestamp ||= Time.now.to_i
+  end
+
+  def signature(content)
+    JsonApiSignature.generate(content, timestamp, api_key_for_agency!)
+  end
+
+  def api_key_for_agency!
+    @api_key ||= User.api_key_for_agency(@current_agency.id)
+    return @api_key if @api_key
+
+    Rails.logger.error "No active API key found for agency #{@current_agency.id}"
+    raise "No active API key found for agency #{@current_agency.id}"
+  end
+
+  def raise_response_error!(response)
+    message = "Unexpected response from agency: code=#{response.code} message=#{response.message}"
+    Rails.logger.error message
+    Rails.logger.error "Error response body: #{response.body}"
+
+    error_class = silently_retry_error_codes.include?(response.code.to_s) ?
+      ApplicationJob::SilencedError :
+      HttpDocumentTransmitterError
+    raise error_class, message
+  end
+
+  def silently_retry_error_codes
+    Array(@current_agency.transmission_method_configuration["silently_retry_error_codes"]).map(&:to_s)
+  end
+
+  class HttpDocumentTransmitterError < StandardError; end
+end

--- a/app/app/services/transmitters/http_document_transmitter.rb
+++ b/app/app/services/transmitters/http_document_transmitter.rb
@@ -6,7 +6,7 @@ class Transmitters::HttpDocumentTransmitter
   def initialize(activity_flow, current_agency)
     @activity_flow = activity_flow
     @current_agency = current_agency
-    @processed_s3_service = S3Service.new("bucket" => ENV.fetch("PROCESSED_BUCKET_NAME"))
+    @processed_s3_service = ProcessedDownloadService.new
   end
 
   def deliver

--- a/app/config/client-agency-config.yml
+++ b/app/config/client-agency-config.yml
@@ -112,11 +112,12 @@
   argyle:
     environment: <%= ENV["SANDBOX_ARGYLE_ENVIRONMENT"] %>
   income_flow_transmission_method: shared_email
-  activity_flow_transmission_method: encrypted_s3
+  activity_flow_transmission_method: <%= ENV.fetch("SANDBOX_ACTIVITY_FLOW_TRANSMISSION_METHOD", "encrypted_s3") %>
   transmission_method_configuration:
     email: <%= ENV['SLACK_TEST_EMAIL'] %>
     bucket: <%= ENV["OUTBOUND_TRANSMISSION_S3_BUCKET_NAME"] %>
     s3_directory: <%= ENV.fetch("OUTBOUND_TRANSMISSION_S3_DIRECTORY", "outfiles") %>
+    documents_api_url: <%= ENV["SANDBOX_ACTIVITY_DOCUMENTS_API_URL"] %>
   staff_portal_enabled: true
   pilot_ended: false
   sso:

--- a/app/config/storage.yml
+++ b/app/config/storage.yml
@@ -14,10 +14,17 @@ unscanned:
   service: S3
   bucket: <%= ENV["UNSCANNED_BUCKET_NAME"] %>
 
+processed:
+  service: S3
+  bucket: <%= ENV["PROCESSED_BUCKET_NAME"] %>
+
+# Use these _local ones for dev/testing only.
+# They don't actually scan for viruses.
 unscanned_local:
   service: Disk
   root: <%= Rails.root.join("tmp/storage_unscanned") %>
 
-processed:
-  service: S3
-  bucket: <%= ENV["PROCESSED_BUCKET_NAME"] %>
+processed_local:
+  service: Disk
+  # Local uploads are not virus-scanned, so use the same storage as unscanned_local.
+  root: <%= Rails.root.join("tmp/storage_unscanned") %>

--- a/app/lib/json_api_receiver.rb
+++ b/app/lib/json_api_receiver.rb
@@ -6,6 +6,7 @@
 #
 
 require "sinatra"
+require "fileutils"
 require "json"
 require "openssl"
 
@@ -26,11 +27,32 @@ class JsonApiSignature
 end
 
 class JsonApiReceiver < Sinatra::Base
+  post "/documents" do
+    content = request.body.read
+    unless valid_signature?(content)
+      puts "❌ Invalid signature"
+      halt 401, { error: "Unauthorized" }.to_json
+    end
+
+    filename = File.basename(request.env.fetch("HTTP_CONTENT_DISPOSITION", "")[/filename="([^"]+)"/, 1].to_s)
+    halt 400, { error: "Missing document filename" }.to_json if filename.empty?
+
+    directory = File.expand_path("../tmp/transmitted_documents", __dir__)
+    FileUtils.mkdir_p(directory)
+    file_path = File.join(directory, filename)
+    File.binwrite(file_path, content)
+    puts "Document written successfully to #{file_path}"
+    status 200
+  rescue => e
+    puts "Error writing document: #{e.message}"
+    status 500
+  end
+
   post "/pdf" do
     pdf_content = request.body.read
 
     begin
-      file_path = File.expand_path("../app/tmp/transmitted_pdf.pdf")
+      file_path = File.expand_path("../tmp/transmitted_pdf.pdf", __dir__)
       File.open(file_path, "wb") do |file|
         file.write(pdf_content)
       end
@@ -58,9 +80,7 @@ class JsonApiReceiver < Sinatra::Base
     end
 
     if signature && timestamp
-      api_key = ENV.fetch("JSON_API_KEY", "your-api-key-here")
-
-      unless JsonApiSignature.verify(body, timestamp, signature, api_key)
+      unless valid_signature?(body)
         puts "❌ Invalid signature"
         status 401
         return { error: "Unauthorized" }.to_json
@@ -77,6 +97,14 @@ class JsonApiReceiver < Sinatra::Base
       status 400
       { error: "Invalid JSON" }.to_json
     end
+  end
+
+  def valid_signature?(body)
+    signature = request.env["HTTP_X_IVAAS_SIGNATURE"]
+    timestamp = request.env["HTTP_X_IVAAS_TIMESTAMP"]
+    return false unless signature && timestamp
+
+    JsonApiSignature.verify(body, timestamp, signature, ENV.fetch("JSON_API_KEY", "your-api-key-here"))
   end
 
   run! if __FILE__ == $0

--- a/app/spec/jobs/activity_flow_transmitter_job_spec.rb
+++ b/app/spec/jobs/activity_flow_transmitter_job_spec.rb
@@ -69,6 +69,35 @@ RSpec.describe ActivityFlowTransmitterJob, type: :job do
     end
   end
 
+  context "when the agency uses HTTP document transmission" do
+    let(:transmission_method) { Transmitters::HttpDocumentTransmitter::TRANSMISSION_METHOD }
+    let(:http_transmitter) { instance_double(Transmitters::HttpDocumentTransmitter) }
+
+    before do
+      allow(Transmitters::HttpDocumentTransmitter).to receive(:new)
+        .with(activity_flow, current_agency)
+        .and_return(http_transmitter)
+    end
+
+    it "marks the flow transmitted after document delivery succeeds" do
+      allow(http_transmitter).to receive(:deliver)
+
+      expect {
+        described_class.new.perform(activity_flow.id)
+      }.to change { activity_flow.reload.transmitted_at }.from(nil)
+    end
+
+    it "leaves the flow untransmitted when document delivery fails" do
+      allow(http_transmitter).to receive(:deliver).and_raise(StandardError, "delivery failed")
+
+      expect {
+        described_class.new.perform(activity_flow.id)
+      }.to raise_error(StandardError, "delivery failed")
+
+      expect(activity_flow.reload.transmitted_at).to be_nil
+    end
+  end
+
   describe "retry behavior" do
     let(:retry_test_time) { Time.zone.parse("2026-08-06 10:00:00") }
 

--- a/app/spec/services/processed_download_service_spec.rb
+++ b/app/spec/services/processed_download_service_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ProcessedDownloadService do
+  let(:service) { instance_double(ActiveStorage::Service) }
+  let(:destination) { Rails.root.join("tmp", "processed-download-service-spec") }
+
+  after { FileUtils.rm_f(destination) }
+
+  it "downloads the object from the configured Active Storage service" do
+    allow(service).to receive(:download).with("processed-key").and_return("cleared document")
+
+    described_class.new(service: service).download_file("processed-key", destination)
+
+    expect(File.binread(destination)).to eq("cleared document")
+  end
+
+  it "propagates a download failure without creating a destination file" do
+    allow(service).to receive(:download).with("missing-key").and_raise(ActiveStorage::FileNotFoundError)
+
+    expect {
+      described_class.new(service: service).download_file("missing-key", destination)
+    }.to raise_error(ActiveStorage::FileNotFoundError)
+    expect(destination).not_to exist
+  end
+end

--- a/app/spec/services/transmitters/activity_s3_transmitter_spec.rb
+++ b/app/spec/services/transmitters/activity_s3_transmitter_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
       confirmation_code: "SANDBOX123"
     )
   end
-  let(:processed_bucket_name) { "processed-bucket" }
   let(:destination_bucket_name) { "outbound-bucket" }
   let(:expected_destination_prefix) { "outfiles/SANDBOX123/" }
   let(:report_file_name) { "HR1_Report_2026-08-04.pdf" }
@@ -25,28 +24,21 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
       }
     )
   end
-  let(:processed_s3_service) { instance_double(S3Service) }
+  let(:processed_download_service) { instance_double(ProcessedDownloadService) }
   let(:destination_s3_service) { instance_double(S3Service) }
   let(:pdf_content) { "%PDF-1.4 report" }
   let(:transmitter) { described_class.new(activity_flow, current_agency) }
 
-  around do |example|
-    stub_environment_variable("PROCESSED_BUCKET_NAME", processed_bucket_name, &example)
-  end
-
   before do
-    allow(S3Service).to receive(:new)
-      .with({ "bucket" => processed_bucket_name })
-      .and_return(processed_s3_service)
+    allow(ProcessedDownloadService).to receive(:new).and_return(processed_download_service)
     allow(S3Service).to receive(:new)
       .with({ "bucket" => destination_bucket_name })
       .and_return(destination_s3_service)
     allow(transmitter).to receive(:pdf_content).and_return(pdf_content)
   end
 
-  it "uses the processed and agency destination buckets by default" do
-    expect(S3Service).to have_received(:new)
-      .with({ "bucket" => processed_bucket_name })
+  it "uses the processed download service and agency destination bucket by default" do
+    expect(ProcessedDownloadService).to have_received(:new)
     expect(S3Service).to have_received(:new)
       .with({ "bucket" => destination_bucket_name })
   end
@@ -61,7 +53,7 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
   end
 
   it "uploads only the report when the flow has no supporting documents" do
-    expect(processed_s3_service).not_to receive(:download_file)
+    expect(processed_download_service).not_to receive(:download_file)
     expect(destination_s3_service).to receive(:upload_directory).ordered do |directory, prefix|
       expect(prefix).to eq(expected_destination_prefix)
       expect(Dir.children(directory)).to contain_exactly(report_file_name)
@@ -97,7 +89,7 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
     attach_document(draft, "Draft Document.pdf")
 
     downloaded_keys = []
-    allow(processed_s3_service).to receive(:download_file) do |key, file_path|
+    allow(processed_download_service).to receive(:download_file) do |key, file_path|
       downloaded_keys << key
       File.binwrite(file_path, "cleared #{key}")
     end
@@ -128,7 +120,7 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
   it "does not begin the destination upload when a processed object is missing" do
     activity = create(:volunteering_activity, activity_flow: activity_flow)
     attach_document(activity, "Timesheet.pdf")
-    allow(processed_s3_service).to receive(:download_file).and_raise(StandardError, "missing processed object")
+    allow(processed_download_service).to receive(:download_file).and_raise(StandardError, "missing processed object")
 
     expect(destination_s3_service).not_to receive(:upload_directory)
 
@@ -142,7 +134,7 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
     unknown = attach_document(activity, "Other Document")
     unknown.blob.update!(content_type: "application/x-unknown")
 
-    allow(processed_s3_service).to receive(:download_file) do |_key, file_path|
+    allow(processed_download_service).to receive(:download_file) do |_key, file_path|
       File.binwrite(file_path, "cleared document")
     end
     expect(destination_s3_service).to receive(:upload_directory) do |directory, _prefix|

--- a/app/spec/services/transmitters/http_document_transmitter_spec.rb
+++ b/app/spec/services/transmitters/http_document_transmitter_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe Transmitters::HttpDocumentTransmitter do
+  let(:activity_flow) do
+    create(
+      :activity_flow,
+      volunteering_activities_count: 0,
+      job_training_activities_count: 0,
+      education_activities_count: 0,
+      employment_activities_count: 0,
+      confirmation_code: "SANDBOX123"
+    )
+  end
+  let(:processed_bucket_name) { "processed-bucket" }
+  let(:processed_s3_service) { instance_double(S3Service) }
+  let(:api_url) { "http://fake-state.api.gov/documents" }
+  let(:current_agency) do
+    instance_double(
+      ClientAgencyConfig::ClientAgency,
+      id: "sandbox",
+      transmission_method_configuration: { "documents_api_url" => api_url }
+    )
+  end
+  let(:transmitter) { described_class.new(activity_flow, current_agency) }
+
+  around do |example|
+    stub_environment_variable("PROCESSED_BUCKET_NAME", processed_bucket_name, &example)
+  end
+
+  before do
+    allow(S3Service).to receive(:new)
+      .with({ "bucket" => processed_bucket_name })
+      .and_return(processed_s3_service)
+    allow(User).to receive(:api_key_for_agency).with("sandbox").and_return("api-key")
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it "posts each cleared document with its normalized filename and content type" do
+    volunteering = create(:volunteering_activity, activity_flow: activity_flow)
+    pdf = attach_document(volunteering, "Time Sheet.PDF", "application/pdf")
+    image = attach_document(volunteering, "Time Sheet.jpg", "image/jpeg")
+    files = { pdf.blob.key => "pdf content", image.blob.key => "image content" }
+    allow(processed_s3_service).to receive(:download_file) do |key, path|
+      File.binwrite(path, files.fetch(key))
+    end
+
+    pdf_request = stub_request(:post, api_url).with(
+      body: "pdf content",
+      headers: {
+        "Content-Type" => "application/pdf",
+        "Content-Disposition" => 'attachment; filename="SANDBOX123_community_service_time_sheet_1.pdf"',
+        "X-IVAAS-Confirmation-Code" => "SANDBOX123"
+      }
+    )
+    image_request = stub_request(:post, api_url).with(
+      body: "image content",
+      headers: {
+        "Content-Type" => "image/jpeg",
+        "Content-Disposition" => 'attachment; filename="SANDBOX123_community_service_time_sheet_2.jpg"',
+        "X-IVAAS-Confirmation-Code" => "SANDBOX123"
+      }
+    )
+
+    transmitter.deliver
+
+    expect(pdf_request).to have_been_made.once
+    expect(image_request).to have_been_made.once
+  end
+
+  it "does not make HTTP requests when the flow has no supporting documents" do
+    expect(processed_s3_service).not_to receive(:download_file)
+    expect(Rails.logger).to receive(:info).with(include("document_count=0"))
+
+    transmitter.deliver
+  end
+
+  it "does not transmit later documents when downloading a document fails" do
+    activity = create(:volunteering_activity, activity_flow: activity_flow)
+    attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
+    allow(processed_s3_service).to receive(:download_file).and_raise(StandardError, "missing processed object")
+
+    expect { transmitter.deliver }.to raise_error(StandardError, "missing processed object")
+  end
+
+  it "raises a transmitter error when the agency rejects a document" do
+    activity = create(:volunteering_activity, activity_flow: activity_flow)
+    attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
+    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+    stub_request(:post, api_url).to_return(status: [ 500, "Internal Server Error" ])
+
+    expect { transmitter.deliver }
+      .to raise_error(described_class::HttpDocumentTransmitterError, /code=500 message=Internal Server Error/)
+  end
+
+  it "raises a silenceable error for configured response codes" do
+    activity = create(:volunteering_activity, activity_flow: activity_flow)
+    attach_document(activity, "Timesheet.pdf", "application/pdf")
+    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+    allow(current_agency).to receive(:transmission_method_configuration)
+      .and_return({ "documents_api_url" => api_url, "silently_retry_error_codes" => [ 403 ] })
+    stub_request(:post, api_url).to_return(status: [ 403, "Forbidden" ])
+
+    expect { transmitter.deliver }.to raise_error(ApplicationJob::SilencedError, /code=403 message=Forbidden/)
+  end
+
+  it "raises a helpful error when the configured document URL is malformed" do
+    allow(current_agency).to receive(:transmission_method_configuration)
+      .and_return({ "documents_api_url" => "not a url" })
+    activity = create(:volunteering_activity, activity_flow: activity_flow)
+    attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
+    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+
+    expect { transmitter.deliver }
+      .to raise_error(ArgumentError, 'Invalid documents_api_url "not a url": must be an absolute HTTP(S) URL')
+  end
+
+  def attach_document(activity, filename, content_type)
+    activity.document_uploads.attach(
+      io: StringIO.new("synthetic document"),
+      filename: filename,
+      content_type: content_type
+    )
+    activity.document_uploads_attachments.order(:id).last
+  end
+end

--- a/app/spec/services/transmitters/http_document_transmitter_spec.rb
+++ b/app/spec/services/transmitters/http_document_transmitter_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
       confirmation_code: "SANDBOX123"
     )
   end
-  let(:processed_bucket_name) { "processed-bucket" }
-  let(:processed_s3_service) { instance_double(S3Service) }
+  let(:processed_download_service) { instance_double(ProcessedDownloadService) }
   let(:api_url) { "http://fake-state.api.gov/documents" }
   let(:current_agency) do
     instance_double(
@@ -23,14 +22,8 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
   end
   let(:transmitter) { described_class.new(activity_flow, current_agency) }
 
-  around do |example|
-    stub_environment_variable("PROCESSED_BUCKET_NAME", processed_bucket_name, &example)
-  end
-
   before do
-    allow(S3Service).to receive(:new)
-      .with({ "bucket" => processed_bucket_name })
-      .and_return(processed_s3_service)
+    allow(ProcessedDownloadService).to receive(:new).and_return(processed_download_service)
     allow(User).to receive(:api_key_for_agency).with("sandbox").and_return("api-key")
     allow(Rails.logger).to receive(:info)
   end
@@ -40,7 +33,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
     pdf = attach_document(volunteering, "Time Sheet.PDF", "application/pdf")
     image = attach_document(volunteering, "Time Sheet.jpg", "image/jpeg")
     files = { pdf.blob.key => "pdf content", image.blob.key => "image content" }
-    allow(processed_s3_service).to receive(:download_file) do |key, path|
+    allow(processed_download_service).to receive(:download_file) do |key, path|
       File.binwrite(path, files.fetch(key))
     end
 
@@ -68,7 +61,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
   end
 
   it "does not make HTTP requests when the flow has no supporting documents" do
-    expect(processed_s3_service).not_to receive(:download_file)
+    expect(processed_download_service).not_to receive(:download_file)
     expect(Rails.logger).to receive(:info).with(include("document_count=0"))
 
     transmitter.deliver
@@ -77,7 +70,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
   it "does not transmit later documents when downloading a document fails" do
     activity = create(:volunteering_activity, activity_flow: activity_flow)
     attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
-    allow(processed_s3_service).to receive(:download_file).and_raise(StandardError, "missing processed object")
+    allow(processed_download_service).to receive(:download_file).and_raise(StandardError, "missing processed object")
 
     expect { transmitter.deliver }.to raise_error(StandardError, "missing processed object")
   end
@@ -85,7 +78,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
   it "raises a transmitter error when the agency rejects a document" do
     activity = create(:volunteering_activity, activity_flow: activity_flow)
     attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
-    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+    allow(processed_download_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
     stub_request(:post, api_url).to_return(status: [ 500, "Internal Server Error" ])
 
     expect { transmitter.deliver }
@@ -95,7 +88,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
   it "raises a silenceable error for configured response codes" do
     activity = create(:volunteering_activity, activity_flow: activity_flow)
     attach_document(activity, "Timesheet.pdf", "application/pdf")
-    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+    allow(processed_download_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
     allow(current_agency).to receive(:transmission_method_configuration)
       .and_return({ "documents_api_url" => api_url, "silently_retry_error_codes" => [ 403 ] })
     stub_request(:post, api_url).to_return(status: [ 403, "Forbidden" ])
@@ -108,7 +101,7 @@ RSpec.describe Transmitters::HttpDocumentTransmitter do
       .and_return({ "documents_api_url" => "not a url" })
     activity = create(:volunteering_activity, activity_flow: activity_flow)
     attachment = attach_document(activity, "Timesheet.pdf", "application/pdf")
-    allow(processed_s3_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
+    allow(processed_download_service).to receive(:download_file) { |_key, path| File.binwrite(path, "document content") }
 
     expect { transmitter.deliver }
       .to raise_error(ArgumentError, 'Invalid documents_api_url "not a url": must be an absolute HTTP(S) URL')

--- a/docs/local-replication.md
+++ b/docs/local-replication.md
@@ -6,7 +6,7 @@ you'll have the app serving at `http://localhost:3000` and be able to walk
 through the applicant and caseworker flows against sandbox data.
 
 > This is a practical quick-start, but fundamentally Emmy is a connector
-> between agencies, applicants, and verification data sources. As such 
+> between agencies, applicants, and verification data sources. As such
 > you will either need to have access to data services like Argyle, or create
 > stubs as needed for those services.
 
@@ -161,7 +161,9 @@ JSON_API_KEY=$(bin/rails runner "puts User.api_key_for_agency('agency_id')") rub
 Then point the Emmy App at the receiver (running on port 4567) by adding the
 `LA_LDH_*` variables shown in the
 ["JSON API Testing" section of `CONTRIBUTING.md`](/CONTRIBUTING.md) to your
-`.env.local`.
+`.env.local`. To transmit activity supporting documents, also set
+`SANDBOX_ACTIVITY_FLOW_TRANSMISSION_METHOD=http` and
+`SANDBOX_ACTIVITY_DOCUMENTS_API_URL=http://localhost:4567/documents`.
 
 ## Running tests
 


### PR DESCRIPTION
## [FFS-4555](https://jiraent.cms.gov/browse/FFS-4555)

## Changes
<!-- What was added, updated, or removed in this PR. -->

Add an HTTP activity-document transmitter that posts cleared uploads
with normalized filenames and signed headers. Make the sandbox receiver
and configuration support local end-to-end document transmission.

Extract common document management logic into ActivityDocumentsService.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [x] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: Codex
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
