### PR TITLE
FFS-4718: CE PDF Implementation

### DIFF
--- a/app/app/assets/stylesheets/activity_report.scss
+++ b/app/app/assets/stylesheets/activity_report.scss
@@ -1,0 +1,22 @@
+@use "uswds" as *;
+
+.activity-report__report-information {
+  th,
+  td {
+    border: 0;
+    border-bottom: units(1px) solid color("ink");
+  }
+
+  th {
+    background-color: color("white");
+  }
+}
+
+.activity-report__activity {
+  page-break-inside: avoid;
+}
+
+.activity-report__table {
+  table-layout: fixed;
+  word-break: break-word;
+}

--- a/app/app/assets/stylesheets/application.postcss.css
+++ b/app/app/assets/stylesheets/application.postcss.css
@@ -8,6 +8,7 @@
 @forward "advanced-launcher.scss";
 @forward "launcher.scss";
 @forward "document_uploads.scss";
+@forward "activity_report.scss";
 
 /* Import styling from ViewComponents */
 @forward "../../components/activity_flow_progress_indicator/activity_flow_progress_indicator.scss";

--- a/app/app/components/document_uploads_component.html.erb
+++ b/app/app/components/document_uploads_component.html.erb
@@ -12,10 +12,14 @@
     <% documents.each do |document| %>
       <li class="document-uploads__item">
         <div class="document-uploads__file">
-          <svg class="usa-icon document-uploads__icon" aria-hidden="true" focusable="false" role="img">
-            <use href="<%= icon_path %>"></use>
-          </svg>
-          <span class="document-uploads__filename">
+          <% if pdf %>
+            <%= image_tag pdf_icon_path, class: "usa-icon document-uploads__icon text-middle", alt: "" %>
+          <% else %>
+            <svg class="usa-icon document-uploads__icon" aria-hidden="true" focusable="false" role="img">
+              <use href="<%= icon_path %>"></use>
+            </svg>
+          <% end %>
+          <span class="<%= class_names("document-uploads__filename", "text-middle": pdf) %>">
             <%= filename_for(document) %>
           </span>
         </div>

--- a/app/app/components/document_uploads_component.rb
+++ b/app/app/components/document_uploads_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DocumentUploadsComponent < ViewComponent::Base
-  def initialize(documents:, show_remove_file: false, heading_level: 2, edit_path: nil, edit_label: nil, full_width: false, previously_uploaded: false)
+  def initialize(documents:, show_remove_file: false, heading_level: 2, edit_path: nil, edit_label: nil, full_width: false, previously_uploaded: false, pdf: false)
     @documents = documents
     @show_remove_file = show_remove_file
     @heading_level = heading_level
@@ -9,15 +9,17 @@ class DocumentUploadsComponent < ViewComponent::Base
     @edit_label = edit_label
     @full_width = full_width
     @previously_uploaded = previously_uploaded
+    @pdf = pdf
   end
 
   private
 
-  attr_reader :documents, :heading_level, :edit_path
+  attr_reader :documents, :heading_level, :edit_path, :pdf
 
   def section_class
     classes = [ "document-uploads" ]
     classes << "document-uploads--full-width" if @full_width
+    classes << "margin-bottom-0" if pdf
     classes.join(" ")
   end
 
@@ -46,5 +48,9 @@ class DocumentUploadsComponent < ViewComponent::Base
 
   def icon_path
     helpers.uswds_sprite_icon_href("file_present")
+  end
+
+  def pdf_icon_path
+    helpers.wicked_pdf_asset_base64("@uswds/uswds/dist/img/usa-icons/file_present.svg")
   end
 end

--- a/app/app/controllers/activities/submit_controller.rb
+++ b/app/app/controllers/activities/submit_controller.rb
@@ -9,11 +9,10 @@ class Activities::SubmitController < Activities::BaseController
   private
 
   def render_pdf
-    @community_service_activities = @flow.volunteering_activities.published.order(date: :desc, created_at: :desc)
-    @work_programs_activities = @flow.job_training_activities.published.order(created_at: :desc)
-    @education_activities = @flow.education_activities.published.order(created_at: :desc)
-    @submission_timestamp = submission_timestamp
-    @total_hours = progress_calculator.overall_result.total_hours
+    @report = ActivityPdfReport.new(
+      flow: @flow,
+      caseworker: internal_environment? && params[:is_caseworker] == "true"
+    )
 
     render pdf: pdf_filename,
       layout: "pdf",
@@ -22,20 +21,16 @@ class Activities::SubmitController < Activities::BaseController
       disposition: "inline"
   end
 
-  def submission_timestamp
-    @flow.completed_at || Time.zone.now
-  end
-
   def pdf_filename
     "HR1_Report_#{Time.zone.today.strftime("%Y-%m-%d")}"
   end
 
   def pdf_margins
     {
-      top: 10,
-      bottom: 10,
-      left: 10,
-      right: 10
+      top: 8,
+      bottom: 8,
+      left: 0,
+      right: 0
     }
   end
 end

