### PR TITLE
FFS-4669: Deploy to CMS on push to main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,7 @@ Each app should have:
 
 - `cd-[app_name]`: deploys an application
   - Based on [`cd-app`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/cd-%7B%7Bapp_name%7D%7D.yml.jinja)
+- [`cd-cms-app`](./cd-cms-app.yml): on merge to `main`, deploys the app to the CMS Cloud `dev` and `test` environments by calling [`deploy-cms`](./deploy-cms.yml) once per environment
 
 The CD workflow uses these reusable workflows:
 
@@ -47,6 +48,11 @@ graph TD
   build-and-publish
 
   cd-app-->|calls|deploy-->|calls|database-migrations-->|calls|build-and-publish
+
+  cd-cms-app-->|calls|deploy-cms
+  deploy-cms-->|calls|build-and-publish-to-cms
+  deploy-cms-->|calls|database-migrations-cms
+  deploy-cms-->|calls|deploy-ecs
 ```
 
 ## ⛑️ Helper workflows

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ Each app should have:
 
 - `cd-[app_name]`: deploys an application
   - Based on [`cd-app`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/cd-%7B%7Bapp_name%7D%7D.yml.jinja)
-- [`cd-cms-app`](./cd-cms-app.yml): on push to `main`, deploys the app to the CMS Cloud `dev` and `test` environments by calling [`deploy-cms`](./deploy-cms.yml) once per environment
+- [`cd-cms-app`](./cd-cms-app.yml): on push to `main`, deploys the app to the CMS Cloud `dev` and `test` environments by calling [`deploy-cms`](./deploy-cms.yml) once per environment. Sole owner of automatic CMS image builds — `build-and-publish`'s `publish_to_cms` input defaults to `false` so the Nava CD chain does not build the same image concurrently
 
 The CD workflow uses these reusable workflows:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ Each app should have:
 
 - `cd-[app_name]`: deploys an application
   - Based on [`cd-app`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/cd-%7B%7Bapp_name%7D%7D.yml.jinja)
-- [`cd-cms-app`](./cd-cms-app.yml): on merge to `main`, deploys the app to the CMS Cloud `dev` and `test` environments by calling [`deploy-cms`](./deploy-cms.yml) once per environment
+- [`cd-cms-app`](./cd-cms-app.yml): on push to `main`, deploys the app to the CMS Cloud `dev` and `test` environments by calling [`deploy-cms`](./deploy-cms.yml) once per environment
 
 The CD workflow uses these reusable workflows:
 

--- a/.github/workflows/build-and-publish-to-cms.yml
+++ b/.github/workflows/build-and-publish-to-cms.yml
@@ -52,7 +52,6 @@ jobs:
       id-token: write
 
     env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       EMMY_IMAGE_REPO: ${{ vars.EMMY_IMAGE_REPO }}
       AWS_REGION: us-east-1
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,10 +13,10 @@ on:
         required: true
         type: string
       publish_to_cms:
-        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
+        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Automatic CMS publishing is owned by cd-cms-app; enable this only for one-off manual builds.
         required: false
         type: boolean
-        default: true
+        default: false
   workflow_dispatch:
     inputs:
       app_name:
@@ -28,10 +28,10 @@ on:
         required: true
         type: string
       publish_to_cms:
-        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Disable for PR environments, which don't deploy from it.
+        description: Whether to also publish the image to the CMS Artifactory/ECR registry. Automatic CMS publishing is owned by cd-cms-app; enable this only for one-off manual builds.
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   get-commit-hash:

--- a/.github/workflows/cd-cms-app.yml
+++ b/.github/workflows/cd-cms-app.yml
@@ -1,0 +1,31 @@
+name: Deploy CMS App
+run-name: Deploy ${{ github.ref_name }} to CMS dev and test
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "app/**"
+      - "bin/**"
+      - "infra/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy to CMS (${{ matrix.environment }})
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, test]
+    uses: ./.github/workflows/deploy-cms.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      environment: ${{ matrix.environment }}
+      ref: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/cd-cms-app.yml
+++ b/.github/workflows/cd-cms-app.yml
@@ -28,4 +28,3 @@ jobs:
     with:
       environment: ${{ matrix.environment }}
       ref: ${{ github.sha }}
-    secrets: inherit

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -2,14 +2,6 @@ name: Deploy to CMS
 run-name: Deploy ${{ inputs.ref || github.sha }} to CMS app (${{ inputs.environment }})
 
 on:
-# TODO: Uncomment when were ready to push to environments automatically
-# push:
-#    branches:
-#      - "main"
-#    paths:
-#      - "app/**"
-#      - "bin/**"
-#      - "infra/**"
   workflow_call:
     inputs:
       environment:


### PR DESCRIPTION
## [FFS-4669](https://jiraent.cms.gov/browse/FFS-4669)
Deploy to CMS environment on push to `main`

## Context for reviewers
- Removed unused Docker hub credentials

## Acceptance testing
- [X] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)

## AI Usage
- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.