### PR TITLE
FFS-4670: Fix Emmy Launcher to be enabled in CMS Cloud non-production environments

### DIFF
--- a/app/lib/internal_environment.rb
+++ b/app/lib/internal_environment.rb
@@ -7,6 +7,7 @@ module InternalEnvironment
     # CMS-hosted environments
     "uat.emmy.cms.gov",
     "dev.emmy.cms.gov",
+    "test.emmy.cms.gov",
     "demo.emmy.cms.gov",
     "sandbox.emmy.cms.gov"
   ].freeze

--- a/app/spec/lib/internal_environment_spec.rb
+++ b/app/spec/lib/internal_environment_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe InternalEnvironment do
       it { is_expected.to be true }
     end
 
+    context "when the domain is CMS test" do
+      let(:domain_name) { "test.emmy.cms.gov" }
+
+      it { is_expected.to be true }
+    end
+
     context "when the domain is CMS demo" do
       let(:domain_name) { "demo.emmy.cms.gov" }
 


### PR DESCRIPTION
## [FFS-4670](https://jiraent.cms.gov/browse/FFS-4670)

## Changes
Added `test.emmy.cms.gov` to allowlist to enable launcher

## Context for reviewers
CMS dev, sandbox, and UAT were already allowlisted.

After merge, will deploy to test and sandbox, then verify `/launcher` works in dev, test, sandbox, and UAT

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.