--- a/app/app/controllers/activities/submit_controller.rb
+++ b/app/app/controllers/activities/submit_controller.rb
@@ -9,6 +9,10 @@ class Activities::SubmitController < Activities::BaseController
   private
 
   def render_pdf
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "#{1.year.ago}"
+
     @report = ActivityPdfReport.new(
       flow: @flow,
       caseworker: internal_environment? && params[:is_caseworker] == "true"

--- a/app/app/services/activity_pdf_report.rb
+++ b/app/app/services/activity_pdf_report.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+class ActivityPdfReport
+  EMPTY_INCOME_SUMMARY = {
+    accrued_gross_earnings: 0,
+    paychecks_count: 0,
+    total_gig_hours: 0,
+    total_mileage: 0,
+    total_w2_hours: 0
+  }.freeze
+
+  EmploymentEntry = Struct.new(:source, :record, keyword_init: true) do
+    def payroll?
+      source == :payroll
+    end
+  end
+
+  EducationEntry = Struct.new(:activity, :school_name, :enrollment_terms, :comments, :documents, keyword_init: true)
+
+  attr_reader :flow, :report_created_at
+
+  def initialize(flow:, caseworker:, report_created_at: Time.current)
+    @flow = flow
+    @caseworker = caseworker
+    @report_created_at = report_created_at
+  end
+
+  def caseworker?
+    @caseworker
+  end
+
+  def agency_name
+    I18n.t("shared.agency_full_name.#{flow.cbv_applicant.client_agency_id}")
+  end
+
+  def client_name
+    applicant = flow.cbv_applicant
+    [ applicant.first_name, applicant.middle_name, applicant.last_name ].compact_blank.join(" ").presence
+  end
+
+  def employment_entries
+    @employment_entries ||= (
+      payroll_accounts.map { |account| EmploymentEntry.new(source: :payroll, record: account) } +
+      employment_activities.map { |activity| EmploymentEntry.new(source: :self_attested, record: activity) }
+    ).sort_by { |entry| entry.record.created_at }
+  end
+
+  def education_entries
+    @education_entries ||= education_activities.flat_map do |activity|
+      documents = document_names_for(activity)
+
+      if activity.fully_self_attested?
+        EducationEntry.new(
+          activity: activity,
+          school_name: activity.school_name,
+          enrollment_terms: [],
+          comments: activity.additional_comments,
+          documents: documents
+        )
+      else
+        term_groups = grouped_enrollment_terms(activity)
+        term_groups = [ [] ] if term_groups.empty?
+
+        term_groups.map do |terms|
+          EducationEntry.new(
+            activity: activity,
+            school_name: terms.first&.school_name || activity.review_description_school_names,
+            enrollment_terms: terms,
+            comments: activity.additional_comments,
+            documents: documents
+          )
+        end
+      end
+    end
+  end
+
+  def community_service_activities
+    @community_service_activities ||= flow.volunteering_activities.published.order(:created_at)
+  end
+
+  def work_program_activities
+    @work_program_activities ||= flow.job_training_activities.published.order(:created_at)
+  end
+
+  def included_activity_types
+    types = []
+    types << :employment if employment_entries.any?
+    types << :education if education_entries.any?
+    types << :community_service if community_service_activities.any?
+    types << :work_programs if work_program_activities.any?
+    types
+  end
+
+  def employment_summary_for(payroll_account)
+    employment_summaries.fetch(payroll_account.aggregator_account_id, {})
+  end
+
+  def monthly_income_summaries_for(payroll_account)
+    summaries = monthly_income_summaries.fetch(payroll_account.aggregator_account_id, {})
+
+    flow.reporting_months.map do |month|
+      [ month.beginning_of_month, summaries.fetch(month.strftime("%Y-%m"), EMPTY_INCOME_SUMMARY) ]
+    end
+  end
+
+  def payroll_details_for(payroll_account)
+    @payroll_details ||= {}
+    return @payroll_details[payroll_account.id] if @payroll_details.key?(payroll_account.id)
+
+    report = detailed_income_report
+    account_id = payroll_account.aggregator_account_id
+    has_employment = report.has_fetched? && report.employments.any? do |employment|
+      employment.account_id == account_id
+    end
+    details = report.find_account_report(account_id) if has_employment
+    details.paystubs = details.paystubs.select { |paystub| paystub_in_reporting_window?(paystub) } if details
+    @payroll_details[payroll_account.id] = details
+  end
+
+  def activity_month_records(records)
+    records_by_month = records.index_by { |record| record.month.beginning_of_month }
+
+    flow.reporting_months.map do |month|
+      month = month.beginning_of_month
+      [ month, records_by_month[month] ]
+    end
+  end
+
+  def document_names_for(activity)
+    activity.document_uploads_attachments.includes(:blob).order(:id).map do |attachment|
+      if caseworker?
+        caseworker_documents_by_attachment_id.fetch(attachment.id).file_name
+      else
+        attachment.filename.to_s
+      end
+    end
+  end
+
+  private
+
+  def grouped_enrollment_terms(activity)
+    terms = activity.nsc_enrollment_terms
+      .select { |term| term.within_reporting_window?(flow.reporting_window_range) }
+      .sort_by { |term| [ term.term_begin, term.term_end ] }
+
+    terms.group_by { |term| term.school_name.to_s.strip.downcase }.values
+  end
+
+  def education_activities
+    @education_activities ||= flow.education_activities.published.order(:created_at).reject do |activity|
+      activity.validated? && activity.nsc_enrollment_terms.none?
+    end
+  end
+
+  def paystub_in_reporting_window?(paystub)
+    pay_date = paystub.pay_date
+    return false unless pay_date
+
+    flow.reporting_window_range.cover?(Date.parse(pay_date))
+  end
+
+  def detailed_income_report
+    return @detailed_income_report if defined?(@detailed_income_report)
+
+    @detailed_income_report = AggregatorReportFetcher.new(flow).report
+  end
+
+  def payroll_accounts
+    @payroll_accounts ||= flow.payroll_accounts.published.where(synchronization_status: :succeeded)
+  end
+
+  def employment_activities
+    @employment_activities ||= flow.employment_activities.published
+  end
+
+  def employment_summaries
+    @employment_summaries ||= flow.employment_summaries_by_account_with_fallback
+  end
+
+  def monthly_income_summaries
+    @monthly_income_summaries ||= flow.monthly_summaries_by_account_with_fallback
+  end
+
+  def caseworker_documents_by_attachment_id
+    @caseworker_documents_by_attachment_id ||= ActivityDocumentsService.new(flow).all.index_by do |document|
+      document.attachment.id
+    end
+  end
+end

--- a/app/app/services/transmitters/activity_s3_transmitter.rb
+++ b/app/app/services/transmitters/activity_s3_transmitter.rb
@@ -2,7 +2,7 @@ require "tmpdir"
 
 class Transmitters::ActivityS3Transmitter
   TRANSMISSION_METHOD = "encrypted_s3"
-  PDF_MARGIN = { top: 10, bottom: 10, left: 10, right: 10 }.freeze
+  PDF_MARGIN = { top: 8, bottom: 8, left: 0, right: 0 }.freeze
 
   def initialize(activity_flow, current_agency)
     @activity_flow = activity_flow
@@ -52,21 +52,14 @@ class Transmitters::ActivityS3Transmitter
   end
 
   def pdf_content
-    assigns = {
-      flow: @activity_flow,
-      community_service_activities: @activity_flow.volunteering_activities.published.order(date: :desc, created_at: :desc),
-      work_programs_activities: @activity_flow.job_training_activities.published.order(created_at: :desc),
-      education_activities: @activity_flow.education_activities.published.order(created_at: :desc),
-      submission_timestamp: @activity_flow.completed_at,
-      total_hours: ActivityFlowProgressCalculator.new(@activity_flow).overall_result.total_hours
-    }
-
     html = I18n.with_locale(:en) do
       Activities::SubmitController.new.render_to_string(
         template: "activities/submit/show",
         formats: [ :pdf ],
         layout: "layouts/pdf",
-        assigns: assigns
+        assigns: {
+          report: ActivityPdfReport.new(flow: @activity_flow, caseworker: true)
+        }
       )
     end
 

--- a/app/app/views/activities/submit/_detail_activity.pdf.erb
+++ b/app/app/views/activities/submit/_detail_activity.pdf.erb
@@ -1,0 +1,40 @@
+<section class="activity-report__activity">
+  <% if section_heading.present? %>
+    <h2>
+      <%= section_heading %>
+    </h2>
+  <% end %>
+
+  <h3 class="bg-base-lighter border-1px border-ink font-heading-sm margin-top-3 margin-bottom-0 padding-2">
+    <%= title %>
+  </h3>
+
+  <% if comments.present? %>
+    <div class="usa-summary-box font-sans-3xs margin-y-2">
+      <div class="usa-summary-box__body">
+        <h4 class="usa-summary-box__heading font-sans-3xs line-height-sans-5">
+          <%= t("activities.submit.pdf.activity_comments") %>
+        </h4>
+        <p class="usa-summary-box__text">
+          <%= comments %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+
+  <% if details.any? %>
+    <%= render(TableComponent.new(
+      class_names: "activity-report__table font-sans-3xs margin-0 margin-top-2 maxw-none"
+    )) do |table| %>
+      <%= table.with_header_cell(scope: "col").with_content(information_heading) %>
+      <%= table.with_header_cell(scope: "col").with_content(t("shared.table_headers.your_details")) %>
+
+      <% details.each do |label, value| %>
+        <%= table.with_row do |row| %>
+          <%= row.with_data_cell(is_header: true, scope: "row").with_content(label) %>
+          <%= row.with_data_cell.with_content(value.presence || t("activities.submit.pdf.not_provided")) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</section>

--- a/app/app/views/activities/submit/_payroll_payments.pdf.erb
+++ b/app/app/views/activities/submit/_payroll_payments.pdf.erb
@@ -1,0 +1,56 @@
+<section class="margin-top-2">
+  <% if w2 %>
+    <% payroll_details.paystubs.each_with_index do |paystub, index| %>
+      <div class="activity-report__activity">
+        <%= render(TableComponent.new(
+          class_names: "activity-report__table font-sans-3xs margin-0 margin-bottom-2 maxw-none"
+        )) do |table| %>
+          <%= table.with_header_cell(scope: "col").with_content(
+            t("activities.submit.pdf.payment_information", number: index + 1)
+          ) %>
+          <%= table.with_header_cell(scope: "col").with_content(t("shared.table_headers.your_details")) %>
+
+          <%= table.with_data_point(:pay_date, paystub.pay_date) %>
+          <%= table.with_data_point(:pay_gross, paystub.gross_pay_amount) %>
+          <% if paystub.hours.present? %>
+            <%= table.with_data_point(:number_of_hours_worked, paystub.hours) %>
+          <% else %>
+            <%= table.with_row do |row| %>
+              <% row.with_data_cell(is_header: true, scope: "row")
+                .with_content(t("cbv.payment_details.show.number_of_hours_worked")) %>
+              <% row.with_data_cell.with_content(not_provided) %>
+            <% end %>
+          <% end %>
+          <%= table.with_row do |row| %>
+            <% row.with_data_cell(is_header: true, scope: "row")
+              .with_content(t("activities.submit.pdf.hourly_wage_hours_paid")) %>
+            <% row.with_data_cell.with_content(
+              payroll_details.income&.compensation_amount.present? ?
+                format_money(payroll_details.income.compensation_amount) :
+                not_provided
+            ) %>
+          <% end %>
+          <% paystub.deductions.select { |deduction| deduction.amount.to_f.nonzero? }.each do |deduction| %>
+            <%= table.with_data_point(:deduction, deduction.category, deduction.tax || "unknown", deduction.amount) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="activity-report__activity">
+      <h4 class="margin-bottom-1">
+        <%= t("components.report.monthly_summary_table.payments_from_header", employer_name: employer_name) %>
+      </h4>
+      <p class="margin-y-1">
+        <%= t("activities.submit.pdf.gig_payments_description", employer_name: employer_name) %>
+      </p>
+      <ul class="usa-list margin-top-1">
+        <% payroll_details.paystubs.each do |paystub| %>
+          <li>
+            <%= format_date(paystub.pay_date, "%m/%d/%Y") %> - <%= format_money(paystub.gross_pay_amount) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</section>

--- a/app/app/views/activities/submit/_summary_activity.pdf.erb
+++ b/app/app/views/activities/submit/_summary_activity.pdf.erb
@@ -1,0 +1,36 @@
+<section>
+  <% if section_heading.present? %>
+    <h2>
+      <%= section_heading %>
+    </h2>
+  <% end %>
+
+  <h3 class="bg-base-lighter border-1px border-ink font-heading-sm margin-top-3 margin-bottom-0 padding-2">
+    <%= title %>
+  </h3>
+
+  <%= render(TableComponent.new(
+    multi_column: columns.length > 2,
+    class_names: "activity-report__table border-top-0 font-sans-3xs margin-0 maxw-none"
+  )) do |table| %>
+    <% columns.each do |column| %>
+      <%= table.with_header_cell(scope: "col").with_content(column) %>
+    <% end %>
+
+    <% rows.each do |cells| %>
+      <%= table.with_row do |row| %>
+        <% cells.each_with_index do |cell, index| %>
+          <%= row.with_data_cell(is_header: index.zero?, scope: ("row" if index.zero?)).with_content(cell) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if documents.any? %>
+    <%= render DocumentUploadsComponent.new(
+      documents: documents.map { |filename| { filename: filename } },
+      heading_level: 4,
+      pdf: true
+    ) %>
+  <% end %>
+</section>

--- a/app/app/views/activities/submit/show.pdf.erb
+++ b/app/app/views/activities/submit/show.pdf.erb
@@ -1,155 +1,431 @@
 <% not_provided = t("activities.submit.pdf.not_provided") %>
+<% flow = @report.flow %>
+<% agency_name = @report.agency_name %>
+<% activity_types = @report.included_activity_types.map { |type|
+  t("activities.submit.pdf.activity_types.#{type}")
+}.to_sentence %>
 
 <% content_for :title, t("activities.submit.pdf.title") %>
+<% content_for :pdf_html_class, "bg-white" %>
+<% content_for :pdf_section_class, "padding-x-8" %>
 
-<h1>
-  <%= t("activities.submit.pdf.heading") %>
-</h1>
-<p>
-  <%= t("activities.submit.pdf.description") %>
-</p>
+<div class="font-sans-3xs">
+  <header>
+    <p class="font-heading-sm line-height-sans-2 margin-0 text-bold">
+      <span class="text-primary">
+        <%= t("activities.submit.pdf.product_name") %>
+      </span>
+      <span aria-hidden="true">
+        |
+      </span>
+      <span>
+        <%= agency_name %>
+      </span>
+    </p>
 
-<%= render TableComponent.new do |table| %>
-  <%= table.with_header do %>
+    <h1 class="margin-top-0 margin-bottom-1 padding-top-2">
+      <%= t("activities.submit.pdf.heading") %>
+    </h1>
+
+    <p class="margin-top-1">
+      <%= t(
+        "activities.submit.pdf.description",
+        activity_types: activity_types,
+        agency_name: agency_name
+      ) %>
+    </p>
+  </header>
+
+  <section class="margin-top-4">
     <h2>
-      <%= t("activities.submit.pdf.report_overview") %>
+      <%= t(
+        "activities.submit.pdf.client_and_report_information",
+        client_name: @report.client_name.presence || not_provided
+      ) %>
     </h2>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.reporting_window")) %>
-    <% row.with_data_cell.with_content(@flow.reporting_window_display) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.confirmation_code")) %>
-    <% row.with_data_cell.with_content(@flow.confirmation_code) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.submitted_at")) %>
-    <% row.with_data_cell.with_content(l(@submission_timestamp, format: :long)) %>
-  <% end %>
-<% end %>
 
-<%= render TableComponent.new do |table| %>
-  <%= table.with_header do %>
-    <h2>
-      <%= t("activities.submit.pdf.summary_heading") %>
-    </h2>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.community_service_count")) %>
-    <% row.with_data_cell.with_content(@community_service_activities.size) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.work_programs_count")) %>
-    <% row.with_data_cell.with_content(@work_programs_activities.size) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.education_count")) %>
-    <% row.with_data_cell.with_content(@education_activities.size) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.income_activities")) %>
-    <% row.with_data_cell.with_content(@flow.payroll_accounts.size) %>
-  <% end %>
-  <%= table.with_row do |row| %>
-    <% row.with_data_cell.with_content(t("activities.submit.pdf.total_hours")) %>
-    <% row.with_data_cell.with_content(@total_hours) %>
-  <% end %>
-<% end %>
+    <table class="activity-report__report-information activity-report__table width-full">
+      <tbody>
+        <tr>
+          <th scope="row">
+            <%= t("activities.submit.pdf.date_range") %>
+          </th>
+          <td>
+            <%= t(
+              "activities.submit.pdf.date_range_value",
+              start_date: l(flow.reporting_window_range.begin, format: :long),
+              end_date: l(flow.reporting_window_range.end, format: :long)
+            ) %>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <%= t("activities.submit.pdf.confirmation_code") %>
+          </th>
+          <td>
+            <%= flow.confirmation_code.presence || not_provided %>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <%= t("activities.submit.pdf.report_created_at") %>
+          </th>
+          <td>
+            <%= l(@report.report_created_at.to_date, format: :long) %>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <%= t("activities.submit.pdf.agreement_consent_timestamp") %>
+          </th>
+          <td>
+            <% if flow.completed_at.present? %>
+              <%= l(flow.completed_at.utc, format: "%B %-d, %Y %H:%M:%S UTC") %>
+            <% else %>
+              <%= not_provided %>
+            <% end %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 
-<h2>
-<%= t("activities.education.title") %>
-</h2>
+  <% if @report.employment_entries.any? %>
+    <section class="margin-top-4">
+      <% @report.employment_entries.each_with_index do |entry, index| %>
+        <% if entry.payroll? %>
+          <% employment = @report.employment_summary_for(entry.record) %>
+          <% employer_name = employment[:employer_name].presence || not_provided %>
+          <% employment_type = (employment[:employment_type] || "w2").to_sym %>
+          <% if employment_type == :gig %>
+            <% monthly_summaries = @report.monthly_income_summaries_for(entry.record) %>
+            <% show_mileage = monthly_summaries.any? { |_month, summary| summary[:total_mileage].to_f.positive? } %>
+            <% columns = [
+              t("activities.summary.employment.month"),
+              t("activities.summary.employment.gross_income")
+            ] %>
+            <% columns << t("activities.submit.pdf.mileage_expenses") if show_mileage %>
+            <% columns << t("activities.summary.employment.community_engagement_hours") %>
+            <% rows = monthly_summaries.map do |month, summary|
+              row = [
+                l(month, format: :month_year),
+                format_money(summary[:accrued_gross_earnings])
+              ]
+              if show_mileage
+                cents_per_mile = federal_cents_per_mile(month.year)
+                miles = summary[:total_mileage].to_f.round
+                row << t(
+                  "activities.submit.pdf.mileage_expense_value",
+                  amount: format_money(miles * cents_per_mile),
+                  rate: format_money_with_subcents(cents_per_mile),
+                  miles: miles
+                )
+              end
+              row << format_decimal_amount(summary[:total_gig_hours])
+            end %>
+          <% else %>
+            <% columns = [
+              t("activities.summary.employment.month"),
+              t("activities.summary.employment.gross_income"),
+              t("activities.submit.pdf.number_of_paychecks"),
+              t("activities.submit.pdf.total_hours_worked")
+            ] %>
+            <% rows = @report.monthly_income_summaries_for(entry.record).map do |month, summary|
+              [
+                l(month, format: :month_year),
+                format_money(summary[:accrued_gross_earnings]),
+                summary[:paychecks_count],
+                format_decimal_amount(summary[:total_w2_hours])
+              ]
+            end %>
+          <% end %>
+          <% documents = [] %>
+        <% else %>
+          <% activity = entry.record %>
+          <% employer_name = activity.employer_name %>
+          <% columns = [
+            t("activities.summary.employment.month"),
+            t("activities.summary.employment.gross_income"),
+            t("activities.summary.employment.community_engagement_hours")
+          ] %>
+          <% rows = @report.activity_month_records(activity.employment_activity_months).map do |month, activity_month|
+            [
+              l(month, format: :month_year),
+              activity_month ? number_to_currency(activity_month.gross_income) : not_provided,
+              activity_month ? format_decimal_amount(activity_month.hours) : not_provided
+            ]
+          end %>
+          <% documents = @report.document_names_for(activity) %>
+        <% end %>
 
-<% if @education_activities.any? %>
-  <% @education_activities.each do |education_activity| %>
-    <% education_activity.nsc_enrollment_terms.each do |enrollment_term| %>
-      <%= render(EnrollmentTermTableComponent.new(nsc_enrollment_term: enrollment_term)) %>
-    <% end %>
-
-    <% if education_activity.additional_comments.present? %>
-      <h3><%= t("activities.summaries.show.additional_comments") %></h3>
-      <p><%= education_activity.additional_comments %></p>
-    <% end %>
-  <% end %>
-<% else %>
-  <%= t("activities.submit.pdf.no_education") %>
-<% end %>
-
-<h2>
-  <%= t("activities.submit.pdf.community_service_section") %>
-</h2>
-<% if @community_service_activities.any? %>
-  <%= render TableComponent.new(multi_column: true) do |table| %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.organization_name")) %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.hours")) %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.date")) %>
-    <% @community_service_activities.each do |activity| %>
-      <% date_value = activity.date ? l(activity.date) : not_provided %>
-      <%= table.with_row do |row| %>
-        <% row.with_data_cell.with_content(activity.organization_name.presence || not_provided) %>
-        <% row.with_data_cell.with_content(activity.volunteering_activity_months.sum(:hours)) %>
-        <% row.with_data_cell.with_content(date_value) %>
+        <%= render "activities/submit/summary_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.employment_summary") : nil,
+          title: t("activities.submit.pdf.employer_title", number: index + 1, name: employer_name),
+          columns: columns,
+          rows: rows,
+          documents: documents %>
       <% end %>
