### PR TITLE
FFS-4668: Add CMS review app workflow placeholders

### DIFF
--- a/.github/workflows/cms-pr-environment-checks.yml
+++ b/.github/workflows/cms-pr-environment-checks.yml
@@ -1,0 +1,29 @@
+# TEST PLACEHOLDER: This workflow intentionally performs no AWS operations.
+name: CMS Cloud PR Environment Update
+run-name: Test CMS Cloud PR Environment Update ${{ inputs.pr_number }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      commit_hash:
+        description: Full commit SHA to deploy
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Test placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo review-app inputs
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          COMMIT_HASH: ${{ inputs.commit_hash }}
+        run: echo "Test placeholder for PR ${PR_NUMBER} at ${COMMIT_HASH}"

--- a/.github/workflows/cms-pr-environment-destroy.yml
+++ b/.github/workflows/cms-pr-environment-destroy.yml
@@ -1,0 +1,24 @@
+# TEST PLACEHOLDER: This workflow intentionally performs no AWS operations.
+name: CMS Cloud PR Environment Destroy
+run-name: Test CMS Cloud PR Environment Destroy ${{ inputs.pr_number }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Test placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo review-app input
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: echo "Test placeholder for destroying PR ${PR_NUMBER}"


### PR DESCRIPTION
## [FFS-4668](https://jiraent.cms.gov/browse/FFS-4668)

## Changes

- Add placeholder CMS review-app update and destroy workflows.
- Preserve the real workflows workflow_dispatch inputs so feature branches can be selected and tested after this PR merges.
- Run only dummy echo steps and clearly mark both files as test placeholders.

## Context for reviewers

Merge this PR before #1982. GitHub requires workflow files to exist on the default branch before their feature-branch versions can be selected for manual dispatch and iteration.

## Acceptance testing

- [x] No acceptance testing needed
  - These placeholder workflows perform no AWS or application operations.

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.

Optional — for learning, not audited:
- AI tools used: Codex

## Infrastructure Changes

No Terraform or deployed infrastructure changes.

## **Risk / Downtime:**

No downtime. The workflows have read-only repository permissions and only echo their supplied inputs.