### PR TITLE
FFS-4705: Add "Choose how you want to add your work" page to Emmy CE Employment flow

### DIFF
--- a/app/app/controllers/activities/employment/add_your_work_controller.rb
+++ b/app/app/controllers/activities/employment/add_your_work_controller.rb
@@ -1,7 +1,7 @@
 class Activities::Employment::AddYourWorkController < Activities::BaseController
   ADD_WORK_METHODS = %w[connect_automatically enter_paid_manually enter_unpaid_manually].freeze
 
-  after_action :track_page_accessed_event, only: :show
+  after_action :track_viewed_event, only: :show
 
   def show
   end
@@ -14,7 +14,7 @@ class Activities::Employment::AddYourWorkController < Activities::BaseController
       return redirect_to activities_flow_income_add_your_work_path
     end
 
-    track_event(TrackEvent::ApplicantContinuedFromAddYourWorkPage, add_work_method: add_work_method)
+    track_event(TrackEvent::EmploymentAddYourWorkSubmitted, add_work_method: add_work_method)
 
     redirect_to next_step_path(add_work_method)
   end
@@ -29,7 +29,9 @@ class Activities::Employment::AddYourWorkController < Activities::BaseController
     end
   end
 
-  def track_page_accessed_event
-    track_event(TrackEvent::ApplicantAccessedAddYourWorkPage)
+  def track_viewed_event
+    return unless response.successful?
+
+    track_event(TrackEvent::EmploymentAddYourWorkViewed)
   end
 end

--- a/app/app/controllers/activities/employment/add_your_work_controller.rb
+++ b/app/app/controllers/activities/employment/add_your_work_controller.rb
@@ -1,0 +1,35 @@
+class Activities::Employment::AddYourWorkController < Activities::BaseController
+  ADD_WORK_METHODS = %w[connect_automatically enter_paid_manually enter_unpaid_manually].freeze
+
+  after_action :track_page_accessed_event, only: :show
+
+  def show
+  end
+
+  def create
+    add_work_method = params[:add_work_method]
+
+    unless ADD_WORK_METHODS.include?(add_work_method)
+      flash[:slim_alert] = { message: t("shared.next_path.notice_no_answer"), type: "error" }
+      return redirect_to activities_flow_income_add_your_work_path
+    end
+
+    track_event(TrackEvent::ApplicantContinuedFromAddYourWorkPage, add_work_method: add_work_method)
+
+    redirect_to next_step_path(add_work_method)
+  end
+
+  private
+
+  def next_step_path(add_work_method)
+    if add_work_method == "connect_automatically"
+      activities_flow_income_employer_search_path
+    else
+      new_activities_flow_income_employment_path
+    end
+  end
+
+  def track_page_accessed_event
+    track_event(TrackEvent::ApplicantAccessedAddYourWorkPage)
+  end
+end

--- a/app/app/controllers/activities/employment_controller.rb
+++ b/app/app/controllers/activities/employment_controller.rb
@@ -93,7 +93,7 @@ class Activities::EmploymentController < Activities::BaseController
 
   def set_back_url
     if action_name.in?(%w[new create])