-    <% end %>
+    </section>
   <% end %>
-<% else %>
-  <p>
-    <%= t("activities.submit.pdf.no_community_service") %>
-  </p>
-<% end %>
 
-<h2>
-  <%= t("activities.submit.pdf.work_programs_section") %>
-</h2>
-<% if @work_programs_activities.any? %>
-  <%= render TableComponent.new(multi_column: true) do |table| %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.program_name")) %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.organization_address")) %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.submit.pdf.hours")) %>
-    <% @work_programs_activities.each do |activity| %>
-      <% total_hours = activity.job_training_activity_months.sum(:hours) %>
-      <%= table.with_row do |row| %>
-        <% row.with_data_cell.with_content(activity.program_name.presence || not_provided) %>
-        <% row.with_data_cell.with_content(activity.organization_address.presence || not_provided) %>
-        <% row.with_data_cell.with_content(total_hours) %>
+  <% if @report.education_entries.any? %>
+    <section class="margin-top-4">
+      <% @report.education_entries.each_with_index do |entry, index| %>
+        <% activity = entry.activity %>
+        <% if activity.fully_self_attested? %>
+          <% columns = [
+            t("activities.summary.education.month"),
+            t("activities.summary.education.credit_hours"),
+            t("activities.summary.education.community_engagement_hours")
+          ] %>
+          <% rows = @report.activity_month_records(activity.education_activity_months).map do |month, activity_month|
+            [
+              l(month, format: :month_year),
+              activity_month ? format_decimal_amount(activity_month.hours) : not_provided,
+              activity_month ? format_decimal_amount(activity.community_engagement_hours(activity_month.hours)) : not_provided
+            ]
+          end %>
+        <% else %>
+          <% enrollment_terms = entry.enrollment_terms %>
+          <% show_credit_hours = enrollment_terms.any?(&:less_than_half_time?) %>
+          <% columns = [
+            t("activities.education.review.term"),
+            t("components.enrollment_term_table_component.enrollment_status")
+          ] %>
+          <% if show_credit_hours %>
+            <% columns += [
+              t("activities.summary.education.credit_hours"),
+              t("activities.summary.education.community_engagement_hours")
+            ] %>
+          <% end %>
+          <% rows = enrollment_terms.map do |term|
+            row = [
+              t(
+                "activities.submit.pdf.term_date_range",
+                start_date: format_date(term.term_begin),
+                end_date: format_date(term.term_end)
+              ),
+              term.enrollment_status_display
+            ]
+            if show_credit_hours
+              if term.less_than_half_time?
+                credit_hours = activity.review_term_credit_hours(term)
+                row += [
+                  format_decimal_amount(credit_hours),
+                  format_decimal_amount(activity.community_engagement_hours(credit_hours))
+                ]
+              else
+                row += [ t("shared.not_applicable"), t("shared.not_applicable") ]
+              end
+            end
+            row
+          end %>
+        <% end %>
+
+        <%= render "activities/submit/summary_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.education_summary") : nil,
+          title: t(
+            "activities.submit.pdf.institution_title",
+            number: index + 1,
+            name: entry.school_name.presence || not_provided
+          ),
+          columns: columns,
+          rows: rows,
+          documents: entry.documents %>
       <% end %>
