### PR TITLE
FFS-4596 No consent pdf showing

### DIFF
--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -21,7 +21,7 @@ class Cbv::SubmitsController < Cbv::BaseController
     respond_to do |format|
       format.html
       format.pdf do
-        return if redirect_unless_consent!(t("cbv.submits.update.consent_to_authorize_warning"))
+        next if redirect_unless_consent!(t("cbv.submits.update.consent_to_authorize_warning"))
 
         event_logger.track(TrackEvent::ApplicantDownloadedIncomePDF, request, {
           time: Time.now.to_i,

--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -80,7 +80,6 @@ class Cbv::SubmitsController < Cbv::BaseController
   def redirect_unless_consent!(warning_message)
     return false if has_consent
 
-    @cbv_flow.errors.add(:consent_to_authorized_use, :blank, message: warning_message)
     redirect_to(cbv_flow_submit_path, flash: { alert: warning_message })
     true
   end

--- a/app/app/controllers/cbv/submits_controller.rb
+++ b/app/app/controllers/cbv/submits_controller.rb
@@ -21,6 +21,8 @@ class Cbv::SubmitsController < Cbv::BaseController
     respond_to do |format|
       format.html
       format.pdf do
+        return if redirect_unless_consent!(t("cbv.submits.update.consent_to_authorize_warning"))
+
         event_logger.track(TrackEvent::ApplicantDownloadedIncomePDF, request, {
           time: Time.now.to_i,
           client_agency_id: current_agency&.id,
@@ -50,10 +52,7 @@ class Cbv::SubmitsController < Cbv::BaseController
   end
 
   def update
-    unless has_consent
-      @cbv_flow.errors.add(:consent_to_authorized_use, :blank, message: t(".consent_to_authorize_warning"))
-      return redirect_to(cbv_flow_submit_path, flash: { alert: t(".consent_to_authorize_warning") })
-    end
+    return if redirect_unless_consent!(t(".consent_to_authorize_warning"))
 
     if params[:cbv_flow] && params[:cbv_flow][:consent_to_authorized_use] == "1"
       timestamp = Time.now.to_datetime
@@ -76,6 +75,14 @@ class Cbv::SubmitsController < Cbv::BaseController
       Rails.logger.error "Aggregator report nil for #{@cbv_flow.id}. Investigate, as we didn't think it should be possible to get here because at least one account should be usable."
       redirect_to flow_navigator.income_sync_path(:synchronization_failures)
     end
+  end
+
+  def redirect_unless_consent!(warning_message)
+    return false if has_consent
+
+    @cbv_flow.errors.add(:consent_to_authorized_use, :blank, message: warning_message)
+    redirect_to(cbv_flow_submit_path, flash: { alert: warning_message })
+    true
   end
 
   def has_consent

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe Cbv::SubmitsController do
         before do
           cbv_flow.update(consented_to_authorized_use_at: nil)
         end
-        
+
         it "does not allow access to pdf" do
           get :show, format: :pdf
           expect(response).to redirect_to(cbv_flow_submit_path)

--- a/app/spec/controllers/cbv/submits_controller_spec.rb
+++ b/app/spec/controllers/cbv/submits_controller_spec.rb
@@ -281,6 +281,17 @@ RSpec.describe Cbv::SubmitsController do
         end
       end
 
+      context "when legal agreement not checked" do
+        before do
+          cbv_flow.update(consented_to_authorized_use_at: nil)
+        end
+        
+        it "does not allow access to pdf" do
+          get :show, format: :pdf
+          expect(response).to redirect_to(cbv_flow_submit_path)
+        end
+      end
+
       context "when legal agreement checked" do
         before do
           cbv_flow.update(consented_to_authorized_use_at: Time.now)


### PR DESCRIPTION
## [FFS-4596](https://jiraent.cms.gov/browse/FFS-4596)

## Changes
<!-- What was added, updated, or removed in this PR. -->
Added a guard to prevent a user from trying to load a pdf without having checked the consent checkbox.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
The PDF endpoint could render without recorded consent, causing a 500 error. This happens if a user tries to load the PDF url directly without consent. The user should be redirected back to the agreement step if trying to directly load the PDF without giving consent.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.

## AI Usage
- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.