-      @back_url = activities_flow_income_employer_search_path
+      @back_url = activities_flow_income_add_your_work_path
     elsif action_name == "edit" && params[:from_review].present?
       @back_url = review_activities_flow_income_employment_path(
         id: @employment_activity,

--- a/app/app/helpers/uswds_form_builder.rb
+++ b/app/app/helpers/uswds_form_builder.rb
@@ -63,9 +63,10 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
 
     label_text = options.delete(:label)
     label_options = { for: field_id(attribute, tag_value) }.merge(options)
+    input_options = options.except(:hint)
 
     @template.content_tag(:div, class: "usa-radio") do
-      super(attribute, tag_value, options) + us_toggle_label("radio", attribute, label_text, label_options)
+      super(attribute, tag_value, input_options) + us_toggle_label("radio", attribute, label_text, label_options)
     end
   end
 

--- a/app/app/models/track_event.rb
+++ b/app/app/models/track_event.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module TrackEvent
+  ApplicantAccessedAddYourWorkPage = "ApplicantAccessedAddYourWorkPage"
   ApplicantAccessedArgyleModalMFAScreen = "ApplicantAccessedArgyleModalMFAScreen"
   ApplicantAccessedExpiredLinkPage = "ApplicantAccessedExpiredLinkPage"
   ApplicantAccessedFlowWithoutCookie = "ApplicantAccessedFlowWithoutCookie"
@@ -23,6 +24,7 @@ module TrackEvent
   ApplicantClosedPinwheelModal = "ApplicantClosedPinwheelModal"
   ApplicantConsentedToTerms = "ApplicantConsentedToTerms"
   ApplicantContinuedFromAddJobsPage = "ApplicantContinuedFromAddJobsPage"
+  ApplicantContinuedFromAddYourWorkPage = "ApplicantContinuedFromAddYourWorkPage"
   ApplicantContinuedFromOtherJobsPage = "ApplicantContinuedFromOtherJobsPage"
   ApplicantCopiedInvitationLink = "ApplicantCopiedInvitationLink"
   ApplicantCreatedArgyleAccount = "ApplicantCreatedArgyleAccount"

--- a/app/app/models/track_event.rb
+++ b/app/app/models/track_event.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module TrackEvent
-  ApplicantAccessedAddYourWorkPage = "ApplicantAccessedAddYourWorkPage"
   ApplicantAccessedArgyleModalMFAScreen = "ApplicantAccessedArgyleModalMFAScreen"
   ApplicantAccessedExpiredLinkPage = "ApplicantAccessedExpiredLinkPage"
   ApplicantAccessedFlowWithoutCookie = "ApplicantAccessedFlowWithoutCookie"
@@ -24,7 +23,6 @@ module TrackEvent
   ApplicantClosedPinwheelModal = "ApplicantClosedPinwheelModal"
   ApplicantConsentedToTerms = "ApplicantConsentedToTerms"
   ApplicantContinuedFromAddJobsPage = "ApplicantContinuedFromAddJobsPage"
-  ApplicantContinuedFromAddYourWorkPage = "ApplicantContinuedFromAddYourWorkPage"
   ApplicantContinuedFromOtherJobsPage = "ApplicantContinuedFromOtherJobsPage"
   ApplicantCopiedInvitationLink = "ApplicantCopiedInvitationLink"
   ApplicantCreatedArgyleAccount = "ApplicantCreatedArgyleAccount"
@@ -82,6 +80,8 @@ module TrackEvent
   CaseworkerInvitedApplicantToFlow = "CaseworkerInvitedApplicantToFlow"
   CbvPageView = "CbvPageView"
   EmailSent = "EmailSent"
+  EmploymentAddYourWorkSubmitted = "EmploymentAddYourWorkSubmitted"
+  EmploymentAddYourWorkViewed = "EmploymentAddYourWorkViewed"
   EmploymentBackClicked = "EmploymentBackClicked"
   EmploymentDocumentUploadSubmitted = "EmploymentDocumentUploadSubmitted"
   EmploymentDocumentUploadViewed = "EmploymentDocumentUploadViewed"

--- a/app/app/views/activities/activities/index.html.erb
+++ b/app/app/views/activities/activities/index.html.erb
@@ -93,7 +93,7 @@
       <%= render "activities/activities/activity_section",
             activity_type: "employment",
             section_title: t("activities.employment.title"),
-            add_path: activities_flow_income_employer_search_path,
+            add_path: activities_flow_income_add_your_work_path,
             empty_message: t("activities.hub.empty.employment"),
             cards: employment_card_data do %>
         <% employment_card_data.each do |card_data| %>

--- a/app/app/views/activities/employment/add_your_work/show.html.erb
+++ b/app/app/views/activities/employment/add_your_work/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t(".header") %>
+
+<% content_for :activity_flow_header do %>
+  <%= render ActivityFlowHeaderComponent.new(
+    title: t("activities.employment.title_singular"),
+    exit_url: activities_flow_root_path
+  ) %>
+<% end %>
+
+<h1><%= t(".header") %></h1>
+<p><%= t(".description") %></p>
+
+<%= form_with(url: activities_flow_income_add_your_work_path, class: "maxw-none", builder: UswdsFormBuilder, id: "add_your_work_form") do |f| %>
+  <%= f.radio_button(:add_work_method, "connect_automatically", { label: tag.span(t(".options.automatic.label"), class: "text-bold"), hint: t(".options.automatic.hint") }) %>
+  <%= f.radio_button(:add_work_method, "enter_paid_manually", { label: tag.span(t(".options.paid.label"), class: "text-bold"), hint: t(".options.paid.hint") }) %>
+  <%= f.radio_button(:add_work_method, "enter_unpaid_manually", { label: tag.span(t(".options.unpaid.label"), class: "text-bold"), hint: t(".options.unpaid.hint") }) %>
+
+  <%= f.submit t("continue") %>
+<% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -257,6 +257,20 @@ en:
         last_name: Last name
     employment:
       account_id: Account ID
+      add_your_work:
+        show:
+          description: If you held multiple jobs during the reporting period, you'll need to add each job separately.
+          header: Choose how you want to add your work
+          options:
+            automatic:
+              hint: We'll pull your hours and income from your payroll account. Works with ADP, Workday, Uber, Lyft, and most large employers.
+              label: Connect your work automatically
+            paid:
+              hint: Add details for a job where you can't view paystubs online, like a small employer, a job where you were paid in cash, or self-employment.
+              label: Enter paid work manually
+            unpaid:
+              hint: Add work where you received housing, food, or other goods instead of money.
+              label: Enter unpaid or in-kind work
       document_upload_month_detail: "%{gross_income}, %{hours}"
       document_upload_suggestion_text_html: "<ul><li>Paystubs</li><li>1099 or W-2 tax document</li><li>Schedule C (1040) tax document if you're self-employed</li><li>Bank statement showing income earned</li><li>Official email or letter from your employer's HR department with monthly income and hours detailed</li></ul>"
       hours_input:

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
       resource :submit, only: %i[show], controller: "submit", format: %i[html pdf]
       resource :success, only: %i[show], controller: "success"
       scope "/income", as: :income do
+        resource :add_your_work, only: %i[show create], controller: "employment/add_your_work"
         resource :employer_search, only: %i[show], controller: "income/employer_searches"
         resource :synchronizations, only: %i[show update], controller: "income/synchronizations"
         resource :synchronization_failures, only: %i[show], controller: "income/synchronization_failures"

--- a/app/spec/controllers/activities/activities_controller_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Activities::ActivitiesController, type: :controller do
       get :index, params: { from_edit: 1, from_review: 1 }
     end
 
+    it "points the employment add button at the add your work page" do
+      expect(Capybara.string(response.body)).to have_css(
+        "[data-activity-type='employment'] form[action='#{activities_flow_income_add_your_work_path}']"
+      )
+    end
+
     it "shows current flow community service activities" do
       expect(
         assigns(:community_service_activities)

--- a/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
+++ b/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Activities::Employment::AddYourWorkController, type: :controller 
         let(:perform_tracked_action) { post :create, params: { add_work_method: add_work_method } }
 
         it_behaves_like "tracks an event", TrackEvent::ApplicantContinuedFromAddYourWorkPage,
-          extra_attributes: { add_work_method: add_work_method }
+          extra_attributes: -> { { add_work_method: add_work_method } }
       end
     end
   end

--- a/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
+++ b/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Activities::Employment::AddYourWorkController, type: :controller 
       expect(Capybara.string(response.body)).not_to have_link("Back")
     end
 
-    it_behaves_like "tracks an event", TrackEvent::ApplicantAccessedAddYourWorkPage
+    it_behaves_like "tracks an event", TrackEvent::EmploymentAddYourWorkViewed
   end
 
   describe "#create" do
@@ -80,9 +80,9 @@ RSpec.describe Activities::Employment::AddYourWorkController, type: :controller 
       expect(response).to redirect_to(activities_flow_income_add_your_work_path)
     end
 
-    it "does not track a continued event when nothing is selected" do
+    it "does not track a submitted event when nothing is selected" do
       expect(EventTrackingJob).not_to receive(:perform_later)
-        .with(TrackEvent::ApplicantContinuedFromAddYourWorkPage, anything, anything)
+        .with(TrackEvent::EmploymentAddYourWorkSubmitted, anything, anything)
 
       post :create
     end
@@ -91,7 +91,7 @@ RSpec.describe Activities::Employment::AddYourWorkController, type: :controller 
       context "when the applicant selects #{add_work_method}" do
         let(:perform_tracked_action) { post :create, params: { add_work_method: add_work_method } }
 
-        it_behaves_like "tracks an event", TrackEvent::ApplicantContinuedFromAddYourWorkPage,
+        it_behaves_like "tracks an event", TrackEvent::EmploymentAddYourWorkSubmitted,
           extra_attributes: -> { { add_work_method: add_work_method } }
       end
     end

--- a/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
+++ b/app/spec/controllers/activities/employment/add_your_work_controller_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe Activities::Employment::AddYourWorkController, type: :controller do
+  include_context "activity_hub"
+
+  render_views
+
+  let(:activity_flow) { create(:activity_flow) }
+  let(:tracked_flow) { activity_flow }
+
+  before do
+    session[:flow_id] = activity_flow.id
+    session[:flow_type] = :activity
+  end
+
+  describe "#show" do
+    let(:perform_tracked_action) { get :show }
+
+    it "renders properly" do
+      get :show
+      expect(response).to be_successful
+    end
+
+    it "renders the header and description" do
+      get :show
+      expect(response.body).to include(I18n.t("activities.employment.add_your_work.show.header"))
+      expect(response.body).to include(CGI.escapeHTML(I18n.t("activities.employment.add_your_work.show.description")))
+    end
+
+    it "renders all three options with bolded labels and their hints" do
+      get :show
+
+      %w[automatic paid unpaid].each do |option|
+        label = CGI.escapeHTML(I18n.t("activities.employment.add_your_work.show.options.#{option}.label"))
+        expect(response.body).to include("<span class=\"text-bold\">#{label}</span>")
+        expect(response.body).to include(CGI.escapeHTML(I18n.t("activities.employment.add_your_work.show.options.#{option}.hint")))
+      end
+    end
+
+    it "does not render the hint as an attribute on the radio input" do
+      get :show
+      expect(response.body).not_to include("hint=")
+    end
+
+    it "renders the activity flow header with exit button and no back link" do
+      get :show
+      expect(response.body).to include(I18n.t("activities.employment.title_singular"))
+      expect(response.body).to include("exit-confirmation-modal")
+      expect(Capybara.string(response.body)).not_to have_link("Back")
+    end
+
+    it_behaves_like "tracks an event", TrackEvent::ApplicantAccessedAddYourWorkPage
+  end
+
+  describe "#create" do
+    it "redirects to employer search when connecting work automatically" do
+      post :create, params: { add_work_method: "connect_automatically" }
+      expect(response).to redirect_to(activities_flow_income_employer_search_path)
+    end
+
+    it "redirects to self-attested employment when entering paid work manually" do
+      post :create, params: { add_work_method: "enter_paid_manually" }
+      expect(response).to redirect_to(new_activities_flow_income_employment_path)
+    end
+
+    it "redirects to self-attested employment when entering unpaid work manually" do
+      post :create, params: { add_work_method: "enter_unpaid_manually" }
+      expect(response).to redirect_to(new_activities_flow_income_employment_path)
+    end
+
+    it "redirects back with an alert when nothing is selected" do
+      post :create
+      expect(flash[:slim_alert][:message]).to eq(I18n.t("shared.next_path.notice_no_answer"))
+      expect(response).to redirect_to(activities_flow_income_add_your_work_path)
+    end
+
+    it "redirects back with an alert when the selection is not recognized" do
+      post :create, params: { add_work_method: "something_else" }
+      expect(flash[:slim_alert][:message]).to eq(I18n.t("shared.next_path.notice_no_answer"))
+      expect(response).to redirect_to(activities_flow_income_add_your_work_path)
+    end
+
+    it "does not track a continued event when nothing is selected" do
+      expect(EventTrackingJob).not_to receive(:perform_later)
+        .with(TrackEvent::ApplicantContinuedFromAddYourWorkPage, anything, anything)
+
+      post :create
+    end
+
+    %w[connect_automatically enter_paid_manually enter_unpaid_manually].each do |add_work_method|
+      context "when the applicant selects #{add_work_method}" do
+        let(:perform_tracked_action) { post :create, params: { add_work_method: add_work_method } }
+
+        it_behaves_like "tracks an event", TrackEvent::ApplicantContinuedFromAddYourWorkPage,
+          extra_attributes: { add_work_method: add_work_method }
+      end
+    end
+  end
+end

--- a/app/spec/controllers/activities/employment_navigation_spec.rb
+++ b/app/spec/controllers/activities/employment_navigation_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe Activities::EmploymentController, type: :controller do
   # ── Creation flow ──
 
   describe "creation flow" do
-    it "employer info back goes to employer search" do
+    it "employer info back goes to the add your work page" do
       get :new
-      expected = activities_flow_income_employer_search_path
+      expected = activities_flow_income_add_your_work_path
       expect(Capybara.string(response.body)).to have_link("Back", href: expected)
     end
 
     it "employer info back still shows when create fails validation" do
       post :create, params: { employment_activity: { employer_name: "" } }
       expect(response).to have_http_status(:unprocessable_content)
-      expected = activities_flow_income_employer_search_path
+      expected = activities_flow_income_add_your_work_path
       expect(Capybara.string(response.body)).to have_link("Back", href: expected)
     end
 

--- a/app/spec/controllers/activities/income/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/activities/income/employer_searches_controller_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Activities::Income::EmployerSearchesController do
       expect(response.body).to include("exit-confirmation-modal")
     end
 
+    it "does not render a back link" do
+      get :show
+      expect(Capybara.string(response.body)).not_to have_link("Back")
+    end
+
     it "tracks an accessed search event with activity_flow_id" do
       allow(EventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
       expect(EventTrackingJob).to receive(:perform_later).with("ApplicantAccessedSearchPage", anything, hash_including(

--- a/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
+++ b/app/spec/e2e/activity_hub_employment_self_attestation_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe "e2e Employment self-attestation review flow", :js, type: :featur
       click_button I18n.t("activities.hub.add")
     end
 
+    # Add your work page
+    verify_page(page, title: I18n.t("activities.employment.add_your_work.show.header"))
+    click_button I18n.t("continue")
+    expect(page).to have_content(I18n.t("shared.next_path.notice_no_answer"))
+    find("label[for='add_work_method_connect_automatically']").click
+    click_button I18n.t("continue")
+
     # Employer search page
     verify_page(page, title: I18n.t("activities.income.employer_searches.show.header"))
     find('.usa-input[type="search"]').fill_in with: "blahblahblah"

--- a/app/spec/e2e/activity_hub_spec.rb
+++ b/app/spec/e2e/activity_hub_spec.rb
@@ -156,8 +156,9 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
 
   def add_self_attested_employment_activity
     within("[data-activity-type='employment']") { click_button I18n.t("activities.hub.add") }
-    verify_page(page, title: I18n.t("activities.income.employer_searches.show.header"))
-    visit new_activities_flow_income_employment_path
+    verify_page(page, title: I18n.t("activities.employment.add_your_work.show.header"))
+    find("label[for='add_work_method_enter_paid_manually']").click
+    click_button I18n.t("continue")
     verify_page(page, title: I18n.t("activities.employment_info.title"))
     fill_in I18n.t("activities.employment_info.employer_name"), with: "Gainesville Wrecking"
     fill_in I18n.t("activities.employment_info.street_address"), with: "942 W Harlan Ave"
@@ -209,6 +210,9 @@ RSpec.describe 'e2e Activity Hub flow test', :js, type: :feature do
     within("[data-activity-type='employment']") do
       click_button I18n.t("activities.hub.add")
     end
+    verify_page(page, title: I18n.t("activities.employment.add_your_work.show.header"))
+    find("label[for='add_work_method_connect_automatically']").click
+    click_button I18n.t("continue")
     verify_page(page, title: I18n.t("activities.income.employer_searches.show.header"))
     @e2e.replay_modal_callbacks(page.driver.browser) do
       click_button "Paychex"

--- a/app/spec/helpers/uswds_form_builder_spec.rb
+++ b/app/spec/helpers/uswds_form_builder_spec.rb
@@ -221,6 +221,10 @@ RSpec.describe UswdsFormBuilder do
       it 'outputs a hint' do
         expect(result).to have_element(:span, text: 'Select yes', class: 'usa-radio__label-description')
       end
+
+      it 'does not output the hint as an attribute on the input' do
+        expect(result).not_to include('hint=')
+      end
     end
   end
 


### PR DESCRIPTION
## [FFS-4705](https://jiraent.cms.gov/browse/FFS-4705)
- Clicking the option to add employment in the hub now brings you to a page asking which type of employment it is. If its the first option it takes you to the employer search, if its the other two it sends you to the self attested employment page. If no option is selected and you hit continue, it sends you back prompting you to select one.
- Track `ApplicantAccessedAddYourWorkPage` on page view and `ApplicantContinuedFromAddYourWorkPage` with one of the following `add_work_method` options based on what was selected: `connect_automatically`, `enter_paid_manually`, or `enter_unpaid_manually`
- Fix radio button creating unintentional `hint` attribute in the `input` which does nothing.

## Context for reviewers
- The new page becomes the entry point for adding employment, so employer search is no longer the first step and no longer renders a back link.
- Both manual options currently route to the same self-attested employment form. The paid vs. unpaid distinction is only captured in the tracking event for now.
- `add_work_method` is validated against an allowlist in the controller rather than a model, since nothing is persisted at this step.
- The `UswdsFormBuilder#radio_button` change is a general fix: `:hint` was being passed through to the `input` tag along with the label options. It only affects radios that pass a hint.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<!-- begin CMS review environment info -->
## CMS Cloud review environment
♻️ Environment destroyed ♻️
<!-- end CMS review environment info -->