-    <% end %>
+    </section>
   <% end %>
-<% else %>
-  <p>
-    <%= t("activities.submit.pdf.no_work_programs") %>
-  </p>
-<% end %>
 
-<h2>
-  <%= t("activities.submit.pdf.income_activities") %>
-</h2>
-<% if @flow.payroll_accounts.any? %>
-  <%= render TableComponent.new do |table| %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.employment.account_id")) %>
-    <%= table.with_header_cell(colspan: 1)
-           .with_content(t("activities.employment.synchronization_status")) %>
-    <% @flow.payroll_accounts.each do |payroll_account| %>
-      <%= table.with_row do |row| %>
-        <% row.with_data_cell.with_content(payroll_account.aggregator_account_id) %>
-        <% row.with_data_cell.with_content(payroll_account.synchronization_status) %>
+  <% if @report.community_service_activities.any? %>
+    <section class="margin-top-4">
+      <% @report.community_service_activities.each_with_index do |activity, index| %>
+        <% rows = @report.activity_month_records(activity.volunteering_activity_months).map do |month, activity_month|
+          [
+            l(month, format: :month_year),
+            activity_month ? format_decimal_amount(activity_month.hours) : not_provided
+          ]
+        end %>
+        <%= render "activities/submit/summary_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.community_service_summary") : nil,
+          title: t(
+            "activities.submit.pdf.organization_title",
+            number: index + 1,
+            name: activity.organization_name.presence || not_provided
+          ),
+          columns: [
+            t("activities.summary.community_service.month"),
+            t("activities.summary.community_service.community_engagement_hours")
+          ],
+          rows: rows,
+          documents: @report.document_names_for(activity) %>
       <% end %>
-    <% end %>
+    </section>
   <% end %>
-<% else %>
-  <p>
-    <%= t("activities.submit.pdf.no_income") %>
-  </p>
-<% end %>
 
