### PR TITLE
FFS-4688: Clean up order and styling of components on doc upload page

### DIFF
--- a/app/app/assets/stylesheets/document_uploads.scss
+++ b/app/app/assets/stylesheets/document_uploads.scss
@@ -16,7 +16,8 @@
   }
 }
 .document-uploads__heading {
-  margin-bottom: units(2);
+  @include u-font-size("heading", 8);
+  margin-bottom: units(1);
   margin-top: 0;
 }
 .document-uploads__list {
@@ -28,37 +29,37 @@
   align-items: center;
   border-bottom: 1px solid color("gray-cool-20");
   display: flex;
-  gap: units(2);
+  gap: units(1);
   justify-content: space-between;
-  padding-bottom: units(1);
-  padding-top: units(1);
+  padding-bottom: units(1.5);
+  padding-top: units(1.5);
 }
 .document-uploads__file {
   align-items: center;
   display: flex;
-  gap: units(2);
+  gap: units(1);
   min-width: 0;
 }
 .document-uploads__icon {
   background-color: color("blue-warm-5");
   border: 1px solid color("blue-warm-20v");
   border-radius: radius("md");
-  box-sizing: content-box;
   color: color("primary");
   flex-shrink: 0;
-  height: 1.5rem;
+  height: units(5);
   padding: units(1);
-  width: 1.5rem;
+  width: units(5);
 }
 .document-uploads__filename {
-  @include u-font("sans", 4);
-  line-height: line-height("sans", 4);
+  @include u-font("sans", 5);
+  line-height: line-height("sans", 1);
   overflow: hidden;
   word-break: break-word;
 }
 .document-uploads__remove-link {
   color: color("secondary-dark");
   flex-shrink: 0;
-  @include u-font("sans", 4);
-  line-height: line-height("sans", 4);
+  @include u-font("sans", 5);
+  line-height: line-height("sans", 1);
+  padding: units(0.5) units(1);
 }

