### PR TITLE
FFS-4525 No matching employments error should not crash pdf

### DIFF
--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -252,7 +252,7 @@ module Aggregators::AggregatorReports
       # data sets to make sure we're only using ones that match the employment ID we chose here.
       relevant_employments = employments.select { |e| e[:account_id] == account_id }
       if relevant_employments.empty?
-        Rails.logger.error("No employments found that match account_id #{account_id}")
+        Rails.logger.error("No employments found that match account_id #{account_id} out of #{employments.count} employments")
         raise NoMatchingEmploymentError, "No employments found that match account_id #{account_id}"
       end
 

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -126,7 +126,7 @@ module Aggregators::AggregatorReports
         account_id = payroll_account.aggregator_account_id
         account_report = find_account_report(account_id)
 
-        next if account_report.nil? 
+        next if account_report.nil?
 
         has_income_data = payroll_account.job_succeeded?("income")
         has_employment_data = payroll_account.job_succeeded?("employment")
@@ -155,7 +155,7 @@ module Aggregators::AggregatorReports
           account_id = payroll_account.aggregator_account_id
           account_report = find_account_report(account_id)
 
-          next if account_report.nil? 
+          next if account_report.nil?
 
           paystubs = account_report.paystubs
           gigs = account_report.gigs

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -3,6 +3,8 @@ module Aggregators::AggregatorReports
   class AggregatorReport
     include Cbv::MonthlySummaryHelper
 
+    class NoMatchingEmploymentError < StandardError; end
+
     attr_accessor :payroll_accounts, :identities, :incomes, :employments, :gigs, :paystubs, :has_fetched, :fetched_days, :reporting_date_range
 
     def initialize(payroll_accounts: [], days_to_fetch_for_w2: nil, days_to_fetch_for_gig: nil, reporting_date_range: nil)
@@ -53,7 +55,12 @@ module Aggregators::AggregatorReports
 
     AccountReportStruct = Struct.new(:identity, :income, :employment, :paystubs, :gigs)
     def find_account_report(account_id)
-      account_employment = pick_employment(@employments, @paystubs, account_id)
+      begin
+        account_employment = pick_employment(@employments, @paystubs, account_id)
+      rescue NoMatchingEmploymentError => e
+        Rails.logger.warn("Skipping account #{account_id}: #{e.message}")
+        return
+      end
       employment_filter = employment_filter_for(account_id, account_employment&.employment_matching_id)
 
       # Note that, once we filter by employment match, we do not yet have a good solution for displaying multiple
@@ -118,6 +125,9 @@ module Aggregators::AggregatorReports
       @payroll_accounts.each_with_object({}) do |payroll_account, hash|
         account_id = payroll_account.aggregator_account_id
         account_report = find_account_report(account_id)
+
+        next if account_report.nil? 
+
         has_income_data = payroll_account.job_succeeded?("income")
         has_employment_data = payroll_account.job_succeeded?("employment")
         has_identity_data = payroll_account.job_succeeded?("identity")
@@ -205,7 +215,11 @@ module Aggregators::AggregatorReports
     end
 
     def fetched_days_for_account(account_id)
-      account_employment = pick_employment(@employments, @paystubs, account_id)
+      begin
+        account_employment = pick_employment(@employments, @paystubs, account_id)
+      rescue NoMatchingEmploymentError => e
+        return @fetched_days
+      end
       return @fetched_days unless account_employment
 
       case account_employment.employment_type
@@ -236,7 +250,7 @@ module Aggregators::AggregatorReports
       relevant_employments = employments.select { |e| e[:account_id] == account_id }
       if relevant_employments.empty?
         Rails.logger.error("No employments found that match account_id #{account_id}")
-        raise "No employments found that match account_id #{account_id}"
+        raise NoMatchingEmploymentError, "No employments found that match account_id #{account_id}"
       end
 
       # Pick the employment with the latest update when considering the start_date,

--- a/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/aggregator_report.rb
@@ -154,6 +154,9 @@ module Aggregators::AggregatorReports
         .each_with_object({}) do |payroll_account, hash|
           account_id = payroll_account.aggregator_account_id
           account_report = find_account_report(account_id)
+
+          next if account_report.nil? 
+
           paystubs = account_report.paystubs
           gigs = account_report.gigs
           extracted_dates = extract_dates(paystubs, gigs)

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -226,17 +226,17 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
           expect(employer_name).to eq("Lyft Driver")
         end
 
-        it "raises an error when the wrong id is used and no employments match" do
+        it "returns nil when the wrong id is used and no employments match" do
           invalid_payroll_account = create(
             :payroll_account,
             :argyle_fully_synced,
             flow: cbv_flow,
             aggregator_account_id: "wrong-id"
           )