-<p>
-  <%= t("activities.submit.pdf.disclaimer") %>
-</p>
+  <% if @report.work_program_activities.any? %>
+    <section class="margin-top-4">
+      <% @report.work_program_activities.each_with_index do |activity, index| %>
+        <% rows = @report.activity_month_records(activity.job_training_activity_months).map do |month, activity_month|
+          [
+            l(month, format: :month_year),
+            activity_month ? format_decimal_amount(activity_month.hours) : not_provided
+          ]
+        end %>
+        <%= render "activities/submit/summary_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.work_program_summary") : nil,
+          title: t(
+            "activities.submit.pdf.organization_title",
+            number: index + 1,
+            name: activity.program_name
+          ),
+          columns: [
+            t("activities.summary.job_training.month"),
+            t("activities.summary.job_training.community_engagement_hours")
+          ],
+          rows: rows,
+          documents: @report.document_names_for(activity) %>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if @report.employment_entries.any? %>
+    <section class="margin-top-4">
+      <% @report.employment_entries.each_with_index do |entry, index| %>
+        <% if entry.payroll? %>
+          <% employment = @report.employment_summary_for(entry.record) %>
+          <% employment_type = (employment[:employment_type] || "w2").to_sym %>
+          <% payroll_details = @report.payroll_details_for(entry.record) %>
+          <% employer_name = employment[:employer_name].presence || not_provided %>
+          <% details = [
+            [ t("activities.summary.employment.address"), employment[:employer_address] ],
+            [
+              t("activities.summary.employment.contact_phone"),
+              number_to_phone(employment[:employer_phone_number], area_code: true)
+            ]
+          ] %>
+          <% if employment_type == :w2 %>
+            <% income = payroll_details&.income %>
+            <% pay_frequency = translate_aggregator_value("payment_frequencies", income&.pay_frequency) %>
+            <% details += [
+              [ t("activities.submit.pdf.pay_period_frequency"), pay_frequency ],
+              [ t("activities.submit.pdf.employment_status"), employment[:employment_status] ]
+            ] %>
+          <% end %>
+          <% comments = entry.record.additional_information %>
+        <% else %>
+          <% activity = entry.record %>
+          <% employer_name = activity.employer_name %>
+          <% details = [
+            [ t("activities.summary.employment.address"), activity.formatted_address ]
+          ] %>
+          <% unless activity.is_self_employed %>
+            <% details += [
+              [ t("activities.summary.employment.contact_name"), activity.contact_name ],
+              [ t("activities.summary.employment.contact_email"), activity.contact_email ],
+              [
+                t("activities.summary.employment.contact_phone"),
+                number_to_phone(activity.contact_phone_number, area_code: true)
+              ]
+            ] %>
+          <% end %>
+          <% comments = activity.additional_comments %>
+        <% end %>
+
+        <%= render "activities/submit/detail_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.employment_details") : nil,
+          title: t("activities.submit.pdf.employer_title", number: index + 1, name: employer_name),
+          comments: comments,
+          information_heading: t("shared.table_headers.employer_information"),
+          details: details %>
+
+        <% if entry.payroll? && payroll_details&.paystubs&.any? %>
+          <%= render "activities/submit/payroll_payments",
+            employer_name: employer_name,
+            not_provided: not_provided,
+            payroll_details: payroll_details,
+            w2: employment_type == :w2 %>
+        <% end %>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if @report.education_entries.any? %>
+    <section class="margin-top-4">
+      <% @report.education_entries.each_with_index do |entry, index| %>
+        <% activity = entry.activity %>
+        <% education_details = [] %>
+        <% if activity.fully_self_attested? %>
+          <% education_details = [
+            [ t("activities.submit.pdf.address"), activity.formatted_address ],
+            [ t("activities.submit.pdf.school_contact_name"), activity.contact_name ],
+            [ t("activities.submit.pdf.school_contact_email"), activity.contact_email ],
+            [
+              t("activities.submit.pdf.school_contact_phone_number"),
+              number_to_phone(activity.contact_phone_number, area_code: true)
+            ]
+          ] %>
+        <% end %>
+        <%= render "activities/submit/detail_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.education_details") : nil,
+          title: t(
+            "activities.submit.pdf.institution_title",
+            number: index + 1,
+            name: entry.school_name.presence || not_provided
+          ),
+          comments: entry.comments,
+          information_heading: t("activities.submit.pdf.institution_information"),
+          details: education_details %>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if @report.community_service_activities.any? %>
+    <section class="margin-top-4">
+      <% @report.community_service_activities.each_with_index do |activity, index| %>
+        <%= render "activities/submit/detail_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.community_service_details") : nil,
+          title: t(
+            "activities.submit.pdf.organization_title",
+            number: index + 1,
+            name: activity.organization_name.presence || not_provided
+          ),
+          comments: activity.additional_comments,
+          information_heading: t("activities.submit.pdf.organization_information"),
+          details: [
+            [ t("activities.submit.pdf.address"), activity.formatted_address ],
+            [ t("activities.submit.pdf.organization_contact_name"), activity.coordinator_name ],
+            [ t("activities.submit.pdf.organization_contact_email"), activity.coordinator_email ],
+            [
+              t("activities.submit.pdf.organization_contact_phone_number"),
+              number_to_phone(activity.coordinator_phone_number, area_code: true)
+            ]
+          ] %>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if @report.work_program_activities.any? %>
+    <section class="margin-top-4">
+      <% @report.work_program_activities.each_with_index do |activity, index| %>
+        <%= render "activities/submit/detail_activity",
+          section_heading: index.zero? ? t("activities.submit.pdf.work_program_details") : nil,
+          title: t(
+            "activities.submit.pdf.organization_title",
+            number: index + 1,
+            name: activity.program_name
+          ),
+          comments: activity.additional_comments,
+          information_heading: t("activities.submit.pdf.organization_information"),
+          details: [
+            [ t("activities.submit.pdf.address"), activity.formatted_address ],
+            [ t("activities.submit.pdf.organization_contact_name"), activity.contact_name ],
+            [ t("activities.submit.pdf.organization_contact_email"), activity.contact_email ],
+            [
+              t("activities.submit.pdf.organization_contact_phone_number"),
+              number_to_phone(activity.contact_phone_number, area_code: true)
+            ]
+          ] %>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/app/app/views/layouts/pdf.pdf.erb
+++ b/app/app/views/layouts/pdf.pdf.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="<%= I18n.locale %>" class="<%= content_for(:pdf_html_class) %>">
   <head>
     <meta charset="utf-8" >
     <title><%= content_for?(:title) ? yield(:title) : t("cbv.submits.show.pdf.client.header") %></title>
@@ -13,7 +13,7 @@
   <body class="wkhtmltopdf">
     <div id="root">
       <main id="main-content">
-        <section class="grid-container usa-section">
+        <section class="<%= content_for?(:pdf_section_class) ? yield(:pdf_section_class) : "grid-container usa-section" %>">
           <%= yield %>
         </section>
       </main>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -256,7 +256,6 @@ en:
         header: Let's verify your student enrollment
         last_name: Last name
     employment:
-      account_id: Account ID
       add_your_work:
         show:
           description: If you held multiple jobs during the reporting period, you'll need to add each job separately.
@@ -301,7 +300,6 @@ en:
         name: Name
         save: Save and add to my report
         title: Review your employment information for %{employer_name}
-      synchronization_status: Status
       title: Employment
       title_singular: Employment
     employment_info:
@@ -447,32 +445,53 @@ en:
       consent_required: Please check the legal agreement box to share your report.
       description: Your report will be sent to %{agency_name}. You must check the legal agreement box to share your report.
       pdf:
-        community_service_count: Community service activities
-        community_service_section: Community service activities
+        activity_comments: Activity comments
+        activity_types:
+          community_service: community service
+          education: education
+          employment: employment
+          work_programs: work program
+        address: Address
+        agreement_consent_timestamp: Agreement consent timestamp
+        client_and_report_information: 'Client and report information: %{client_name}'
+        community_service_details: Community service
+        community_service_summary: Community service summary
         confirmation_code: Confirmation code
-        date: Date
-        description: The following information was provided by the Medicaid client for verification of the Community Engagement Requirements.
-        disclaimer: This report is based on the activities you entered. Contact your agency if you need to make a correction.
-        education_count: Education activities
-        heading: Your Medicaid Community Engagement Activity report
-        hours: Hours
-        income_activities: Employment activities
-        no_community_service: No community service activities were reported.
-        no_education: No education activities were reported.
-        no_income: No employment activities were reported.
-        no_work_programs: No work program activities were reported.
+        date_range: Date range for report
+        date_range_value: "%{start_date} to %{end_date}"
+        description: We have collected %{activity_types} information with your consent and sent it to %{agency_name}. Any additional income that you weren’t able to add to this report should be shared separately with %{agency_name}.
+        education_details: Education details
+        education_summary: Education summary
+        employer_title: 'Employer %{number}: %{name}'
+        employment_details: Employment details
+        employment_status: Employment status
+        employment_summary: Employment summary
+        gig_payments_description: 'These were the dates that the client was paid for their work at %{employer_name} and the gross pay amount:'
+        heading: Community Engagement Report
+        hourly_wage_hours_paid: 'Hourly wage: Hours paid'
+        institution_information: Institution information
+        institution_title: 'Institution %{number}: %{name}'
+        mileage_expense_value: "%{amount} (%{rate} x %{miles} miles)"
+        mileage_expenses: Mileage expenses
         not_provided: Not provided
