### PR TITLE
FFS-4668: Report PR webhook initialization errors

### DIFF
--- a/app/config/initializers/pr_environment_webhooks.rb
+++ b/app/config/initializers/pr_environment_webhooks.rb
@@ -10,7 +10,7 @@
 # on PR review apps. Teardown happens via `rake pr_webhooks:destroy`, invoked
 # by `bin/destroy-pr-environment`.
 Rails.application.config.to_prepare do
-  Rails.application.config.pr_env_webhooks_initialization_error = nil
+  Rails.application.config.webhooks_initialization_error = nil
 
   domain = ENV["DOMAIN_NAME"]
   pr_match = domain&.match(/\Ap-(\d+)\.navapbc\.cloud\z/)
@@ -33,7 +33,7 @@ Rails.application.config.to_prepare do
           .create_subscriptions_if_necessary(receiver_base_url, subscription_name)
       end
     rescue => ex
-      Rails.application.config.pr_env_webhooks_initialization_error = ex.message
+      Rails.application.config.webhooks_initialization_error = ex.message
       Rails.logger.error "🟥 Unable to configure webhooks for PR environment: #{ex}"
       Rails.logger.error "🟥   in #{ex.backtrace.first}"
     end


### PR DESCRIPTION
## [FFS-4668](https://jiraent.cms.gov/browse/FFS-4668)

## Changes

- Store PR review-app webhook initialization failures in `Rails.application.config.webhooks_initialization_error`.
- Reset the same shared setting before each initialization attempt.

## Context for reviewers

While working on the review apps, an unrelated issue caused the webhooks to fail to register upon startup. That led me to notice the lack of this error message showing up. This commit fixes it by showing the error in the same way as the local dev webhook subscriber error messages:

The employer-search controllers already read `webhooks_initialization_error` to display webhook registration failures. The PR environment initializer previously wrote to a separate `pr_env_webhooks_initialization_error` setting that had no consumers.

## Acceptance testing

- [x] No acceptance testing needed
  * This fixes internal error propagation without changing the normal user experience.
- [ ] Acceptance testing prior to merge
- [ ] Acceptance testing in PR Environment
- [ ] Acceptance testing after merge

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: Codex

## Infrastructure Changes

No infrastructure changes.

- [ ] Plan reviewed
- [ ] Applied in dev before merge
- [ ] Applied in demo after merge
- [ ] Applied in prod after merge

## **Risk / Downtime:**

Low risk. This only changes which Rails configuration field receives an initialization error; no downtime or migration is required.