--- a/app/app/javascript/controllers/document_upload_controller.js
+++ b/app/app/javascript/controllers/document_upload_controller.js
@@ -3,7 +3,7 @@ import CSRF from "../utilities/csrf"
 import fileChecksum from "../utilities/file_checksum"
 
 export default class extends Controller {
-  static targets = ["input", "list", "listHeading", "error", "signedIds"]
+  static targets = ["input", "listSection", "list", "listHeading", "error", "signedIds"]
 
   static values = {
     presignUrl: String,
@@ -178,7 +178,7 @@ export default class extends Controller {
 
     const remove = document.createElement("button")
     remove.type = "button"
-    remove.className = "usa-button usa-button--unstyled document-uploads__remove-link"
+    remove.className = "usa-button usa-button--unstyled margin-0 document-uploads__remove-link"
     remove.dataset.action = "document-upload#remove"
     remove.textContent = this.removeLabelValue
 
@@ -190,8 +190,7 @@ export default class extends Controller {
   #refreshList() {
     const count = this.listTarget.children.length
 
-    this.listTarget.hidden = count === 0
-    this.listHeadingTarget.hidden = count === 0
+    this.listSectionTarget.hidden = count === 0
     this.listHeadingTarget.textContent = this.headingTemplateValue.replace("%{count}", count)
   }
 

--- a/app/app/views/activities/document_uploads/new.html.erb
+++ b/app/app/views/activities/document_uploads/new.html.erb
@@ -63,6 +63,11 @@
 
   <div hidden data-document-upload-target="signedIds"></div>
 
+  <div class="document-uploads" hidden data-document-upload-target="listSection">
+    <h2 class="document-uploads__heading" data-document-upload-target="listHeading"></h2>
+    <ul class="document-uploads__list" data-document-upload-target="list"></ul>
+  </div>
+
   <%= f.file_field :document_uploads,
       multiple: true,
       label: t(".input_label"),
@@ -76,11 +81,6 @@
       } %>
 
   <div class="usa-error-message" hidden data-document-upload-target="error" role="alert"></div>
-
-  <div class="document-uploads">
-    <h2 class="document-uploads__heading" hidden data-document-upload-target="listHeading"></h2>
-    <ul class="document-uploads__list" hidden data-document-upload-target="list"></ul>
-  </div>
 
   <%= render(AccordionComponent.new(id: "document-upload-suggestions")) do |accordion| %>
     <% accordion.with_title { t(".suggestion_title") } %>

--- a/app/spec/controllers/activities/document_uploads_controller_spec.rb
+++ b/app/spec/controllers/activities/document_uploads_controller_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Activities::DocumentUploadsController, type: :controller do
       expect(response.body).to include(activities_flow_community_service_document_uploads_path)
       expect(response.body).not_to include(I18n.t("activities.document_uploads.heading_previous", document_count: 0))
       expect(response.body).to include(I18n.t("activities.document_uploads.new.input_label"))
+
+      rendered = Capybara.string(response.body)
+      upload_form = rendered.find("form[data-controller='document-upload']", visible: :all)
+      ordered_elements = upload_form.all(
+        "[data-document-upload-target='listSection'], input[type='file']",
+        visible: :all
+      )
+      expect(ordered_elements.map { |element| element[:"data-document-upload-target"] })
+        .to eq([ "listSection", "input" ])
     end
 
     it "shows the Save changes label and preserves from_review in the form action when from_review is set" do

--- a/app/spec/javascript/controllers/document_upload.spec.js
+++ b/app/spec/javascript/controllers/document_upload.spec.js
@@ -61,12 +61,14 @@ describe("DocumentUploadController", () => {
         data-document-upload-error-upload-failed-value="${FAILED}"
       >
         <div hidden data-document-upload-target="signedIds"></div>
+        <div class="document-uploads" hidden data-document-upload-target="listSection">
+          <h2 data-document-upload-target="listHeading"></h2>
+          <ul data-document-upload-target="list"></ul>
+        </div>
         <input type="file" multiple
                data-document-upload-target="input"
                data-action="change->document-upload#select">
         <div class="usa-error-message" hidden data-document-upload-target="error"></div>
-        <h2 hidden data-document-upload-target="listHeading"></h2>
-        <ul hidden data-document-upload-target="list"></ul>
         <input type="submit" value="Continue">
       </form>
     `
@@ -318,8 +320,9 @@ describe("DocumentUploadController", () => {
     )
 
     const heading = document.querySelector("[data-document-upload-target=listHeading]")
+    const section = document.querySelector("[data-document-upload-target=listSection]")
 
-    expect(heading.hidden).toBe(false)
+    expect(section.hidden).toBe(false)
     expect(heading.textContent).toBe("Uploaded documents (2)")
   })
 
@@ -332,10 +335,12 @@ describe("DocumentUploadController", () => {
 
     await selectFiles(buildFile("verification.pdf", "application/pdf", 1024))
 
-    document.querySelector(".document-uploads__remove-link").click()
+    const removeLink = document.querySelector(".document-uploads__remove-link")
+    expect(removeLink.classList).toContain("margin-0")
+    removeLink.click()
 
     expect(signedIdValues()).toEqual([])
     expect(listItems()).toHaveLength(0)
-    expect(document.querySelector("[data-document-upload-target=listHeading]").hidden).toBe(true)
+    expect(document.querySelector("[data-document-upload-target=listSection]").hidden).toBe(true)
   })
 })


### PR DESCRIPTION
## [FFS-4688](https://jiraent.cms.gov/browse/FFS-4688)

## Changes
<!-- What was added, updated, or removed in this PR. -->
- Moved "Uploaded documents" above "Add documents"
- Updated file row spacing and sizing to match designs

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<img width="526" height="701" alt="Screenshot 2026-08-18 at 11 17 26 AM" src="https://github.com/user-attachments/assets/eedfd07a-824f-451a-9bc0-f45d2dc43d87" />