-        organization_address: Organization address
-        organization_name: Organization
-        program_name: Program name
-        report_overview: Report overview
-        reporting_window: Reporting window
-        submitted_at: Submitted on
-        summary_heading: Activity summary
-        title: Community Engagement activity report
-        total_hours: Total hours reported
-        work_programs_count: Work program activities
-        work_programs_section: Work program and education
+        number_of_paychecks: Number of paychecks
+        organization_contact_email: Organization contact email
+        organization_contact_name: Organization contact name
+        organization_contact_phone_number: Organization contact phone number
+        organization_information: Organization information
+        organization_title: 'Organization %{number}: %{name}'
+        pay_period_frequency: Pay period frequency
+        payment_information: Payment information (%{number})
+        product_name: Emmy Community Engagement
+        report_created_at: Date report was created
+        school_contact_email: School contact email
+        school_contact_name: School contact name
+        school_contact_phone_number: School contact phone number
+        term_date_range: "%{start_date} to %{end_date}"
+        title: Community Engagement Report
+        total_hours_worked: Total hours worked
+        work_program_details: Work program
+        work_program_summary: Work program summary
       title: Submit your Medicaid community engagement report
     success:
       show:

--- a/app/spec/components/document_uploads_component_spec.rb
+++ b/app/spec/components/document_uploads_component_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe DocumentUploadsComponent, type: :component do
     expect(result).not_to have_text("Remove file")
   end
 
