### PR TITLE
FFS-4794: Add environment selection to deploy script

### DIFF
--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -129,11 +129,11 @@ def update_release_files(version, both_changes:, income_changes:, ce_changes:, o
   File.write(VERSION_PATH, "#{version}\n")
 end
 
-def commit_lines(prod, current_sha)
+def commit_lines(prod_version, current_sha)
   run_command(
     "git", "log", "--no-decorate",
     '--pretty=format:%s - %an|%H',
-    "v#{prod}..#{current_sha}"
+    "v#{prod_version}..#{current_sha}"
   ).lines(chomp: true)
 end
 
@@ -196,9 +196,9 @@ if ARGV.first == "--test"
 end
 
 run_command("git", "fetch", "--quiet")
-prod = fetch_production_version
+prod_version = fetch_production_version
 current_sha = run_command("git", "rev-parse", "origin/main")
-commits = commit_lines(prod, current_sha)
+commits = commit_lines(prod_version, current_sha)
 
 both_changes = []
 income_changes = []
@@ -279,7 +279,7 @@ append_changes(
 )
 append_changes(output, "⚙️ *Other/Maintenance (Not user facing)*", other_changes)
 output << "\n"
-output << "See the full diff: https://github.com/DSACMS/iv-cbv-payroll/compare/#{prod[0, 7]}..#{current_sha[0, 7]}\n"
+output << "See the full diff: https://github.com/DSACMS/iv-cbv-payroll/compare/v#{prod_version}..#{current_sha[0, 7]}\n"
 
 update_release_files(
   release_version,

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -159,9 +159,9 @@ def tags_for_changes(both_changes, income_changes, ce_changes)
   if has_income.positive? && has_ce.zero?
     "#{tags} @Jake"
   elsif has_ce.positive? && has_income.zero?
-    "#{tags} @Seth"
+    "#{tags} @Jacob"
   else
-    "#{tags} @Jake @Seth"
+    "#{tags} @Jake @Jacob"
   end
 end
 

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -37,7 +37,7 @@ def run_command(*command)
 end
 
 def fetch_production_version
-  response = URI.open("https://snap-income-pilot.com/health", &:read)
+  response = URI.open("https://emmy.cms.gov/health", &:read)
   JSON.parse(response).fetch("version")
 end
 

--- a/app/bin/will-deploy
+++ b/app/bin/will-deploy
@@ -159,9 +159,9 @@ def tags_for_changes(both_changes, income_changes, ce_changes)
   if has_income.positive? && has_ce.zero?
     "#{tags} @Jake"
   elsif has_ce.positive? && has_income.zero?
-    "#{tags} @Jacob"
+    "#{tags} @Seth"
   else
-    "#{tags} @Jake @Jacob"
+    "#{tags} @Jake @Seth"
   end
 end
 

--- a/bin/deploy-to-nava-and-cms
+++ b/bin/deploy-to-nava-and-cms
@@ -4,10 +4,20 @@
 # hour), at least it's better and safer than triggering these all manually.
 #
 # This script deploys one Git commit through each environment in order.
+#
+# Usage: bin/deploy-to-nava-and-cms [nonprod|dev|prod|all]
+#
+# nonprod deploys the Nava demo and CMS sandbox and demo environments.
+# dev deploys the Nava dev and CMS dev and test environments. These
+# environments are typically deployed via CD, so they are not included in
+# nonprod by default.
+# prod deploys the Nava production and CMS UAT and production environments.
+# all deploys nonprod and dev, then prompts for confirmation before prod.
 
 set -euo pipefail
 
 readonly REPOSITORY="DSACMS/iv-cbv-payroll"
+readonly NAVA_DEV_HEALTH_URL="${NAVA_DEV_HEALTH_URL:-https://verify-demo.navapbc.cloud}"
 readonly NAVA_DEMO_HEALTH_URL="${NAVA_DEMO_HEALTH_URL:-https://demo.reportmyincome.org}"
 readonly NAVA_PROD_HEALTH_URL="${NAVA_PROD_HEALTH_URL:-https://reportmyincome.org}"
 readonly CMS_DEV_BASE_URL="${CMS_DEV_BASE_URL:-https://dev.emmy.cms.gov}"
@@ -26,10 +36,22 @@ require_command() {
   }
 }
 
+usage() {
+  cat <<EOF
+Usage: $0 [nonprod|dev|prod|all]
+
+Deploy a commit to the selected environment group:
+  dev      Nava dev + CMS dev and test
+  nonprod  Nava demo + CMS sandbox and demo
+  prod     Nava production + CMS UAT and production
+  all      nonprod and dev, followed by a confirmation before prod
+EOF
+}
+
 require_expected_host() {
   local url="$1"
 
-  [[ "$url" =~ ^https://([a-z0-9.-]+\.)?(emmy\.cms\.gov|reportmyincome\.org)(/|$) ]] || {
+  [[ "$url" =~ ^https://([a-z0-9.-]+\.)?(emmy\.cms\.gov|reportmyincome\.org|navapbc\.cloud)(/|$) ]] || {
     echo "Refusing to use unexpected health URL: ${url}" >&2
     exit 1
   }
@@ -115,13 +137,50 @@ deploy_cms() {
   verify_health "CMS Cloud ${environment}" "$base_url" "$DEPLOY_SHA"
 }
 
+deploy_nonprod() {
+  echo "Deploying Nonprod environments..."
+  deploy_nava demo "$NAVA_DEMO_HEALTH_URL"
+  deploy_cms sandbox "$CMS_SANDBOX_BASE_URL"
+  deploy_cms demo "$CMS_DEMO_BASE_URL"
+}
+
+deploy_dev() {
+  echo "Deploying dev environments..."
+  deploy_nava dev "$NAVA_DEV_HEALTH_URL"
+  deploy_cms dev "$CMS_DEV_BASE_URL"
+  deploy_cms test "$CMS_TEST_BASE_URL"
+}
+
+deploy_prod() {
+  echo "Deploying production environments..."
+  deploy_nava prod "$NAVA_PROD_HEALTH_URL"
+  deploy_cms uat "$CMS_UAT_BASE_URL"
+  deploy_cms prod "$CMS_PROD_BASE_URL"
+}
+
+[[ $# -eq 1 ]] || {
+  usage >&2
+  exit 1
+}
+
+deployment_target="$1"
+case "$deployment_target" in
+  nonprod|dev|prod|all) ;;
+  *)
+    echo "Unknown deployment target: ${deployment_target}" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
 require_command gh
 require_command curl
 require_command jq
 
-for url in "$NAVA_DEMO_HEALTH_URL" "$NAVA_PROD_HEALTH_URL" \
-  "$CMS_DEV_BASE_URL" "$CMS_TEST_BASE_URL" "$CMS_SANDBOX_BASE_URL" \
-  "$CMS_DEMO_BASE_URL" "$CMS_UAT_BASE_URL" "$CMS_PROD_BASE_URL"; do
+for url in "$NAVA_DEV_HEALTH_URL" "$NAVA_DEMO_HEALTH_URL" \
+  "$NAVA_PROD_HEALTH_URL" "$CMS_DEV_BASE_URL" "$CMS_TEST_BASE_URL" \
+  "$CMS_SANDBOX_BASE_URL" "$CMS_DEMO_BASE_URL" "$CMS_UAT_BASE_URL" \
+  "$CMS_PROD_BASE_URL"; do
   [[ -n "$url" ]] && require_expected_host "$url"
 done
 
@@ -139,20 +198,26 @@ compare_status=$(gh api "repos/${REPOSITORY}/compare/main...${DEPLOY_SHA}" --jq 
 }
 echo "Deploying immutable commit: ${DEPLOY_SHA}"
 
-deploy_nava demo "$NAVA_DEMO_HEALTH_URL"
-deploy_cms dev "$CMS_DEV_BASE_URL"
-deploy_cms test "$CMS_TEST_BASE_URL"
-deploy_cms sandbox "$CMS_SANDBOX_BASE_URL"
-deploy_cms demo "$CMS_DEMO_BASE_URL"
+case "$deployment_target" in
+  nonprod)
+    deploy_nonprod
+    ;;
+  dev)
+    deploy_dev
+    ;;
+  prod)
+    deploy_prod
+    ;;
+  all)
+    deploy_nonprod
+    deploy_dev
+    read -r -p "Nonprod deployments succeeded. Type DEPLOY_PRODUCTION to continue: " confirmation
+    [[ "$confirmation" == "DEPLOY_PRODUCTION" ]] || {
+      echo "Production deployments cancelled."
+      exit 0
+    }
+    deploy_prod
+    ;;
+esac
 
