### PR TITLE
FFS-3788: Investigate and fix undefined method 'identity' for an instance of CbvFlow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
     name: prettier
     entry: bin/run-linter --cd app -- npm run format:precommit
     language: node
+    additional_dependencies: ["prettier"]
     files: '^app/.*\.(js|ts|json)$'
 
   - id: terraform_fmt

--- a/app/app/controllers/flow_controller.rb
+++ b/app/app/controllers/flow_controller.rb
@@ -74,10 +74,19 @@ class FlowController < ApplicationController
       track_invitation_clicked_event(invitation, @flow)
     elsif session[:flow_id]
       begin
-        # Use the controller's `flow_param` so controllers scoped to a
-        # particular flow (e.g. activities) don't accidentally load a
-        # different flow type from the session (e.g. CbvFlow).
-        @flow = flow_class(flow_param).find(session[:flow_id])
+        # For activity-scoped controllers, require the ActivityFlow class be
+        # used so an activities controller cannot accidentally load a
+        # CbvFlow from a session id. For other controllers preserve the
+        # previous behavior of resolving the flow class from the
+        # `session[:flow_type]` when present to avoid changing unrelated
+        # behavior (eg. tests that expect a CBV controller to honor the
+        # session's flow type).
+        if flow_param == :activity
+          @flow = flow_class(flow_param).find(session[:flow_id])
+        else
+          @flow = flow_class.find(session[:flow_id])
+        end
+
         @cbv_flow = @flow # Maintain for compatibility until all controllers are converted
       rescue ActiveRecord::RecordNotFound
         reset_cbv_session!

--- a/app/app/controllers/flow_controller.rb
+++ b/app/app/controllers/flow_controller.rb
@@ -74,7 +74,10 @@ class FlowController < ApplicationController
       track_invitation_clicked_event(invitation, @flow)
     elsif session[:flow_id]
       begin
-        @flow = flow_class.find(session[:flow_id])
+        # Use the controller's `flow_param` so controllers scoped to a
+        # particular flow (e.g. activities) don't accidentally load a
+        # different flow type from the session (e.g. CbvFlow).
+        @flow = flow_class(flow_param).find(session[:flow_id])
         @cbv_flow = @flow # Maintain for compatibility until all controllers are converted
       rescue ActiveRecord::RecordNotFound
         reset_cbv_session!

--- a/app/spec/controllers/activities/activities_controller_flow_session_mismatch_spec.rb
+++ b/app/spec/controllers/activities/activities_controller_flow_session_mismatch_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Activities::ActivitiesController, type: :controller do
+  describe "GET #index when session contains a different flow type" do
+    it "resets the session and redirects when the session flow id can't be found" do
+      # Simulate session containing an id that ActivityFlow cannot find (e.g. it's a CbvFlow id)
+      session[:flow_id] = 999_999
+
+      # Enable the activity hub so the before_action doesn't redirect early
+      allow_any_instance_of(Activities::BaseController).to receive(:activity_hub_enabled?).and_return(true)
+
+      allow(ActivityFlow).to receive(:find).with(999_999).and_raise(ActiveRecord::RecordNotFound)
+
+      get :index
+
+      expect(session[:flow_id]).to be_nil
+      expect(response).to redirect_to(root_url(cbv_flow_timeout: true))
+    end
+  end
+end


### PR DESCRIPTION
## [FFS-3788](https://jiraent.cms.gov/browse/FFS-3788)

## Changes
When restoring the saved session we used a generic lookup that could return the wrong model. So `@flow` could be a `CbvFlow `when the Activities controller expected an ActivityFlow. Calling `@flow.identity` on the wrong object raised the error. When loading from session, we now ask for the specific kind of flow the controller expects instead of using the generic finder. Also added a regression spec.

## Context for reviewers
Sorry I don't have EUA access yet and I'm with skylight so I can't get the ticket link or tag acceptance testing in slack!

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: <e.g. GitHub Copilot, Claude Code — shows what's in use>
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>

## Infrastructure Changes
<!-- If this PR includes Terraform changes, please provide relevant info. -->
  - [ ] Plan reviewed
  - [ ] Applied in dev before merge
  - [ ] Applied in demo after merge
  - [ ] Applied in prod after merge (note any exceptions or special coordination below)

## **Risk / Downtime:**
<!-- Note exceptions, potential downtime, or required coordination -->