+  it "renders the icon as an embedded image for PDFs" do
+    component = described_class.new(
+      documents: [ { filename: "verification.pdf" } ],
+      pdf: true
+    )
+    allow(component).to receive(:pdf_icon_path).and_return("data:image/svg+xml;base64,icon")
+
+    result = render_inline(component)
+
+    expect(result).to have_selector('img.document-uploads__icon.text-middle[src^="data:image/svg+xml;base64,"]')
+    expect(result).to have_selector(".document-uploads__filename.text-middle", text: "verification.pdf")
+    expect(result).to have_selector(".document-uploads.margin-bottom-0")
+  end
+
   it "uses the provided edit_label when given" do
     result = render_inline(
       described_class.new(

--- a/app/spec/controllers/activities/submit_controller_spec.rb
+++ b/app/spec/controllers/activities/submit_controller_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe Activities::SubmitController, type: :controller do
       expect(response.body).to include(I18n.t("activities.submit.title"))
     end
 
+    it "prevents the PDF response from being cached" do
+      get :show, format: :pdf
+
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"]).to eq("#{1.year.ago}")
+    end
+
     it "renders the submitted activity summaries and details from the approved design" do
       activity_flow.update!(completed_at: frozen_time, confirmation_code: test_confirmation_code)
       employment = create(

--- a/app/spec/controllers/activities/submit_controller_spec.rb
+++ b/app/spec/controllers/activities/submit_controller_spec.rb
@@ -5,7 +5,34 @@ RSpec.describe Activities::SubmitController, type: :controller do
 
   render_views
 
-  let(:activity_flow) { create(:activity_flow) }
+  let(:identity) do
+    create(
+      :identity,
+      activity_flows_count: 0,
+      first_name: "Synthetic",
+      last_name: "Identity"
+    )
+  end
+  let(:cbv_applicant) do
+    create(
+      :cbv_applicant,
+      first_name: "Jordan",
+      middle_name: nil,
+      last_name: "Taylor"
+    )
+  end
+  let(:activity_flow) do
+    create(
+      :activity_flow,
+      cbv_applicant: cbv_applicant,
+      identity: identity,
+      volunteering_activities_count: 0,
+      job_training_activities_count: 0,
+      education_activities_count: 0,
+      employment_activities_count: 0,
+      reporting_window_months: 2
+    )
+  end
   let(:frozen_time) { Time.zone.local(2025, 12, 1, 12, 0, 0) }
   let(:test_confirmation_code) { "SANDBOX123" }
 
@@ -26,20 +53,179 @@ RSpec.describe Activities::SubmitController, type: :controller do
       expect(response.body).to include(I18n.t("activities.submit.title"))
     end
 
-    it "renders a PDF report with activity details" do
+    it "renders the submitted activity summaries and details from the approved design" do
       activity_flow.update!(completed_at: frozen_time, confirmation_code: test_confirmation_code)
-      create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Food Pantry", hours: 5)
-      create(:job_training_activity, activity_flow: activity_flow, program_name: "Career Prep", organization_address: "123 Main St", hours: 8)
+      employment = create(
+        :employment_activity,
+        activity_flow: activity_flow,
+        employer_name: "Garden State Market",
+        contact_phone_number: "2255550199",
+        additional_comments: "My schedule changed in November"
+      )
+      create(:employment_activity_month, employment_activity: employment, month: activity_flow.reporting_months.first, hours: 12, gross_income: 240)
+      education = create(
+        :education_activity,
+        activity_flow: activity_flow,
+        data_source: :fully_self_attested,
+        school_name: "Bayou College"
+      )
+      create(:education_activity_month, education_activity: education, month: activity_flow.reporting_months.first, hours: 3)
+      volunteering = create(
+        :volunteering_activity,
+        activity_flow: activity_flow,
+        organization_name: "Food Pantry",
+        street_address: "456 Service Road",
+        additional_comments: "Food pantry schedule attached",
+        hours: 5
+      )
+      volunteering.document_uploads.attach(
+        io: StringIO.new("synthetic document"),
+        filename: "Volunteer Log.pdf",
+        content_type: "application/pdf"
+      )
+      create(
+        :job_training_activity,
+        activity_flow: activity_flow,
+        program_name: "Career Prep",
+        organization_address: "123 Main St",
+        hours: 8
+      )
 
       get :show, format: :pdf
 
       expect(response).to have_http_status(:ok)
       expect(response.header["Content-Type"]).to include("pdf")
       pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to include("Emmy Community Engagement | Test Agency")
+      expect(pdf_text).to include("Client and report information: Jordan Taylor")
       expect(pdf_text).to include("Food Pantry")
       expect(pdf_text).to include("Career Prep")
+      expect(pdf_text).to include("Garden State Market")
+      expect(pdf_text).to include("(225) 555-0199")
+      expect(pdf_text).to include("Bayou College")
+      expect(pdf_text).to include("Volunteer Log.pdf")
       expect(pdf_text).to include(test_confirmation_code)
-      expect(pdf_text).to include(I18n.l(frozen_time, format: :long))
+      expect(pdf_text).to include("December 1, 2025 12:00:00 UTC")
+      expect(pdf_text).to include(
+        "School contact name",
+        "School contact email",
+        "School contact phone number"
+      )
+      expect(pdf_text.scan("Organization contact name").size).to eq(2)
+      expect(pdf_text.scan("Organization contact email").size).to eq(2)
+      expect(pdf_text.scan("Organization contact phone number").size).to eq(2)
+      expect(pdf_text.index("Food pantry schedule attached")).to be < pdf_text.index("456 Service Road")
+    end
+
+    context "with an uploaded employment document" do
+      before do
+        activity_flow.update!(confirmation_code: test_confirmation_code)
+        employment = create(
+          :employment_activity,
+          activity_flow: activity_flow,
+          employer_name: "Garden State Market"
+        )
+        employment.document_uploads.attach(
+          io: StringIO.new("synthetic document"),
+          filename: "Shift Log.pdf",
+          content_type: "application/pdf"
+        )
+      end
+
+      it "renders the caseworker PDF when requested in an internal environment" do
+        allow(controller).to receive(:internal_environment?).and_return(true)
+
+        get :show, format: :pdf, params: { is_caseworker: "true" }
+
+        expect(extract_pdf_text(response)).to include(
+          "#{test_confirmation_code}_employment_shift_log_1.pdf"
+        )
+      end
+
+      it "renders the client PDF when explicitly requested in an internal environment" do
+        allow(controller).to receive(:internal_environment?).and_return(true)
+
+        get :show, format: :pdf, params: { is_caseworker: "false" }
+
+        expect(extract_pdf_text(response)).to include("Shift Log.pdf")
+      end
+
+      it "renders the client PDF outside an internal environment" do
+        allow(controller).to receive(:internal_environment?).and_return(false)
+
+        get :show, format: :pdf, params: { is_caseworker: "true" }
+
+        expect(extract_pdf_text(response)).to include("Shift Log.pdf")
+      end
+    end
+
+    it "uses the remaining summary overflow page for details" do
+      employment = create(:employment_activity, activity_flow: activity_flow, employer_name: "Garden State Market")
+      activity_flow.reporting_months.each do |month|
+        create(:employment_activity_month, employment_activity: employment, month: month, hours: 12, gross_income: 240)
+      end
+
+      education = create(
+        :education_activity,
+        activity_flow: activity_flow,
+        data_source: :partially_self_attested,
+        status: :succeeded,
+        school_name: nil,
+        additional_comments: "This schedule covers both institutions"
+      )
+      3.times do |index|
+        education.document_uploads.attach(
+          io: StringIO.new("synthetic document"),
+          filename: "Enrollment record #{index + 1}.pdf",
+          content_type: "application/pdf"
+        )
+      end
+      activity_flow.reporting_months.each_with_index do |month, index|
+        create(
+          :nsc_enrollment_term,
+          :less_than_half_time,
+          education_activity: education,
+          school_name: "School #{index + 1}",
+          term_begin: month.beginning_of_month,
+          term_end: month.end_of_month,
+          credit_hours: 3
+        )
+      end
+
+      get :show, format: :pdf
+
+      pages = PDF::Reader.new(StringIO.new(response.body)).pages
+      last_summary_page = pages.reverse.find { |page| page.text.include?("Enrollment record 3.pdf") }
+      expect(last_summary_page&.text).to include(
+        "Enrollment record 3.pdf",
+        "Employment details"
+      )
+      education_details_text = pages.find { |page| page.text.include?("Education details") }&.text
+      expect(education_details_text).to include(
+        "Education details",
+        "This schedule covers both institutions"
+      )
+      expect(education_details_text).not_to include("Institution information")
+    end
+
+    it "omits contact rows that do not apply to self-employed work" do
+      create(
+        :employment_activity,
+        activity_flow: activity_flow,
+        employer_name: "Taylor Services",
+        is_self_employed: true,
+        street_address: "123 Main Street"
+      )
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to include("Taylor Services", "123 Main Street")
+      expect(pdf_text).not_to include(
+        I18n.t("activities.summary.employment.contact_name"),
+        I18n.t("activities.summary.employment.contact_email"),
+        I18n.t("activities.summary.employment.contact_phone")
+      )
     end
 
     it "renders community service hours from monthly records in the PDF" do
@@ -51,7 +237,180 @@ RSpec.describe Activities::SubmitController, type: :controller do
       get :show, format: :pdf
 
       pdf_text = extract_pdf_text(response)
-      expect(pdf_text).to match(/Food Pantry\s+36/)
+      expect(pdf_text).to match(/Food Pantry.*October 2025\s+17.*November 2025\s+19/)
     end
+
+    it "renders activity-level education data for each NSC school" do
+      education = create(
+        :education_activity,
+        activity_flow: activity_flow,
+        data_source: :partially_self_attested,
+        status: :succeeded,
+        school_name: nil,
+        additional_comments: "Comment for both reported schools"
+      )
+      education.document_uploads.attach(
+        io: StringIO.new("synthetic document"),
+        filename: "Transcript.pdf",
+        content_type: "application/pdf"
+      )
+      reporting_window = activity_flow.reporting_window_range
+      create(
+        :nsc_enrollment_term,
+        :less_than_half_time,
+        education_activity: education,
+        school_name: "School A",
+        term_begin: reporting_window.begin,
+        term_end: reporting_window.begin.end_of_month,
+        credit_hours: 3
+      )
+      create(
+        :nsc_enrollment_term,
+        education_activity: education,
+        school_name: "School B",
+        term_begin: reporting_window.end.beginning_of_month,
+        term_end: reporting_window.end
+      )
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text.scan("Comment for both reported schools").size).to eq(2)
+      expect(pdf_text.scan("Transcript.pdf").size).to eq(2)
+    end
+
+    it "renders the approved W-2 payment details" do
+      payroll_account = create_persisted_payroll_account(employment_type: "w2")
+      paystub = Aggregators::ResponseObjects::Paystub.new(
+        account_id: payroll_account.aggregator_account_id,
+        gross_pay_amount: 800_00,
+        pay_date: "2025-11-15",
+        hours: nil,
+        deductions: [
+          Aggregators::ResponseObjects::Deduction.new(
+            category: "health_insurance",
+            tax: "pre_tax",
+            amount: 100_00
+          )
+        ]
+      )
+      outside_reporting_window = Aggregators::ResponseObjects::Paystub.new(
+        account_id: payroll_account.aggregator_account_id,
+        gross_pay_amount: 999_00,
+        pay_date: "2024-01-15",
+        hours: 40,
+        deductions: []
+      )
+      stub_detailed_income_report(
+        payroll_account,
+        employment_type: :w2,
+        paystubs: [ paystub, outside_reporting_window ]
+      )
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to match(/Payment information \(1\)\s+Your details/)
+      expect(pdf_text).to include("Pay date")
+      expect(pdf_text).to include("Payment before taxes (gross)")
+      expect(pdf_text).to match(/Number of hours worked\s+Not provided/)
+      expect(pdf_text).to include("Hourly wage: Hours paid")
+      expect(pdf_text).to include("Deduction: Health insurance (pre-tax)")
+      expect(pdf_text).not_to include("January 15, 2024")
+    end
+
+    it "omits mileage expenses for gig work without mileage" do
+      payroll_account = create_persisted_payroll_account(employment_type: "gig", total_mileage: 0)
+      paystub = Aggregators::ResponseObjects::Paystub.new(
+        account_id: payroll_account.aggregator_account_id,
+        gross_pay_amount: 450_00,
+        pay_date: "2025-11-15"
+      )
+      stub_detailed_income_report(payroll_account, employment_type: :gig, paystubs: [ paystub ])
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to include("Payments from Payroll Employer")
+      expect(pdf_text).to include("These were the dates that the client was paid")
+      expect(pdf_text).to include("11/15/2025 - $450.00")
+      expect(pdf_text).not_to include("Mileage expenses")
+    end
+
+    it "omits activity sections the client did not submit" do
+      activity_flow.update!(completed_at: frozen_time, confirmation_code: test_confirmation_code)
+      create(:volunteering_activity, activity_flow: activity_flow, organization_name: "Food Pantry", hours: 5)
+
+      get :show, format: :pdf
+
+      pdf_text = extract_pdf_text(response)
+      expect(pdf_text).to include("Community service summary")
+      expect(pdf_text).not_to include("Employment summary")
+      expect(pdf_text).not_to include("Education summary")
+      expect(pdf_text).not_to include("Work program summary")
+    end
+  end
+
+  def create_persisted_payroll_account(employment_type:, total_mileage: 0)
+    payroll_account = create(
+      :payroll_account,
+      :pinwheel_fully_synced,
+      flow: activity_flow,
+      aggregator_account_id: "account1"
+    )
+    create(
+      :activity_flow_employment_summary,
+      activity_flow: activity_flow,
+      payroll_account: payroll_account,
+      employer_name: "Payroll Employer",
+      employment_type: employment_type,
+      employment_status: "employed"
+    )
+    activity_flow.reporting_months.each do |month|
+      create(
+        :activity_flow_monthly_summary,
+        activity_flow: activity_flow,
+        payroll_account: payroll_account,
+        month: month,
+        accrued_gross_earnings_cents: 450_00,
+        paychecks_count: 1,
+        total_gig_hours: employment_type == "gig" ? 20 : 0,
+        total_mileage: total_mileage,
+        total_w2_hours: employment_type == "w2" ? 32 : 0
+      )
+    end
+    payroll_account
+  end
+
+  def stub_detailed_income_report(payroll_account, employment_type:, paystubs:)
+    employment = Aggregators::ResponseObjects::Employment.new(
+      account_id: payroll_account.aggregator_account_id,
+      employer_name: "Payroll Employer",
+      employment_type: employment_type
+    )
+    income = Aggregators::ResponseObjects::Income.new(
+      account_id: payroll_account.aggregator_account_id,
+      pay_frequency: "weekly",
+      compensation_amount: 25_00,
+      compensation_unit: "hourly"
+    )
+    account_report = Aggregators::AggregatorReports::AggregatorReport::AccountReportStruct.new(
+      nil,
+      income,
+      employment,
+      paystubs,
+      []
+    )
+    detailed_report = instance_double(
+      Aggregators::AggregatorReports::AggregatorReport,
+      has_fetched?: true,
+      employments: [ employment ]
+    )
+    allow(detailed_report).to receive(:find_account_report)
+      .with(payroll_account.aggregator_account_id)
+      .and_return(account_report)
+    allow(AggregatorReportFetcher).to receive(:new)
+      .with(activity_flow)
+      .and_return(instance_double(AggregatorReportFetcher, report: detailed_report))
   end
 end

--- a/app/spec/services/activity_pdf_report_spec.rb
+++ b/app/spec/services/activity_pdf_report_spec.rb
@@ -1,0 +1,189 @@
+require "rails_helper"
+
+RSpec.describe ActivityPdfReport do
+  let(:identity) do
+    create(
+      :identity,
+      activity_flows_count: 0,
+      first_name: "Synthetic",
+      last_name: "Identity"
+    )
+  end
+  let(:cbv_applicant) do
+    create(
+      :cbv_applicant,
+      first_name: "Jordan",
+      middle_name: nil,
+      last_name: "Taylor"
+    )
+  end
+  let(:activity_flow) do
+    create(
+      :activity_flow,
+      cbv_applicant: cbv_applicant,
+      identity: identity,
+      volunteering_activities_count: 0,
+      job_training_activities_count: 0,
+      education_activities_count: 0,
+      employment_activities_count: 0,
+      confirmation_code: "SANDBOX123"
+    )
+  end
+
+  describe "#client_name" do
+    it "uses the authoritative applicant name instead of the flow identity" do
+      report = described_class.new(flow: activity_flow, caseworker: false)
+
+      expect(report.client_name).to eq("Jordan Taylor")
+    end
+
+    it "does not display a synthetic identity when the applicant has no name" do
+      cbv_applicant.update!(
+        first_name: nil,
+        middle_name: nil,
+        last_name: nil
+      )
+
+      report = described_class.new(flow: activity_flow, caseworker: false)
+
+      expect(report.client_name).to be_nil
+    end
+  end
+
+  describe "#monthly_income_summaries_for" do
+    it "returns one row for every month in a 12-month reporting window" do
+      activity_flow.update!(reporting_window_months: 12)
+      payroll_account = create(:payroll_account, :pinwheel_fully_synced, flow: activity_flow)
+      activity_flow.reporting_months.each_with_index do |month, index|
+        create(
+          :activity_flow_monthly_summary,
+          activity_flow: activity_flow,
+          payroll_account: payroll_account,
+          month: month,
+          accrued_gross_earnings_cents: index * 100,
+          paychecks_count: index
+        )
+      end
+
+      report = described_class.new(flow: activity_flow, caseworker: false)
+      summaries = report.monthly_income_summaries_for(payroll_account)
+
+      expect(summaries.map(&:first)).to eq(activity_flow.reporting_months.map(&:beginning_of_month))
+      expect(summaries.last.second[:paychecks_count]).to eq(11)
+    end
+  end
+
+  describe "#activity_month_records" do
+    it "returns one row for every month in a 12-month reporting window" do
+      activity_flow.update!(reporting_window_months: 12)
+      activity = create(:volunteering_activity, activity_flow: activity_flow)
+      reported_month = activity_flow.reporting_months.third
+      activity_month = create(
+        :volunteering_activity_month,
+        volunteering_activity: activity,
+        month: reported_month,
+        hours: 18
+      )
+
+      report = described_class.new(flow: activity_flow, caseworker: false)
+      records = report.activity_month_records(activity.volunteering_activity_months)
+
+      expect(records.map(&:first)).to eq(activity_flow.reporting_months.map(&:beginning_of_month))
+      expect(records.to_h.fetch(reported_month.beginning_of_month)).to eq(activity_month)
+    end
+  end
+
+  describe "#education_entries" do
+    it "creates a separate institution entry for each NSC school with its activity-level data" do
+      education = create(
+        :education_activity,
+        activity_flow: activity_flow,
+        data_source: :partially_self_attested,
+        status: :succeeded,
+        school_name: nil,
+        additional_comments: "Comment for the education activity"
+      )
+      education.document_uploads.attach(
+        io: StringIO.new("synthetic document"),
+        filename: "Transcript.pdf",
+        content_type: "application/pdf"
+      )
+      reporting_window = activity_flow.reporting_window_range
+      school_a_term = create(
+        :nsc_enrollment_term,
+        education_activity: education,
+        school_name: "School A",
+        term_begin: reporting_window.begin,
+        term_end: reporting_window.begin.end_of_month
+      )
+      school_b_term = create(
+        :nsc_enrollment_term,
+        education_activity: education,
+        school_name: "School B",
+        term_begin: reporting_window.end.beginning_of_month,
+        term_end: reporting_window.end
+      )
+
+      report = described_class.new(flow: activity_flow, caseworker: false)
+      entries = report.education_entries
+
+      expect(entries.map(&:school_name)).to eq([ "School A", "School B" ])
+      expect(entries.map(&:enrollment_terms)).to eq([ [ school_a_term ], [ school_b_term ] ])
+      expect(entries.map(&:comments)).to eq([
+        "Comment for the education activity",
+        "Comment for the education activity"
+      ])
+      expect(entries.map(&:documents)).to eq([ [ "Transcript.pdf" ], [ "Transcript.pdf" ] ])
+    end
+
+    it "preserves activity-level data when no enrollment terms overlap the reporting window" do
+      education = create(
+        :education_activity,
+        activity_flow: activity_flow,
+        data_source: :partially_self_attested,
+        status: :succeeded,
+        additional_comments: "The transcript is for an earlier term"
+      )
+      education.document_uploads.attach(
+        io: StringIO.new("synthetic document"),
+        filename: "Transcript.pdf",
+        content_type: "application/pdf"
+      )
+      create(
+        :nsc_enrollment_term,
+        education_activity: education,
+        school_name: "School A",
+        term_begin: activity_flow.reporting_window_range.begin - 1.year,
+        term_end: activity_flow.reporting_window_range.end - 1.year
+      )
+
+      report = described_class.new(flow: activity_flow, caseworker: false)
+      entry = report.education_entries.sole
+
+      expect(entry.school_name).to eq("School A")
+      expect(entry.enrollment_terms).to be_empty
+      expect(entry.comments).to eq("The transcript is for an earlier term")
+      expect(entry.documents).to eq([ "Transcript.pdf" ])
+      expect(report.included_activity_types).to include(:education)
+    end
+  end
+
+  describe "#document_names_for" do
+    it "uses original filenames in the client report and templated filenames in the caseworker report" do
+      activity = create(:employment_activity, activity_flow: activity_flow)
+      activity.document_uploads.attach(
+        io: StringIO.new("synthetic document"),
+        filename: "Pay Stub Final.PDF",
+        content_type: "application/pdf"
+      )
+
+      client_report = described_class.new(flow: activity_flow, caseworker: false)
+      caseworker_report = described_class.new(flow: activity_flow, caseworker: true)
+
+      expect(client_report.document_names_for(activity)).to eq([ "Pay Stub Final.PDF" ])
+      expect(caseworker_report.document_names_for(activity)).to eq([
+        "SANDBOX123_employment_pay_stub_final_1.pdf"
+      ])
+    end
+  end
+end

--- a/app/spec/services/transmitters/activity_s3_transmitter_spec.rb
+++ b/app/spec/services/transmitters/activity_s3_transmitter_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe Transmitters::ActivityS3Transmitter do
     transmitter.deliver
   end
 
+  it "renders the caseworker report with templated document filenames" do
+    employment = create(:employment_activity, activity_flow: activity_flow)
+    attach_document(employment, "Pay Stub.pdf")
+    allow(processed_download_service).to receive(:download_file) do |_key, file_path|
+      File.binwrite(file_path, "cleared document")
+    end
+    allow(transmitter).to receive(:pdf_content).and_call_original
+    expect(destination_s3_service).to receive(:upload_directory) do |directory, _prefix|
+      content = File.binread(File.join(directory, report_file_name))
+      pdf_text = PDF::Reader.new(StringIO.new(content)).pages.map(&:text).join(" ").gsub(/\s+/, " ")
+      expect(pdf_text).to include("SANDBOX123_employment_pay_stub_1.pdf")
+    end
+
+    transmitter.deliver
+  end
+
   it "uploads only the report when the flow has no supporting documents" do
     expect(processed_download_service).not_to receive(:download_file)
     expect(destination_s3_service).to receive(:upload_directory).ordered do |directory, prefix|


### PR DESCRIPTION
## [FFS-4718](https://jiraent.cms.gov/browse/FFS-4718)

## Changes
<!-- What was added, updated, or removed in this PR. -->
- CE PDF matching the approved Figma designs
- Client and staff reports for all activity types

## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->
- The "Cont." header is deferred to the future after design clarification
- Some rows suggested in Figma had no available data source, and rather than show "not provided," are omitted (NSC doesn't send us a lot of the education details)
- Income PDF unchanged
- Staff PDF differs only in system file names for doc uploads

Future work: evaluate how detailed paystub data can be reused safely. Individual payment details are currently fetched live for both Income and CE PDFs, only summaries are persisted.

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [ ] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [x] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

<!-- begin CMS review environment info -->
## CMS Cloud review environment
♻️ Environment destroyed ♻️
<!-- end CMS review environment info -->