-          expect {
-            # Initializing the component under test
-            described_class.new(argyle_report, invalid_payroll_account).employer_name
-          }.to raise_error(RuntimeError, "No employments found that match account_id wrong-id")
+          
+          employer_name = described_class.new(argyle_report, invalid_payroll_account).employer_name
+          
+          expect(employer_name).to be_nil
         end
       end
 

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
             flow: cbv_flow,
             aggregator_account_id: "wrong-id"
           )
-          
+
           employer_name = described_class.new(argyle_report, invalid_payroll_account).employer_name
-          
+
           expect(employer_name).to be_nil
         end
       end

--- a/app/spec/components/report/payments_deductions_monthly_summary_component_spec.rb
+++ b/app/spec/components/report/payments_deductions_monthly_summary_component_spec.rb
@@ -211,10 +211,10 @@ RSpec.describe Report::PaymentsDeductionsMonthlySummaryComponent, type: :compone
         argyle_report.fetch
       end
 
-      it "raises an error without the paystubs data" do
+      it "renders without error even when paystubs failed to sync" do
         expect {
           render_inline(described_class.new(argyle_report, payroll_account, is_w2_worker: false, pay_frequency_text: "monthly"))
-        }.to raise_error(RuntimeError, "No employments found that match account_id 019571bc-2f60-3955-d972-dbadfe0913a8")
+        }.not_to raise_error
       end
     end
   end

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service 
           # income_report should not crash and should return valid data
           expect { argyle_report.income_report }.not_to raise_error
           result = argyle_report.income_report
-          
+
           # When no matching employment, that account is skipped, so employments should be empty
           expect(result[:employments]).to eq([])
           expect(result[:has_other_jobs]).to be_falsy

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -91,10 +91,12 @@ RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service 
           payroll_account.flow = cbv_flow
 
           # Override all mocks to return empty data
-          allow(argyle_service).to receive(:fetch_employments_api).and_return({ "results" => [] })
-          allow(argyle_service).to receive(:fetch_paystubs_api).and_return({ "results" => [] })
-          allow(argyle_service).to receive(:fetch_identities_api).and_return({ "results" => [] })
-          allow(argyle_service).to receive(:fetch_account_api).and_return({ "results" => [] })
+          allow(argyle_service).to receive_messages(
+            fetch_employments_api: { "results" => [] },
+            fetch_paystubs_api: { "results" => [] },
+            fetch_identities_api: { "results" => [] },
+            fetch_account_api: { "results" => [] }
+          )
           allow(argyle_service).to receive(:fetch_gigs_api).and_return(nil)
 
           argyle_report.fetch

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service 
         )
       end
 
+      context 'when employments are not found' do
+        it 'income_report does not crash when no matching employment' do
+          cbv_flow = create(:cbv_flow, has_other_jobs: false)
+          payroll_account.flow = cbv_flow
+
+          # Override all mocks to return empty data
+          allow(argyle_service).to receive(:fetch_employments_api).and_return({ "results" => [] })
+          allow(argyle_service).to receive(:fetch_paystubs_api).and_return({ "results" => [] })
+          allow(argyle_service).to receive(:fetch_identities_api).and_return({ "results" => [] })
+          allow(argyle_service).to receive(:fetch_account_api).and_return({ "results" => [] })
+          allow(argyle_service).to receive(:fetch_gigs_api).and_return(nil)
+
+          argyle_report.fetch
+
+          # income_report should not crash and should return valid data
+          expect { argyle_report.income_report }.not_to raise_error
+          result = argyle_report.income_report
+          
+          # When no matching employment, that account is skipped, so employments should be empty
+          expect(result[:employments]).to eq([])
+          expect(result[:has_other_jobs]).to be_falsy
+        end
+      end
+
       context "busy joe, an employee with multiple employments" do
         before do
           argyle_report.fetch

--- a/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/aggregator_report_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe Aggregators::AggregatorReports::AggregatorReport, type: :service 
 
           argyle_report.fetch
 
+          expect {
+            argyle_report.send(:pick_employment, argyle_report.employments, argyle_report.paystubs, account)
+          }.to raise_error(Aggregators::AggregatorReports::AggregatorReport::NoMatchingEmploymentError, /No employments found that match account_id/)
+
           # income_report should not crash and should return valid data
           expect { argyle_report.income_report }.not_to raise_error
           result = argyle_report.income_report


### PR DESCRIPTION
## [FFS-4525](https://jiraent.cms.gov/browse/FFS-4525)

## Changes
<!-- What was added, updated, or removed in this PR. -->
Added NoMatchingEmploymentError and gracefully handle pdf generation when no matching employment is found.

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
Currently it will show blank after `Employment and Payment Details` but if needed I can change it to display a message or something else.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester

<img width="793" height="1080" alt="Screenshot 2026-09-01 at 9 44 51 AM" src="https://github.com/user-attachments/assets/edf0a9c7-16a6-49f3-80a0-40ae00868fa1" />


## AI Usage
- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.