-read -r -p "Lower environments succeeded. Type DEPLOY_PRODUCTION to continue: " confirmation
-[[ "$confirmation" == "DEPLOY_PRODUCTION" ]] || {
-  echo "Production deployments cancelled."
-  exit 0
-}
-
-deploy_nava prod "$NAVA_PROD_HEALTH_URL"
-deploy_cms uat "$CMS_UAT_BASE_URL"
-deploy_cms prod "$CMS_PROD_BASE_URL"
-
-echo "All deployments completed; configured health checks passed."
+echo "Selected deployments completed; configured health checks passed."


### PR DESCRIPTION
## [FFS-4794](https://jiraent.cms.gov/browse/FFS-4794)

## Changes
<!-- What was added, updated, or removed in this PR. -->

Allow operators to deploy nonprod, dev, prod, or all environment groups.
Keep CD-managed dev environments out of nonprod by default and retain
the production confirmation for all deployments.


## Context for reviewers
<!-- Anything you'd like other engineers on the team to know. -->

## Acceptance testing
Tag product and design in Slack for acceptance: @emmy-acceptance-testers

- [ ] No acceptance testing needed
  * This change will not affect the user experience (bugfix, dependency updates, etc.)
- [x] Acceptance testing prior to merge
  * This change can be verified visually via screenshots attached below or by sending a link to a local development environment to the acceptance tester
  * Acceptance testing should be done by **design** for visual changes, **product** for behavior/logic changes, **or both** for changes that impact both.
- [ ] Acceptance testing in PR Environment
  * This change can be verified in a PR environment. Run [this Github Action](https://github.com/DSACMS/iv-cbv-payroll/actions/workflows/ci-app-pr-environment-checks.yml) with the existing PR and most recent git sha.
- [ ] Acceptance testing after merge
  * This change is hard to test locally, so we'll test it in the demo environment (deployed automatically after merge.)
  * Make sure to notify the team once this PR is merged so we don't inadvertently deploy the unaccepted change to production. (e.g. `:alert: Deploy block! @ffs-eng I just merged PR [#123] and will be doing acceptance testing in demo - please don't deploy until I'm finished!`)

## AI Usage
- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

Optional — for learning, not audited:
- AI tools used: OpenAI Codex
- Prompt artifacts: <link a prompt/chat if worth keeping; otherwise skip>
